### PR TITLE
fix: stabilize AGENT runtime and MCP toolflow (issue #23)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 import packageJson from "../package.json";
+import { registerCrashRecoveryHandlers } from "./util/crash-recovery";
 
 // =============================================================================
 // CLI Argument Parsing - BEFORE any TUI initialization
 // =============================================================================
 
 const args = process.argv.slice(2);
+registerCrashRecoveryHandlers();
 
 // Helper to check for flag
 const hasFlag = (short: string, long: string): boolean => {

--- a/src/mcp/discovery.ts
+++ b/src/mcp/discovery.ts
@@ -442,7 +442,7 @@ export const MCPDiscovery = {
       }
     }
     
-    return `mcp_call ${tool.server} ${tool.name} '${JSON.stringify(args)}'`;
+    return `${tool.name}(${JSON.stringify(args)})`;
   },
   
   /**

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -48,6 +48,7 @@ export interface MCPServer {
   config: MCPServerConfig;
   status: MCPConnectionStatus;
   error?: string;
+  sessionId?: string;       // HTTP MCP session ID (Mcp-Session-Id header)
   tools: string[];          // Tool names only (backwards compat)
   toolMetadata?: MCPTool[]; // Full tool metadata when fetched
 }

--- a/src/tools/mcp-discover.ts
+++ b/src/tools/mcp-discover.ts
@@ -129,5 +129,6 @@ export const mcpDiscoverTool = Tool.define(
   "mcp_discover",
   "Discover MCP tools. Use search, list, or details. See docs/tools/mcp-discover.md.",
   MCPDiscoverSchema,
-  execute
+  execute,
+  { timeout: 15000 }
 );

--- a/src/ui/components/CollapsibleToolBlock.tsx
+++ b/src/ui/components/CollapsibleToolBlock.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, Show, type JSX } from "solid-js";
 import { Colors, Indicators } from "../design";
 
 /**
@@ -64,10 +64,11 @@ export function CollapsibleToolBlock(props: CollapsibleToolBlockProps) {
 
   const [expanded, setExpanded] = createSignal(initialExpanded());
   const [userToggled, setUserToggled] = createSignal(false);
+  const hasExpandableContent = createMemo(() => !!props.expandedContent);
 
   // Toggle on click (only if there's content to expand)
   const handleClick = () => {
-    if (props.expandedContent) {
+    if (hasExpandableContent()) {
       setUserToggled(true);
       setExpanded(prev => !prev);
     }
@@ -77,14 +78,13 @@ export function CollapsibleToolBlock(props: CollapsibleToolBlockProps) {
   // This keeps file diffs visible once metadata arrives (e.g. pending -> success).
   createEffect(() => {
     if (userToggled()) return;
-    if (!props.expandedContent) return;
+    if (!hasExpandableContent()) return;
     if (initialExpanded() && !expanded()) {
       setExpanded(true);
     }
   });
 
   const expandIndicator = () => expanded() ? Indicators.expanded : Indicators.collapsed;
-  const hasExpandableContent = () => !!props.expandedContent;
 
   return (
     <box flexDirection="column" paddingLeft={2}>
@@ -106,7 +106,7 @@ export function CollapsibleToolBlock(props: CollapsibleToolBlockProps) {
       </box>
 
       {/* Expanded content */}
-      <Show when={expanded() && props.expandedContent}>
+      <Show when={expanded() && hasExpandableContent()}>
         <box paddingLeft={4} flexDirection="column">
           {props.expandedContent}
         </box>

--- a/src/util/auto-approval.ts
+++ b/src/util/auto-approval.ts
@@ -1,0 +1,25 @@
+const NEGATIVE_PATTERNS: RegExp[] = [
+  /\b(no|nah|nope|deny|denied|decline|declined|reject|rejected|cancel|stop)\b/i,
+  /\bdo\s+not\b/i,
+  /\bdon't\b/i,
+  /\bnot\s+now\b/i,
+];
+
+const AFFIRMATIVE_PATTERNS: RegExp[] = [
+  /\b(yes|y|ok|okay|approve|approved|proceed|execute|allow|go\s+ahead|start|continue|confirmed)\b/i,
+];
+
+/**
+ * AUTO approval answers can be freeform text from the question overlay.
+ * Accept common affirmative phrases while still rejecting explicit negatives.
+ */
+export function isAutoApprovalAffirmative(answer: string): boolean {
+  const normalized = answer.trim();
+  if (!normalized) return false;
+
+  if (NEGATIVE_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return false;
+  }
+
+  return AFFIRMATIVE_PATTERNS.some((pattern) => pattern.test(normalized));
+}

