### PR TITLE
feat: /continue command + todo stream snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,12 +447,11 @@ Loading Animation (Braille Wheel):
     ┃
     ┃ ▶ file_write src/api/types.ts                              [OK]
     ┃ ▶ file_write src/api/client.ts                             [OK]
+    ┃ ▼ todo_write (1/2)                                         [OK]
+    ┃   [>] Implement API client
+    ┃   [ ] Set up project structure
     
     ─────────────────────────────────────────────────────────────────────────────
-    ┌─ Todo ─────────────────────────────────────────────────────────── 1/2 ────┐
-    │ [>] Implement API client                                                  │
-    │ [ ] Set up project structure                                              │
-    └───────────────────────────────────────────────────────────────────────────┘
     ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     ┃  > _                                                                      ┃
     ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -460,7 +459,7 @@ Loading Animation (Braille Wheel):
 ```
 
 **Notes:**
-- Sidebar removed - todos now in BottomPanel above input
+- Todos render inside `todo_read`/`todo_write` tool blocks; `/todo` shows the full list overlay
 - Messages have accent lines (mode-colored for AI, gray for user)
 - Input area has mode-colored accent lines (no full border)
 - Status line includes spinner, version, optional [EXPRESS] and Queue indicators
@@ -613,7 +612,7 @@ Dynamic header line at the top of the session screen showing context about the c
 | After `/compact` | `[IMPULSE] \| Compacted: <description>` | `[IMPULSE] \| Compacted: Express mode` |
 | After `/undo` | `[IMPULSE] \| Reverted: <description>` | `[IMPULSE] \| Reverted: Express mode` |
 | After `/redo` | `[IMPULSE] \| Reapplied: <description>` | `[IMPULSE] \| Reapplied: Express mode` |
-| After `/load` | Restore saved header | `[IMPULSE] \| Express mode permission system` |
+| After `/continue` | Restore saved header | `[IMPULSE] \| Express mode permission system` |
 
 ### Tool: `set_header`
 
@@ -626,7 +625,7 @@ AI uses the `set_header` tool to update the header. Guidelines:
 ### Persistence
 
 - Header title persists with session on `/save`
-- Restored when session is loaded via `/load`
+- Restored when session is continued via `/continue` (alias: `/load`)
 - Prefixes (Compacted/Reverted/Reapplied) are cleared on next AI update
 
 ## Todo System
@@ -653,31 +652,21 @@ interface Todo {
 
 ### UI Display
 
-Todos appear in a fixed-height bordered panel above the input prompt:
+Todos render inside the chat stream as expanded `todo_read` / `todo_write` tool blocks:
 
 ```
