### PR TITLE
v0.32.0: Fix streaming scroll, paste block indicators, and session-scoped todos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,9 @@
 - [x] Chat auto-scroll stays pinned during tool calls
 - [x] Thinking blocks segment per reasoning phase
 - [x] Responses always include Findings + Next steps
+- [x] Chat auto-scroll stays pinned during streaming updates
+- [x] Paste renders as numbered hidden-input indicator blocks with line wrapping
+- [x] Todos scoped to chat session with current-task snapshot
 
 ## Version Bumping Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2026-02-05
+
+**Type:** minor  
+**Title:** Streaming pin reliability, structured paste blocks, and session-only todos
+
+### Changed
+
+- **Chat streaming stays pinned at the latest output** - Scroll behavior now reliably follows thinking, content, and tool-call updates during active streaming.
+- **Pasted input now renders as numbered indicator blocks** - Each paste is shown as `[Pasted lines #N ~X lines]`, wraps across multiple lines for readability, and stays hidden from the prompt body.
+- **Prompt submission preserves text/paste ordering** - Typed text and hidden pasted blocks are reconstructed in insertion order when submitted.
+
+### Fixed
+
+- **Thinking segments remain visible after streaming** - Completed reasoning blocks no longer disappear once the assistant turn finishes.
+- **Todo state is session-scoped only** - Todo lists no longer leak across chats; each chat session keeps its own isolated todo state.
+
 ## [0.31.0] - 2026-02-04
 
 **Type:** minor  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glm-cli",
-  "version": "0.29.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glm-cli",
-      "version": "0.29.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@opentui/core": "^0.1.74",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": false,
   "description": "Terminal-based AI coding agent powered by Z.ai's Coding Plan - the best cost/engineering ratio for builders",
   "type": "module",

--- a/src/ui/components/MessageBlock.tsx
+++ b/src/ui/components/MessageBlock.tsx
@@ -1,4 +1,4 @@
-import { For, Show, type JSX } from "solid-js";
+import { For, Show, type JSX, type Accessor } from "solid-js";
 import { Colors, Indicators, type Mode, getModeColor, getModeBackground } from "../design";
 import type { ToolMetadata, TodoMetadata } from "../../types/tool-metadata";
 import {
@@ -459,10 +459,26 @@ function renderTodoSnapshot(metadata: TodoMetadata): JSX.Element {
   const remaining = metadata.remaining ?? metadata.todos.filter(
     (t) => t.status !== "completed" && t.status !== "cancelled"
   ).length;
+  const currentTodo = metadata.todos.find((t) => t.status === "in_progress")
+    ?? metadata.todos.find((t) => t.status === "pending");
 
   return (
     <box flexDirection="column">
       <text fg={Colors.ui.dim}>Todo ({remaining}/{total})</text>
+      <Show
+        when={currentTodo}
+        fallback={<text fg={Colors.ui.dim}>Current: (none)</text>}
+      >
+        {(todo: Accessor<TodoMetadata["todos"][number]>) => {
+          const display = getTodoDisplay(todo().status);
+          return (
+            <box flexDirection="row">
+              <text fg={Colors.ui.dim}>Current: </text>
+              <text fg={display.color}>{display.indicator} {todo().content}</text>
+            </box>
+          );
+        }}
+      </Show>
       <Show
         when={metadata.todos.length > 0}
         fallback={<text fg={Colors.ui.dim}>No tasks</text>}
@@ -877,7 +893,7 @@ export function MessageBlock(props: MessageBlockProps) {
   };
   const thinkingSegments = () =>
     reasoningSegments().filter((segment) => segment.content && segment.content.trim().length > 0);
-  const showThinking = () => isStreaming() && thinkingSegments().length > 0;
+  const showThinking = () => thinkingSegments().length > 0;
 
   const toolEntries = () => toolCalls().map((toolCall, index) => ({ toolCall, index }));
   const getAttemptNumber = (index: number) => {


### PR DESCRIPTION
## Summary
- Fix chat auto-scroll so active streaming and tool-call updates stay pinned to the bottom.
- Keep completed reasoning segments visible instead of hiding them after streaming ends.
- Change paste UX to indicator-only blocks: each paste is tracked independently as numbered blocks and wraps across multiple lines.
- Preserve mixed text and paste ordering in submitted prompts.
- Scope todos to the active chat session only and keep todo snapshots with current-task context.
- Bump version to 0.32.0 and add changelog + AGENTS updates.

## Validation
- bun run typecheck
- bun run build

## Issues
Fixes #17
Fixes #13
Fixes #16
Fixes #14