### PR TITLE
feat(chat): rework ordered chat rendering and self-check validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 ### Identity
 
 - **Name:** IMPULSE
-- **Version:** v0.29.0
+- **Version:** v0.33.0
 - **Tagline:** Terminal-based AI coding agent powered by GLM models
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
@@ -126,6 +126,9 @@
 - [x] Chat auto-scroll stays pinned during streaming updates
 - [x] Paste renders as numbered hidden-input indicator blocks with line wrapping
 - [x] Todos scoped to chat session with current-task snapshot
+- [x] Chat view now renders ordered assistant blocks (text/thinking/tools)
+- [x] Self-check panel captures Findings + Next steps from tool outcomes
+- [x] Question tool outputs render as structured summaries in tool blocks
 
 ## Version Bumping Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2026-02-05
+
+**Type:** minor  
+**Title:** Ordered chat rendering, self-check summaries, and safer path handling
+
+### Added
+
+- **Ordered assistant chat rendering** - Assistant responses now preserve stream order across text, thinking, and tool calls for a clearer turn timeline.
+- **Self-check summary panel** - Findings and Next steps are now generated from executed tool outcomes (including delegated subagent task metadata) without mutating model response text.
+- **Question result metadata rendering** - Question tool calls now show structured topic/question/answer summaries directly in tool blocks.
+- **Regression coverage for self-check logic** - Added tests for success/error/running states and subagent audit scenarios.
+
+### Changed
+
+- **Thinking visibility follows global toggle consistently** - Thinking blocks now respect the shared hide/show control during streaming and replay.
+- **Tool call continuity across follow-up turns** - Tool updates merge by id so completed calls stay visible while continuation turns run.
+
+### Fixed
+
+- **Path sanitizer symlink handling** - Valid symlinks inside the base directory and empty-path resolution now pass safely while preserving traversal protection.
+
 ## [0.32.0] - 2026-02-05
 
 **Type:** minor  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glm-cli",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glm-cli",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "MIT",
       "dependencies": {
         "@opentui/core": "^0.1.74",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "private": false,
   "description": "Terminal-based AI coding agent powered by Z.ai's Coding Plan - the best cost/engineering ratio for builders",
   "type": "module",

--- a/src/commands/utility.ts
+++ b/src/commands/utility.ts
@@ -248,6 +248,14 @@ async function handleThink() {
   };
 }
 