-┌─ Todo ──────────────────────────────────────────────── 2/5 ───┐
-│ [>] Current task                                              │ <- cyan, darker bg
-│ [ ] Next task                                                 │ <- dim, lighter bg
-│ [ ] Another task                                              │ <- dim, darker bg
-│ [x] Completed task                                            │ <- dim, lighter bg
-│ [-] Cancelled task                                            │ <- dim+strikethrough
-└───────────────────────────────────────────────────────────────┘
+▼ [OK] todo_write (1/2)
+  [>] Implement API client
+  [ ] Set up project structure
 ```
+
+Use `/todo` to open the full list overlay at any time.
 
 **Status indicators:**
 - `[>]` = in_progress (cyan text)
 - `[ ]` = pending (dim text)
 - `[x]` = completed (dim text)
 - `[-]` = cancelled (dim text + strikethrough entire line)
-
-**Features:**
-- Fixed 5-row height with scrollbar when > 5 items
-- Alternating row backgrounds for readability
-- Counter in upper right: incomplete/total
-- Auto-scrolls to keep in_progress task at top
-- Collapses to single "All tasks complete" row when done
-- Completely hidden when no todos exist
 
 ### Agent Usage
 
@@ -795,7 +784,7 @@ interface QuestionToolOutput {
 | `/new` | New session (prompt to save) |
 | `/compact` | Manual AI summarization |
 | `/save` | Save with AI-suggested name |
-| `/load` | Session picker with preview |
+| `/continue` | Session picker with preview (alias: `/load`) |
 | `/undo` | Git-based revert to checkpoint |
 | `/redo` | Restore undone changes |
 | `/model` | Switch GLM model |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.0] - 2026-02-04
+
+**Type:** minor  
+**Title:** Continue command and todo stream snapshots
+
+### Added
+
+- **Todo snapshots in tool blocks** - `todo_read`/`todo_write` now render expanded todo lists in the chat stream.
+
+### Changed
+
+- **`/continue` is now the primary session command** - `/load` remains as an alias, and help text reflects the new command.
+- **Todo UI moved into the chat stream** - Bottom panel todo removed; `/todo` overlay remains for full-list viewing.
+
 ## [0.30.0] - 2026-02-03
 
 **Type:** minor  
@@ -170,8 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Mode and model now persist across session save/load** - Critical UI fix
-  - Mode colors were showing white and mode labels missing after `/load` or `-c`
+- **Mode and model now persist across session save/continue** - Critical UI fix
+  - Mode colors were showing white and mode labels missing after `/continue` or `-c`
   - Added `mode` and `model` fields to session store Message interface
   - Messages now save and restore mode/model for proper display coloring
   - This was a recurring issue (4+ times) - now properly addressed at storage layer
@@ -456,7 +470,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Shift+Tab "Allow All Edits"** - Quick approve file operations for session
   - Only auto-approves `file_edit` and `file_write` (NOT bash, task, etc.)
-  - Session-scoped only (NOT persisted on /save + /load)
+  - Session-scoped only (NOT persisted on /save + /continue)
   - Only works in AUTO, AGENT, DEBUG modes
   - In read-only modes (EXPLORE, PLANNER, PLAN-PRD): shows flash notification for 5 seconds
   - Hint text updated to show Shift+Tab option
@@ -888,7 +902,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Session picker (`/load`)** - Overlay now closes immediately after selecting a session
+- **Session picker (`/continue`)** - Overlay now closes immediately after selecting a session
 - **Session message restoration** - Tool calls and reasoning content now properly restored when loading saved sessions
   - Previously showed empty messages for assistant responses that only contained tool calls
   - Now displays tool names, arguments, and results correctly
@@ -1595,7 +1609,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Double Overlay Bug** - Fixed `/load` and `/model` commands showing both command autocomplete and picker overlay:
+- **Double Overlay Bug** - Fixed `/continue` and `/model` commands showing both command autocomplete and picker overlay:
   - Autocomplete now cleared before showing session/model picker
   - Also clears autocomplete before showing command result overlays
 
@@ -1647,10 +1661,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Project-Based Session Storage** - Sessions are now organized by working directory:
   - Sessions stored in `~/.config/impulse/storage/session/<projectID>/`
   - Project ID is SHA-1 hash of the working directory path
-  - `/load` only shows sessions for the current project
+  - `/continue` only shows sessions for the current project
   - Matches OpenCode's session organization pattern
 
-- **Fixed-Height Session Picker** - `/load` overlay now has a scrollable list:
+- **Fixed-Height Session Picker** - `/continue` overlay now has a scrollable list:
   - Maximum 10 visible rows with scrollbar for longer lists
   - Prevents UI overflow with many sessions
   - Shows session count for current project
@@ -1686,7 +1700,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Session List Bug** - `/load` command now correctly lists saved sessions:
+- **Session List Bug** - `/continue` command now correctly lists saved sessions:
   - Fixed key indexing in `SessionStoreInstance.list()` - was using `key[0]` ("session") instead of `key[1]` (session ID)
   - Sessions are now properly retrieved from `~/.config/impulse/storage/session/`
 
@@ -2154,7 +2168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Interactive `/load` Session Picker** - `/load` command now opens an interactive overlay:
+- **Interactive `/continue` Session Picker** - `/continue` command now opens an interactive overlay:
   - Lists all saved sessions sorted by most recently updated
   - Shows session name, relative time, message count, and working directory
   - Preview panel displays first user/assistant messages from selected session
@@ -2216,7 +2230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Format: `[IMPULSE] | <context>`
   - AI updates via `set_header` tool at meaningful milestones
   - Prefixes for system actions: `Compacted:`, `Reverted:`, `Reapplied:`
-  - Persists with session on save/load
+  - Persists with session on save/continue
 
 ## [0.7.0] - 2026-01-21
 
@@ -2463,9 +2477,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session store with auto-save (1s debounced)
 - Git-based checkpoint system per message
 - AI-powered auto-compact at 70% threshold
-- Session manager lifecycle (new/load/switch/exit)
+- Session manager lifecycle (new/continue/switch/exit)
 - Command registry with argument parsing
-- Core commands: /new, /save, /load, /quit, /exit
+- Core commands: /new, /save, /continue, /quit, /exit
 - Utility commands: /undo, /redo, /compact, /model, /mode, /think
 - Info commands: /stats, /help, /config, /instruct
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Press `Tab` to cycle modes, `Shift+Tab` to cycle reverse. The AI will suggest mo
 |---------|-------------|
 | `/new` | New session |
 | `/save` | Save session |
-| `/load` | Session picker |
+| `/continue` | Session picker (alias: `/load`) |
 | `/undo` `/redo` | Revert/restore changes |
 | `/compact` | Manually compact context |
 | `/model` | Model picker |

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -492,33 +492,17 @@ The API client is now ready.
 - Blinking cursor during streaming
 - Auto-collapse after generation completes
 
-### 5.7 Sidebar
+### 5.7 Todo Visibility
 
-**Structure:**
+Todo updates render in the chat stream as expanded `todo_read` / `todo_write` tool blocks.
+Use `/todo` to open the full list overlay on demand.
+
+**Example:**
 ```