--- a/src/util/batch.ts
+++ b/src/util/batch.ts
@@ -4,7 +4,7 @@ type BatchFn = () => void;
 
 class BatchSchedulerImpl {
   private static instance: BatchSchedulerImpl;
-  private pendingUpdates: Map<string, BatchFn[]> = new Map();
+  private pendingUpdates: Map<string, BatchFn> = new Map();
   private timers: Map<string, NodeJS.Timeout> = new Map();
   private defaultBatchWindow: number = 16;
   private globalPending: BatchFn[] = [];
@@ -21,15 +21,8 @@ class BatchSchedulerImpl {
 
   schedule(key: string, fn: BatchFn, window?: number): void {
     const batchWindow = window ?? this.defaultBatchWindow;
-
-    if (!this.pendingUpdates.has(key)) {
-      this.pendingUpdates.set(key, []);
-    }
-
-    const updates = this.pendingUpdates.get(key);
-    if (updates) {
-      updates.push(fn);
-    }
+    // Coalesce hot update paths by key (last write wins in this window)
+    this.pendingUpdates.set(key, fn);
 
     // Only create timer if one doesn't exist (don't reset on each call)
     // This ensures we fire after batchWindow from FIRST call, not last
@@ -57,9 +50,8 @@ class BatchSchedulerImpl {
   }
 
   flush(key: string): void {
-    const updates = this.pendingUpdates.get(key);
-
-    if (!updates || updates.length === 0) {
+    const update = this.pendingUpdates.get(key);
+    if (!update) {
       return;
     }
 
@@ -72,12 +64,10 @@ class BatchSchedulerImpl {
     this.pendingUpdates.delete(key);
 
     solidBatch(() => {
-      for (const update of updates) {
-        try {
-          update();
-        } catch (e) {
-          console.error(`Error in batched update [${key}]:`, e);
-        }
+      try {
+        update();
+      } catch (e) {
+        console.error(`Error in batched update [${key}]:`, e);
       }
     });
   }
@@ -115,8 +105,7 @@ class BatchSchedulerImpl {
   }
 
   hasPendingUpdates(key: string): boolean {
-    const updates = this.pendingUpdates.get(key);
-    return updates !== undefined && updates.length > 0;
+    return this.pendingUpdates.has(key);
   }
 
   hasPendingGlobalUpdates(): boolean {

--- a/src/util/crash-recovery.ts
+++ b/src/util/crash-recovery.ts
@@ -1,0 +1,123 @@
+import fs from "fs";
+import path from "path";
+import { Global } from "../global";
+
+const MAX_LAG_SAMPLES = 100;
+
+export interface LagSample {
+  timestamp: string;
+  lagMs: number;
+  intervalMs: number;
+}
+
+interface CrashArtifact {
+  timestamp: string;
+  type: "uncaughtException" | "unhandledRejection";
+  errorName: string;
+  message: string;
+  stack?: string;
+  pid: number;
+  cwd: string;
+  platform: NodeJS.Platform;
+  nodeVersion: string;
+  bunVersion: string | null;
+  uptimeSeconds: number;
+  memoryRssBytes: number;
+  recentLagSamples: LagSample[];
+}
+
+const recentLagSamples: LagSample[] = [];
+let handlersRegistered = false;
+let fatalHandled = false;
+
+export function recordLagSample(sample: LagSample): void {
+  recentLagSamples.push(sample);
+  if (recentLagSamples.length > MAX_LAG_SAMPLES) {
+    recentLagSamples.splice(0, recentLagSamples.length - MAX_LAG_SAMPLES);
+  }
+}
+
+export function getRecentLagSamples(): LagSample[] {
+  return [...recentLagSamples];
+}
+
+function toErrorInfo(reason: unknown): { errorName: string; message: string; stack?: string } {
+  if (reason instanceof Error) {
+    const errorInfo: { errorName: string; message: string; stack?: string } = {
+      errorName: reason.name,
+      message: reason.message,
+    };
+    if (reason.stack) {
+      errorInfo.stack = reason.stack;
+    }
+    return errorInfo;
+  }
+
+  return {
+    errorName: "UnknownError",
+    message: typeof reason === "string" ? reason : JSON.stringify(reason),
+  };
+}
+
+export function captureCrashArtifact(type: "uncaughtException" | "unhandledRejection", reason: unknown): string {
+  const errorInfo = toErrorInfo(reason);
+  const crashDir = path.join(Global.Path.data, "crash");
+  fs.mkdirSync(crashDir, { recursive: true });
+
+  const artifact: CrashArtifact = {
+    timestamp: new Date().toISOString(),
+    type,
+    errorName: errorInfo.errorName,
+    message: errorInfo.message,
+    ...(errorInfo.stack ? { stack: errorInfo.stack } : {}),
+    pid: process.pid,
+    cwd: process.cwd(),
+    platform: process.platform,
+    nodeVersion: process.version,
+    bunVersion: process.versions.bun ?? null,
+    uptimeSeconds: process.uptime(),
+    memoryRssBytes: process.memoryUsage().rss,
+    recentLagSamples: getRecentLagSamples(),
+  };
+
+  const artifactPath = path.join(crashDir, "last-crash.json");
+  fs.writeFileSync(artifactPath, JSON.stringify(artifact, null, 2), "utf8");
+  return artifactPath;
+}
+
+export function registerCrashRecoveryHandlers(): void {
+  if (handlersRegistered) {
+    return;
+  }
+  handlersRegistered = true;
+
+  const handleFatal = (type: "uncaughtException" | "unhandledRejection", reason: unknown) => {
+    if (fatalHandled) {
+      return;
+    }
+    fatalHandled = true;
+
+    try {
+      const artifactPath = captureCrashArtifact(type, reason);
+      console.error(`[fatal] Crash artifact written: ${artifactPath}`);
+    } catch (error) {
+      console.error(
+        `[fatal] Failed to write crash artifact: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const message = reason instanceof Error ? reason.stack ?? reason.message : String(reason);
+    console.error(`[fatal] ${type}: ${message}`);
+
+    // Fail fast to avoid staying in a broken render/runtime loop.
+    setTimeout(() => process.exit(1), 10);
+  };
+
+  process.on("uncaughtException", (error) => {
+    handleFatal("uncaughtException", error);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    handleFatal("unhandledRejection", reason);
+  });
+}

--- a/src/util/lag-monitor.ts
+++ b/src/util/lag-monitor.ts
@@ -1,4 +1,5 @@
 import { isDebugEnabled, logEventLoopLag } from "./debug-log";
+import { recordLagSample } from "./crash-recovery";
 
 interface LagMonitorOptions {
   intervalMs?: number;
@@ -22,6 +23,12 @@ export function startEventLoopLagMonitor(options: LagMonitorOptions = {}): () =>
     last = now;
 
     if (lag < warnMs) return;
+
+    recordLagSample({
+      timestamp: new Date().toISOString(),
+      lagMs: lag,
+      intervalMs,
+    });
 
     if (now - lastLogged >= logThrottleMs) {
       lastLogged = now;

--- a/test/auto-approval.test.ts
+++ b/test/auto-approval.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { isAutoApprovalAffirmative } from "../src/util/auto-approval";
+
+describe("AUTO approval parser", () => {
+  test("accepts common affirmative phrases", () => {
+    expect(isAutoApprovalAffirmative("Yes")).toBe(true);
+    expect(isAutoApprovalAffirmative("Yes, start building")).toBe(true);
+    expect(isAutoApprovalAffirmative("Approved - full execution")).toBe(true);
+    expect(isAutoApprovalAffirmative("ok proceed")).toBe(true);
+  });
+
+  test("rejects explicit negatives", () => {
+    expect(isAutoApprovalAffirmative("No")).toBe(false);
+    expect(isAutoApprovalAffirmative("Do not execute")).toBe(false);
+    expect(isAutoApprovalAffirmative("Don't proceed")).toBe(false);
+  });
+});

--- a/test/mcp-discovery-example.test.ts
+++ b/test/mcp-discovery-example.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { MCPDiscovery } from "../src/mcp/discovery";
+import type { MCPTool } from "../src/mcp/types";
+
+describe("MCP discovery example formatting", () => {
+  test("generates direct tool invocation format", () => {
+    const tool: MCPTool = {
+      server: "web-search",
+      name: "webSearchPrime",
+      description: "Search the web",
+      inputSchema: {
+        type: "object",
+        properties: {
+          search_query: { type: "string" },
+          max_results: { type: "number" },
+        },
+        required: ["search_query"],
+      },
+    };
+
+    const example = MCPDiscovery.generateExampleCall(tool);
+    expect(example.startsWith("webSearchPrime(")).toBe(true);
+    expect(example.includes("mcp_call")).toBe(false);
+  });
+});

--- a/test/question-tool.test.ts
+++ b/test/question-tool.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { questionTool, rejectQuestion, resolveQuestion, type QuestionToolInput } from "../src/tools/question";
+
+const baseQuestion: QuestionToolInput["questions"][number] = {
+  topic: "Scope",
+  question: "Proceed?",
+  options: [
+    { label: "Yes", description: "Continue" },
+    { label: "No", description: "Stop" },
+  ],
+};
+
+afterEach(() => {
+  // Ensure no pending question leaks across tests.
+  rejectQuestion(new Error("test cleanup"));
+});
+
+describe("question tool safeguards", () => {
+  test("truncates to first 3 topics instead of failing", async () => {
+    const input: QuestionToolInput = {
+      context: "test",
+      questions: [
+        { ...baseQuestion, topic: "T1" },
+        { ...baseQuestion, topic: "T2" },
+        { ...baseQuestion, topic: "T3" },
+        { ...baseQuestion, topic: "T4" },
+      ],
+    };
+
+    const responsePromise = questionTool.handler(input);
+    resolveQuestion([["Yes"], ["Yes"], ["No"]]);
+
+    const result = await responsePromise;
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("only the first 3 were asked");
+  });
+
+  test("rejects overlapping question calls while one is pending", async () => {
+    const firstPromise = questionTool.handler({
+      context: "first",
+      questions: [{ ...baseQuestion, topic: "First" }],
+    });
+
+    const secondResult = await questionTool.handler({
+      context: "second",
+      questions: [{ ...baseQuestion, topic: "Second" }],
+    });
+
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.output).toContain("already active");
+
+    resolveQuestion([["Yes"]]);
+    await firstPromise;
+  });
+});

--- a/test/tool-registry-dynamic.test.ts
+++ b/test/tool-registry-dynamic.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import "../src/tools/init";
+import { Tool } from "../src/tools/registry";
+import { resetAutoApproval } from "../src/tools/mode-state";
+
+describe("tool registry dynamic mode filtering", () => {
+  test("unknown dynamic tools default to read_only visibility", () => {
+    const dynamicToolName = `dynamic_read_only_${Date.now()}`;
+
+    Tool.define(
+      dynamicToolName,
+      "dynamic read-only tool",
+      z.object({}),
+      async () => ({ success: true, output: "ok" })
+    );
+
+    const autoDefs = Tool.getAPIDefinitionsForMode("AUTO");
+    const plannerDefs = Tool.getAPIDefinitionsForMode("PLANNER");
+
+    expect(autoDefs.some((def) => def.function.name === dynamicToolName)).toBe(true);
+    expect(plannerDefs.some((def) => def.function.name === dynamicToolName)).toBe(true);
+  });
+
+  test("set_mode remains available as a utility tool across modes", () => {
+    resetAutoApproval();
+    const plannerDefs = Tool.getAPIDefinitionsForMode("PLANNER");
+    const exploreDefs = Tool.getAPIDefinitionsForMode("EXPLORE");
+
+    expect(plannerDefs.some((def) => def.function.name === "set_mode")).toBe(true);
+    expect(exploreDefs.some((def) => def.function.name === "set_mode")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
This draft PR implements the issue #23 stabilization plan across stream handling, continuation guardrails, MCP reliability, and UI/tool safety.

### What changed
- Added crash artifact capture + fail-fast handlers (src/util/crash-recovery.ts) and lag sample capture wiring.
- Added stream watchdog timeouts for assistant, continuation, and English-retry paths in src/ui/App.tsx.
- Added continuation loop guardrails (depth + repeated signature breaker) with explicit cancellation/status surfacing.
- Hardened continuation failure handling and debug response markers.
- Fixed dynamic tool-mode filtering so unknown/dynamically registered tools default to read-only visibility.
- Added set_mode as a utility tool category for mode filtering.
- Hardened MCP HTTP session handling: persist/send Mcp-Session-Id, refresh 	ools/list, retry once on session/auth-like failures.
- Updated MCP discovery examples to direct invocation format and added mcp_discover timeout.
- Hardened question tool: overlap guard and topic truncation (first 3 topics with explicit note).
- Hardened AUTO approval parsing for affirmative phrases.
- Updated collapsible tool block click/effect logic to avoid direct expandable content checks in event context.
- Coalesced keyed batched UI updates (last-write-wins per batch window).

### Tests
Added:
- 	est/auto-approval.test.ts
- 	est/question-tool.test.ts
- 	est/tool-registry-dynamic.test.ts
- 	est/mcp-discovery-example.test.ts

Validation run:
- un run typecheck passed
- un run build passed
- un test has existing Windows path/symlink failures in 	est/path.test.ts (pre-existing, unchanged by this PR)
- un run lint fails in this repo environment because slint is not installed as a project dependency

Closes #23