+async function handleThinkingBlocks() {
+  // This is handled specially in App.tsx to toggle thinking block visibility in SessionContext
+  return {
+    success: true,
+    output: "Thinking block visibility toggled (handled by UI)",
+  };
+}
+
 async function handleExpress() {
   // This is handled specially in App.tsx to use the Express context
   // This handler is just a placeholder for the command registry
@@ -314,6 +322,14 @@ export function registerUtilityCommands(): void {
       description: "Toggle thinking mode",
       handler: handleThink,
       examples: ["/think"],
+    },
+    {
+      name: "thinking-blocks",
+      aliases: ["toggle-thinking-blocks", "thinking"],
+      category: "utility",
+      description: "Toggle visibility of thinking blocks in chat",
+      handler: handleThinkingBlocks,
+      examples: ["/thinking-blocks", "/thinking"],
     },
     {
       name: "express",

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -38,13 +38,26 @@ export interface Message {
   role: "user" | "assistant" | "system"
   content: string
   reasoning_content?: string
+  content_blocks?: MessageContentBlock[]
+  validation?: MessageValidation
   timestamp: string
   tool_calls?: ToolCall[]
   mode?: string       // Mode used when generating (for assistant messages)
   model?: string      // Model used (e.g., "glm-4.7")
 }
 
+export type MessageContentBlock =
+  | { id: string; type: "text"; text: string }
+  | { id: string; type: "thinking"; thinking: string }
+  | { id: string; type: "tool_call"; tool_call_id: string };
+
+export interface MessageValidation {
+  findings: string[]
+  nextSteps: string[]
+}
+
 export interface ToolCall {
+  id?: string
   tool: string
   arguments: Record<string, unknown>
   result?: ToolResult

--- a/src/tools/question.ts
+++ b/src/tools/question.ts
@@ -114,7 +114,14 @@ export const questionTool: Tool<QuestionToolInput> = Tool.define(
         success: true,
         output: `User responded:\n${formattedAnswers.join("\n")}`,
         metadata: {
-          answers,
+          type: "question",
+          context: input.context,
+          questions: input.questions.map((question, index) => ({
+            topic: question.topic,
+            question: question.question,
+            options: question.options.map((option) => option.label),
+            answers: answers[index] ?? [],
+          })),
         },
       };
     } catch (error) {

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -103,6 +103,20 @@ export interface TodoMetadata {
 }
 
 // ============================================
+// Question Tool Metadata
+// ============================================
+export interface QuestionMetadata {
+  type: "question";
+  context?: string;
+  questions: Array<{
+    topic: string;
+    question: string;
+    options: string[];
+    answers: string[];
+  }>;
+}
+
+// ============================================
 // Union Type
 // ============================================
 export type ToolMetadata =
@@ -113,7 +127,8 @@ export type ToolMetadata =
   | GlobMetadata
   | GrepMetadata
   | TaskMetadata
-  | TodoMetadata;
+  | TodoMetadata
+  | QuestionMetadata;
 
 // ============================================
 // Type Guards
@@ -160,6 +175,10 @@ export function isTodoMetadata(m: ToolMetadata): m is TodoMetadata {
   return m.type === "todo";
 }
 
+export function isQuestionMetadata(m: ToolMetadata): m is QuestionMetadata {
+  return m.type === "question";
+}
+
 // ============================================
 // Consolidated Type Guards Object
 // ============================================
@@ -183,4 +202,5 @@ export const TypeGuards = {
   isGrep: (m: ToolMetadata): m is GrepMetadata => m.type === "grep",
   isTask: (m: ToolMetadata): m is TaskMetadata => m.type === "task",
   isTodo: (m: ToolMetadata): m is TodoMetadata => m.type === "todo",
+  isQuestion: (m: ToolMetadata): m is QuestionMetadata => m.type === "question",
 } as const;

--- a/src/ui/components/ThinkingBlock.tsx
+++ b/src/ui/components/ThinkingBlock.tsx
@@ -1,165 +1,47 @@
-import { createSignal, createMemo, createEffect, Show, on } from "solid-js";
+import { Show } from "solid-js";
 import { Colors, type Mode, getModeBackground } from "../design";
 
 /**
  * Thinking Block Component
- * Collapsible thinking display with fixed-height preview
- * 
- * States:
- * - Collapsed (default): Fixed 5-row height with auto-scroll during streaming
- * - Expanded: Shows FULL content inline (no scrollbox), parent ChatView handles scrolling
- * 
- * Behavior:
- * - Auto-collapses when streaming ends (turn complete)
- * - User can expand/collapse manually at any time
- * - Fixed height only when collapsed (prevents jitter during streaming)
- * - Expanded shows all content without internal scroll
- * 
- * Icons:
- * - ● (filled dot) = collapsed (shows preview)
- * - ○ (hollow dot) = expanded (shows full)
- * 
- * Props:
- * - content: Thinking content to display
- * - streaming: Whether content is currently being streamed
+ * pi-mono style: always shows full thinking text unless globally hidden.
  */
-
-// Height constants
-const COLLAPSED_HEIGHT = 5;    // Fixed 5-row preview when collapsed
-const EXPANDED_MAX_HEIGHT = 50; // Max height when expanded (scrollable if exceeds)
 
 /**
- * Darken a hex color by reducing its brightness
- * Used to create thinking block background that's darker than mode background
+ * Darken a hex color by reducing its brightness.
+ * Used to keep thinking content visually distinct from assistant text.
  */
-function darkenColor(hex: string, factor: number = 0.6): string {
-  // Remove # if present
+function darkenColor(hex: string, factor: number = 0.7): string {
   const color = hex.replace("#", "");
-  
-  // Parse RGB components
   const r = parseInt(color.substring(0, 2), 16);
   const g = parseInt(color.substring(2, 4), 16);
   const b = parseInt(color.substring(4, 6), 16);
-  
-  // Darken each component
+
   const dr = Math.round(r * factor);
   const dg = Math.round(g * factor);
   const db = Math.round(b * factor);
-  
-  // Convert back to hex
+
   return `#${dr.toString(16).padStart(2, "0")}${dg.toString(16).padStart(2, "0")}${db.toString(16).padStart(2, "0")}`;
 }
 
 interface ThinkingBlockProps {
   content?: string;
-  streaming?: boolean;
   mode?: Mode | undefined;
 }
 
 export function ThinkingBlock(props: ThinkingBlockProps) {
-  const [expanded, setExpanded] = createSignal(false);
-  
-  // Auto-collapse when streaming ends (turn complete)
-  // This ensures thinking is minimized for completed messages
-  createEffect(on(
-    () => props.streaming,
-    (streaming, prevStreaming) => {
-      // Only collapse when transitioning from streaming to not streaming
-      if (prevStreaming === true && streaming === false) {
-        setExpanded(false);
-      }
-    }
-  ));
-
   const showContent = () => !!props.content && props.content.trim().length > 0;
-
-  const handleToggle = () => {
-    setExpanded((e) => !e);
-  };
-
-  // Calculate content lines for determining if expand is useful
-  const contentLines = createMemo(() => {
-    if (!props.content) return 0;
-    return props.content.split("\n").length;
-  });
-
-  // Only show expand/collapse if content exceeds collapsed height
-  const canExpand = () => contentLines() > COLLAPSED_HEIGHT;
-  
-  const indicator = () => expanded() ? "○" : "●";
-  const label = () => {
-    if (!canExpand()) {
-      return "Thinking";  // No expand option if fits in preview
-    }
-    return expanded() ? "Thinking (click to collapse)" : "Thinking (click to expand)";
-  };
-
-  // Auto-scroll when collapsed and streaming
-  const shouldAutoScroll = () => !expanded() && (props.streaming ?? false);
 
   return (
     <Show when={showContent()}>
-      <box 
-        flexDirection="column" 
+      <box
+        flexDirection="column"
         marginTop={1}
         marginBottom={1}
+        paddingLeft={1}
+        paddingRight={1}
         backgroundColor={props.mode ? darkenColor(getModeBackground(props.mode), 0.7) : Colors.message.thinking}
-        overflow="hidden"
-        flexShrink={0}
       >
-        {/* Header - clickable to toggle only if expandable */}
-        <Show
-          when={canExpand()}
-          fallback={
-            <box flexDirection="row" paddingLeft={1} paddingRight={1} flexShrink={0}>
-              <text fg={Colors.ui.dim}>● {label()}</text>
-            </box>
-          }
-        >
-          <box
-            flexDirection="row"
-            paddingLeft={1}
-            paddingRight={1}
-            // @ts-ignore: OpenTUI onMouseDown handler
-            onMouseDown={handleToggle}
-            flexShrink={0}
-          >
-            <text fg={Colors.ui.dim}>
-              {indicator()} {label()}
-            </text>
-          </box>
-        </Show>
-        
-        {/* Content area - scrollbox with different heights based on state */}
-        <box flexDirection="row" paddingLeft={1} paddingRight={1}>
-          <box flexShrink={0} width={2}>
-            <text fg={Colors.ui.dim}>  </text>
-          </box>
-          <Show
-            when={expanded()}
-            fallback={
-              // Collapsed: Fixed 5-row height with auto-scroll during streaming
-              <scrollbox
-                height={COLLAPSED_HEIGHT}
-                flexGrow={1}
-                stickyScroll={shouldAutoScroll()}
-                stickyStart="bottom"
-              >
-                <text fg={Colors.ui.dim}><em>{props.content}</em></text>
-              </scrollbox>
-            }
-          >
-            {/* Expanded: Show up to 50 lines, scrollable if more */}
-            <scrollbox
-              height={Math.min(contentLines(), EXPANDED_MAX_HEIGHT)}
-              flexGrow={1}
-              stickyScroll={props.streaming ?? false}
-              stickyStart="bottom"
-            >
-              <text fg={Colors.ui.dim}><em>{props.content}</em></text>
-            </scrollbox>
-          </Show>
-        </box>
+        <text fg={Colors.ui.dim}><em>{props.content}</em></text>
       </box>
     </Show>
   );

--- a/src/ui/self-check.ts
+++ b/src/ui/self-check.ts
@@ -1,0 +1,71 @@
+import { isTaskMetadata, type ToolMetadata } from "../types/tool-metadata";
+import type { ToolCallInfo, ValidationSummary } from "./components/MessageBlock";
+
+export function createSelfCheckSummary(toolCalls: ToolCallInfo[]): ValidationSummary {
+  const findings: string[] = [];
+  const nextSteps: string[] = [];
+
+  if (toolCalls.length === 0) {
+    findings.push("No tools were executed.");
+    nextSteps.push("Confirm response quality before continuing.");
+    return { findings, nextSteps };
+  }
+
+  const successCount = toolCalls.filter((toolCall) => toolCall.status === "success").length;
+  const errorCount = toolCalls.filter((toolCall) => toolCall.status === "error").length;
+  const cancelledCount = toolCalls.filter((toolCall) => toolCall.status === "cancelled").length;
+  const runningCount = toolCalls.filter((toolCall) => toolCall.status === "pending" || toolCall.status === "running").length;
+
+  findings.push(
+    `Tool execution summary: ${successCount} success, ${errorCount} error, ${cancelledCount} cancelled, ${runningCount} in-flight.`
+  );
+
+  for (const toolCall of toolCalls) {
+    const meta = toolCall.metadata as ToolMetadata | undefined;
+    if (meta && isTaskMetadata(meta)) {
+      const actionCount = meta.actions.length;
+      findings.push(
+        `Subagent (${meta.subagentType}) "${meta.description}": ${toolCall.status}, ${actionCount}/${meta.toolCallCount} actions recorded.`
+      );
+      if (actionCount === 0) {
+        findings.push(`Subagent "${meta.description}" returned without recorded actions.`);
+      }
+      continue;
+    }
+
+    if (toolCall.status === "error" || toolCall.status === "cancelled") {
+      const reason = toolCall.result?.trim();
+      if (reason) {
+        const snippet = reason.length > 120 ? `${reason.slice(0, 117)}...` : reason;
+        findings.push(`${toolCall.name}: ${toolCall.status} (${snippet})`);
+      } else {
+        findings.push(`${toolCall.name}: ${toolCall.status}`);
+      }
+      continue;
+    }
+
+    findings.push(`${toolCall.name}: ${toolCall.status}`);
+  }
+
+  const hasFailure = toolCalls.some((toolCall) => toolCall.status === "error" || toolCall.status === "cancelled");
+  const hasRunning = toolCalls.some((toolCall) => toolCall.status === "pending" || toolCall.status === "running");
+  const hasSubagent = toolCalls.some((toolCall) => {
+    const metadata = toolCall.metadata as ToolMetadata | undefined;
+    return !!metadata && isTaskMetadata(metadata);
+  });
+
+  if (hasFailure) {
+    nextSteps.push("Review failed/cancelled tools and retry with corrected inputs.");
+  }
+  if (hasRunning) {
+    nextSteps.push("Wait for in-flight tools before finalizing this turn.");
+  }
+  if (hasSubagent) {
+    nextSteps.push("Review subagent action summaries and verify delegated outcomes.");
+  }
+  if (!hasFailure && !hasRunning) {
+    nextSteps.push("Validate file/tool outputs and continue.");
+  }
+
+  return { findings, nextSteps };
+}

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -8,24 +8,54 @@ class SecurityError extends Error {
   }
 }
 
+function isWithinBase(baseDir: string, targetPath: string): boolean {
+  const relative = path.relative(baseDir, targetPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function realpathOrResolved(targetPath: string): string {
+  try {
+    return fs.realpathSync(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+/**
+ * Resolve a path to its canonical form while tolerating missing leaf segments.
+ * This resolves symlinks in existing ancestors so path checks cannot be bypassed
+ * by a symlinked directory with a non-existent child.
+ */
+function resolveWithExistingAncestors(targetPath: string): string {
+  const segments: string[] = [];
+  let cursor = path.resolve(targetPath);
+
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    segments.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+
+  let resolved = realpathOrResolved(cursor);
+  for (const segment of segments) {
+    resolved = path.join(resolved, segment);
+  }
+  return resolved;
+}
+
 function sanitizePath(filePath: string, baseDir: string = process.cwd()): string {
   const resolved = path.resolve(baseDir, filePath);
   const normalizedBaseDir = path.resolve(baseDir);
 
-  if (!resolved.startsWith(normalizedBaseDir)) {
+  if (!isWithinBase(normalizedBaseDir, resolved)) {
     throw new SecurityError(`Path traversal detected: ${filePath}`);
   }
 
-  let realPath: string;
-  try {
-    realPath = fs.realpathSync(resolved);
-  } catch {
-    realPath = resolved;
-  }
+  const realBaseDir = realpathOrResolved(normalizedBaseDir);
+  const realPath = resolveWithExistingAncestors(resolved);
 
-  const realBaseDir = path.resolve(baseDir);
-
-  if (!realPath.startsWith(realBaseDir)) {
+  if (!isWithinBase(realBaseDir, realPath)) {
     throw new SecurityError(`Symlink bypass detected: ${filePath}`);
   }
 

--- a/test/self-check.test.ts
+++ b/test/self-check.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { createSelfCheckSummary } from "../src/ui/self-check";
+import type { ToolCallInfo } from "../src/ui/components/MessageBlock";
+
+function tool(overrides: Partial<ToolCallInfo>): ToolCallInfo {
+  return {
+    id: overrides.id ?? "tc-1",
+    name: overrides.name ?? "read",
+    arguments: overrides.arguments ?? "{}",
+    status: overrides.status ?? "success",
+    ...(overrides.result ? { result: overrides.result } : {}),
+    ...(overrides.metadata ? { metadata: overrides.metadata } : {}),
+  };
+}
+
+describe("createSelfCheckSummary", () => {
+  it("returns baseline findings when no tools were executed", () => {
+    const summary = createSelfCheckSummary([]);
+
+    expect(summary.findings).toEqual(["No tools were executed."]);
+    expect(summary.nextSteps).toEqual(["Confirm response quality before continuing."]);
+  });
+
+  it("captures failure and running status in next steps", () => {
+    const longError = "x".repeat(140);
+    const summary = createSelfCheckSummary([
+      tool({ id: "a", name: "read", status: "success" }),
+      tool({ id: "b", name: "bash", status: "error", result: longError }),
+      tool({ id: "c", name: "grep", status: "running" }),
+      tool({ id: "d", name: "write", status: "cancelled" }),
+    ]);
+
+    expect(summary.findings[0]).toBe("Tool execution summary: 1 success, 1 error, 1 cancelled, 1 in-flight.");
+    expect(summary.findings).toContain("read: success");
+    expect(summary.findings.some((item) => item.startsWith("bash: error (") && item.endsWith("...)"))).toBe(true);
+    expect(summary.findings).toContain("grep: running");
+    expect(summary.findings).toContain("write: cancelled");
+    expect(summary.nextSteps).toContain("Review failed/cancelled tools and retry with corrected inputs.");
+    expect(summary.nextSteps).toContain("Wait for in-flight tools before finalizing this turn.");
+    expect(summary.nextSteps).not.toContain("Validate file/tool outputs and continue.");
+  });
+
+  it("audits subagent task metadata and adds subagent verification step", () => {
+    const summary = createSelfCheckSummary([
+      tool({
+        id: "subagent",
+        name: "task",
+        status: "success",
+        metadata: {
+          type: "task",
+          subagentType: "general",
+          description: "Refactor chat render pipeline",
+          actions: ["inspected stream events", "updated message block rendering"],
+          toolCallCount: 3,
+        },
+      }),
+    ]);
+
+    expect(summary.findings).toContain(
+      'Subagent (general) "Refactor chat render pipeline": success, 2/3 actions recorded.'
+    );
+    expect(summary.nextSteps).toContain("Review subagent action summaries and verify delegated outcomes.");
+    expect(summary.nextSteps).toContain("Validate file/tool outputs and continue.");
+  });
+
+  it("flags subagent responses that return without actions", () => {
+    const summary = createSelfCheckSummary([
+      tool({
+        id: "subagent",
+        name: "task",
+        status: "success",
+        metadata: {
+          type: "task",
+          subagentType: "explore",
+          description: "Inspect tool call flow",
+          actions: [],
+          toolCallCount: 0,
+        },
+      }),
+    ]);
+
+    expect(summary.findings).toContain('Subagent "Inspect tool call flow" returned without recorded actions.');
+  });
+});


### PR DESCRIPTION
## Summary
This PR reworks the chat rendering pipeline to preserve assistant stream order across text, thinking, and tool calls, while adding explicit self-check validation output and stronger tool-result visibility.

Fixes #19

## What Changed
- Added ordered assistant content blocks (`text`, `thinking`, `tool_call`) for deterministic in-order rendering.
- Updated streaming/continuation handling to merge tool calls by id and keep completed calls visible during follow-up turns.
- Added a non-mutating self-check summary panel (Findings and Next steps) generated from real tool outcomes.
- Added structured `question` tool metadata and chat rendering for topic/question/answer visibility.
- Extended session persistence for new message fields (`content_blocks`, `validation`, tool-call ids).
- Simplified thinking block rendering and added global toggle behavior integration.
- Fixed `sanitizePath` canonical checks for symlink-inside-base and empty-path handling.
- Added regression tests for self-check logic.
- Updated project docs (`AGENTS.md`) and changelog.
- Bumped version from `0.32.0` to `0.33.0`.

## Validation
- `bun test`
- `npm run -s typecheck`
- `npm run -s build`

All passed locally.