-Session
-───────────────────────────────────────
-Context: 42% (84k/200k)
-Cost: $0.12
-
-▼ Todo
-[ ] Set up project structure
-[>] Implement API client
-[ ] Add error handling
-[x] Write configuration
-
-▶ MCPs 4/4
-
-▶ Modified Files
+▼ [OK] todo_write (1/2)
+  [>] Implement API client
+  [ ] Set up project structure
 ```
-
-**Specifications:**
-- Fixed width: 42 characters
-- Left border separator from main content
-- Collapsible sections with `▶`/`▼`
-- Section headers: Bold
-- Todo items: Status indicators with content
-- MCP count: Green if all connected
 
 ### 5.8 Input Area
 
@@ -574,7 +558,7 @@ Cost: $0.12
                     │  > /new                                               │
                     │    /new         New session                           │
                     │    /save        Save session                          │
-                    │    /load        Load session                          │
+                    │    /continue    Continue session                      │
                     │    /undo        Revert last change                    │
                     │    /redo        Restore undone                        │
                     │    /model       Switch model                          │
@@ -699,7 +683,7 @@ impulse/
 │   │   ├── registry.ts          # Command registration
 │   │   ├── new.ts               # /new command
 │   │   ├── save.ts              # /save command
-│   │   ├── load.ts              # /load command
+│   │   ├── continue.ts          # /continue command
 │   │   ├── compact.ts           # /compact command
 │   │   ├── undo.ts              # /undo command
 │   │   ├── redo.ts              # /redo command
@@ -787,7 +771,7 @@ impulse/
 3. Todo.update() writes to storage: `["todo", sessionID]`
 4. Bus publishes `todo.updated` event
 5. UI context receives event, updates TodoState store
-6. Sidebar re-renders with new todos via SolidJS reconciliation
+6. Chat view renders todo snapshot inside the todo tool block; /todo overlay reflects the same state
 7. Tool returns count of non-completed todos
 
 ---

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -79,7 +79,7 @@ Generated: 01-19-2026
 | FR-1.5.1 | /new - Start new session with save prompt | Must |
 | FR-1.5.2 | /compact - Manual AI summarization | Must |
 | FR-1.5.3 | /save - Save with AI-suggested name | Must |
-| FR-1.5.4 | /load - Session picker with preview | Must |
+| FR-1.5.4 | /continue - Session picker with preview (alias: /load) | Must |
 | FR-1.5.5 | /undo - Git-based revert to checkpoint | Must |
 | FR-1.5.6 | /redo - Restore undone changes | Must |
 | FR-1.5.7 | /model - Switch GLM model | Must |

--- a/docs/archive/Tasks.md
+++ b/docs/archive/Tasks.md
@@ -2793,7 +2793,7 @@ src/
 **Estimated Effort:** Medium
 
 #### Description
-Implement /new, /save, /load, /quit, /exit commands.
+Implement /new, /save, /continue, /quit, /exit commands.
 
 #### Before
 ```
@@ -2809,21 +2809,21 @@ src/commands/
 ├── registry.ts
 ├── new.ts
 ├── save.ts
-├── load.ts
+├── continue.ts
 └── quit.ts
 ```
 
 #### Steps
 1. Create `src/commands/new.ts` - prompt to save, create new
 2. Create `src/commands/save.ts` - AI-generated name
-3. Create `src/commands/load.ts` - session picker overlay
+3. Create `src/commands/continue.ts` - session picker overlay
 4. Create `src/commands/quit.ts` - show summary, exit
 5. Register all commands
 
 #### Verification
 - [ ] /new prompts to save
 - [ ] /save uses AI name
-- [ ] /load shows picker
+- [ ] /continue shows picker
 - [ ] /quit shows summary
 
 ---
@@ -3287,7 +3287,7 @@ const [messages, setMessages] = createSignal([])
 ```tsx
 // Session state persisted via SessionManager
 const session = useSession()
-// Auto-saves, loads on startup, supports /new, /load, /save
+// Auto-saves, loads on startup, supports /new, /continue, /save
 ```
 
 #### Steps
@@ -3296,14 +3296,14 @@ const session = useSession()
 3. Wire auto-save (30 second interval)
 4. Connect session context to SessionManager
 5. Ensure messages persist across restarts
-6. Wire up /new, /load, /save commands
+6. Wire up /new, /continue, /save commands
 
 #### Verification
 - [ ] Sessions persist to disk
 - [ ] Auto-save triggers every 30s
 - [ ] App loads last session on startup
 - [ ] /new creates fresh session
-- [ ] /load opens session picker
+- [ ] /continue opens session picker
 - [ ] /save persists current session
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": false,
   "description": "Terminal-based AI coding agent powered by Z.ai's Coding Plan - the best cost/engineering ratio for builders",
   "type": "module",

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -10,7 +10,7 @@ const SaveArgsSchema = z.object({
   name: z.string().optional(),
 });
 
-const LoadArgsSchema = z.object({
+const ContinueArgsSchema = z.object({
   id: z.string().optional(),
 });
 
@@ -36,8 +36,8 @@ async function handleSave(args: Record<string, unknown>) {
   };
 }
 
-async function handleLoad(args: Record<string, unknown>) {
-  const parsed = LoadArgsSchema.parse(args);
+async function handleContinue(args: Record<string, unknown>) {
+  const parsed = ContinueArgsSchema.parse(args);
 
   if (!parsed.id) {
     const sessions = await SessionManager.listSessions();
@@ -55,7 +55,7 @@ async function handleLoad(args: Record<string, unknown>) {
 
     return {
       success: true,
-      output: `Available sessions:\n${list}\n\nUse /load <id> to load a session`,
+      output: `Available sessions:\n${list}\n\nUse /continue <id> to continue a session (alias: /load)`,
     };
   }
 
@@ -63,7 +63,7 @@ async function handleLoad(args: Record<string, unknown>) {
 
   return {
     success: true,
-    output: `Loaded session: ${session.name} (${session.id})`,
+    output: `Continued session: ${session.name} (${session.id})`,
   };
 }
 
@@ -115,12 +115,21 @@ export function registerCoreCommands(): void {
       examples: ["/save", "/save 'Fix API bug'"],
     },
     {
+      name: "continue",
+      category: "core",
+      description: "Continue a saved session (alias: /load)",
+      args: ContinueArgsSchema,
+      handler: handleContinue,
+      examples: ["/continue", "/continue sess_1234567890"],
+    },
+    {
       name: "load",
       category: "core",
-      description: "Load a saved session",
-      args: LoadArgsSchema,
-      handler: handleLoad,
+      description: "Alias for /continue",
+      args: ContinueArgsSchema,
+      handler: handleContinue,
       examples: ["/load", "/load sess_1234567890"],
+      hidden: true,
     },
     {
       name: "quit",

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -89,7 +89,7 @@ async function handleHelp() {
     "─".repeat(78),
     `${"/new".padEnd(14)}New session${"".padEnd(10)}${"/model".padEnd(14)}Switch model`,
     `${"/save".padEnd(14)}Save session${"".padEnd(9)}${"/mode".padEnd(14)}Switch mode`,
-    `${"/load".padEnd(14)}Load session${"".padEnd(9)}${"/mcp".padEnd(14)}MCP server status`,
+    `${"/continue".padEnd(14)}Continue session${"".padEnd(5)}${"/mcp".padEnd(14)}MCP server status`,
     `${"/compact".padEnd(14)}Summarize context${"".padEnd(4)}${"/stats".padEnd(14)}Session statistics`,
     `${"/quit".padEnd(14)}Exit with summary${"".padEnd(4)}${"/express".padEnd(14)}Toggle express mode`,
   ];

--- a/src/permission/index.ts
+++ b/src/permission/index.ts
@@ -84,7 +84,7 @@ let expressAcknowledged = false;
 
 /**
  * "Allow All Edits" mode - auto-approves file_edit and file_write only
- * Session-scoped, cleared when session ends (NOT persisted on /save + /load)
+ * Session-scoped, cleared when session ends (NOT persisted on /save + /continue)
  */
 let allowAllEditsMode = false;
 

--- a/src/tools/todo-read.ts
+++ b/src/tools/todo-read.ts
@@ -18,10 +18,22 @@ export const todoRead: Tool<TodoReadInput> = Tool.define(
     try {
       const todos = await Todo.get();
 
+      const total = todos.length;
+      const remaining = todos.filter(
+        (t) => t.status !== "completed" && t.status !== "cancelled"
+      ).length;
+
       if (todos.length === 0) {
         return {
           success: true,
           output: "No todos found for this session.",
+          metadata: {
+            type: "todo",
+            source: "read",
+            todos: [],
+            total,
+            remaining,
+          },
         };
       }
 
@@ -56,8 +68,11 @@ export const todoRead: Tool<TodoReadInput> = Tool.define(
         success: true,
         output: `${statusCounts.join(" | ")}\n${todoLines.join("\n")}`,
         metadata: {
-          total: todos.length,
-          byStatus: statusCounts,
+          type: "todo",
+          source: "read",
+          todos,
+          total,
+          remaining,
         },
       };
     } catch (error) {

--- a/src/tools/todo-write.ts
+++ b/src/tools/todo-write.ts
@@ -34,6 +34,9 @@ export const todoWrite: Tool<TodoWriteInput> = Tool.define(
         success: true,
         output: `Todo list updated. ${incompleteCount} tasks remaining.`,
         metadata: {
+          type: "todo",
+          source: "write",
+          todos: input.todos,
           total: input.todos.length,
           remaining: incompleteCount,
         },

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -87,6 +87,22 @@ export interface TaskMetadata {
 }
 
 // ============================================
+// Todo Tool Metadata
+// ============================================
+export interface TodoMetadata {
+  type: "todo";
+  source: "read" | "write";
+  todos: Array<{
+    id: string;
+    content: string;
+    status: "pending" | "in_progress" | "completed" | "cancelled";
+    priority: "high" | "medium" | "low";
+  }>;
+  total: number;
+  remaining: number;
+}
+
+// ============================================
 // Union Type
 // ============================================
 export type ToolMetadata =
@@ -96,7 +112,8 @@ export type ToolMetadata =
   | FileReadMetadata
   | GlobMetadata
   | GrepMetadata
-  | TaskMetadata;
+  | TaskMetadata
+  | TodoMetadata;
 
 // ============================================
 // Type Guards
@@ -139,6 +156,10 @@ export function isTaskMetadata(m: ToolMetadata): m is TaskMetadata {
   return m.type === "task";
 }
 
+export function isTodoMetadata(m: ToolMetadata): m is TodoMetadata {
+  return m.type === "todo";
+}
+
 // ============================================
 // Consolidated Type Guards Object
 // ============================================
@@ -161,4 +182,5 @@ export const TypeGuards = {
   isGlob: (m: ToolMetadata): m is GlobMetadata => m.type === "glob",
   isGrep: (m: ToolMetadata): m is GrepMetadata => m.type === "grep",
   isTask: (m: ToolMetadata): m is TaskMetadata => m.type === "task",
+  isTodo: (m: ToolMetadata): m is TodoMetadata => m.type === "todo",
 } as const;

--- a/src/ui/components/BottomPanel.tsx
+++ b/src/ui/components/BottomPanel.tsx
@@ -1,19 +1,13 @@
 import { InputArea, type CommandCandidate } from "./InputArea";
-import { TodoBar, TODO_PANEL_HEIGHT } from "./TodoBar";
 import { QueueBar, getQueueBarHeight } from "./QueueBar";
-import { useTodo } from "../context";
 import { useQueue } from "../context/queue";
 import { type Mode } from "../design";
 
 /**
  * BottomPanel Component
- * Vertical stack: optional todo panel ABOVE prompt
+ * Vertical stack: optional queue preview ABOVE prompt
  * 
  * Layout (v0.24.0 update):
- * - When incomplete todos exist: Todo panel above input
- *   - Expanded: 7 rows (5 tasks + border)
- *   - Collapsed: 3 rows (header + 1 task + border)
- * - When all complete or no todos: HIDDEN (use /todo to view history)
  * - Queue preview (if any): stacked above input, no border
  * 
  * Height Calculation for InputArea (borderless design):
@@ -63,19 +57,11 @@ interface BottomPanelProps {
 }
 
 export function BottomPanel(props: BottomPanelProps) {
-  const { incompleteTodos } = useTodo();
   const queue = useQueue();
   
-  // Only show todo panel when there are incomplete todos
-  // (TodoBar handles its own visibility, but we need height calculation)
-  const hasIncompleteTodos = () => incompleteTodos().length > 0;
-
-  // For now, assume expanded state for height calculation
-  // TODO: Could track collapsed state here if needed for precise height
   const panelHeight = () => {
     const queueHeight = getQueueBarHeight(queue.count());
-    if (!hasIncompleteTodos()) return INPUT_HEIGHT + queueHeight;
-    return TODO_PANEL_HEIGHT + queueHeight + INPUT_HEIGHT;
+    return INPUT_HEIGHT + queueHeight;
   };
 
   return (
@@ -86,9 +72,6 @@ export function BottomPanel(props: BottomPanelProps) {
       minWidth={0}
       overflow="hidden"
     >
-      {/* Todo panel - handles its own visibility based on incomplete todos */}
-      <TodoBar />
-      
       {/* Queue preview - stacked queued messages above input */}
       <QueueBar />
       

--- a/src/ui/components/SessionPicker.tsx
+++ b/src/ui/components/SessionPicker.tsx
@@ -164,7 +164,7 @@ export function SessionPickerOverlay(props: SessionPickerOverlayProps) {
     >
       <box
         border
-        title="Load Session"
+        title="Continue Session"
         flexDirection="column"
         padding={1}
         width={95}

--- a/src/ui/components/TodoBar.tsx
+++ b/src/ui/components/TodoBar.tsx
@@ -28,7 +28,7 @@ const VISIBLE_ROWS = 5;
 const PANEL_HEIGHT = VISIBLE_ROWS + 2;  // 5 rows + top/bottom border
 const COLLAPSED_HEIGHT = 3;  // Just header + 1 task + border
 
-// Export for BottomPanel height calculation
+// Exported for legacy sizing (BottomPanel no longer uses this)
 export const TODO_PANEL_HEIGHT = PANEL_HEIGHT;
 export const TODO_COLLAPSED_HEIGHT = COLLAPSED_HEIGHT;
 

--- a/src/ui/context/session.tsx
+++ b/src/ui/context/session.tsx
@@ -102,8 +102,10 @@ function storeToUiMessage(msg: StoreMessage, index: number): Message {
   let toolCalls: ToolCallInfo[] | undefined;
   if (msg.tool_calls && msg.tool_calls.length > 0) {
     toolCalls = msg.tool_calls.map((tc, i) => {
+      const resultMetadata = tc.result?.metadata as Record<string, unknown> | undefined;
+      const wasCancelled = Boolean(resultMetadata?.["cancelled"]);
       const status: "pending" | "running" | "success" | "error" | "cancelled" = tc.result
-        ? (tc.result.metadata?.cancelled ? "cancelled" : (tc.result.success ? "success" : "error"))
+        ? (wasCancelled ? "cancelled" : (tc.result.success ? "success" : "error"))
         : "success";  // If no result recorded, assume success (historical data)
       
       const info: ToolCallInfo = {


### PR DESCRIPTION
## Summary
- make /continue primary command (keep /load alias) and update help/docs
- render todo snapshots inside todo_read/todo_write tool blocks; remove bottom panel todo
- add todo metadata for tool snapshots and update docs

## Testing
- bun run typecheck