### PR TITLE
hotfix: v1.0.1 — fix postinstall error handling and seal root package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-05-18
+
+  **Type:** patch
+  **Title:** Hotfix — postinstall error handling and package configuration
+
+  ### Fixed
+  - Postinstall double error handler — removed conflicting `process.exit(0)`/`process.exit(1)` pattern causing silent failures
+  - Postinstall delete-before-symlink race — symlink created to temp path then atomically renamed, preventing broken wrapper on failure
+  - Root `package.json` marked `private: true` — prevents accidental publish of development workspace over CLI wrapper
+
 ## [1.0.0] - 2026-05-17
 
   **Type:** major

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.0.0",
-  "private": false,
+  "version": "1.0.1",
+  "private": true,
   "description": "Terminal-based provider-flexible AI coding agent for fast software development",
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "0.15.2",
+  "version": "1.0.1",
   "description": "Provider-flexible terminal AI coding agent",
   "license": "MIT",
   "bin": {
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "0.15.2",
-    "@spenceriam/impulse-linux-arm64": "0.15.2",
-    "@spenceriam/impulse-darwin-x64": "0.15.2",
-    "@spenceriam/impulse-darwin-arm64": "0.15.2",
-    "@spenceriam/impulse-windows-x64": "0.15.2"
+    "@spenceriam/impulse-linux-x64": "1.0.1",
+    "@spenceriam/impulse-linux-arm64": "1.0.1",
+    "@spenceriam/impulse-darwin-x64": "1.0.1",
+    "@spenceriam/impulse-darwin-arm64": "1.0.1",
+    "@spenceriam/impulse-windows-x64": "1.0.1"
   }
 }

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -88,23 +88,27 @@ function prepareBinDirectory(binaryName) {
     fs.mkdirSync(binDir, { recursive: true });
   }
 
-  if (fs.existsSync(targetPath)) {
-    fs.unlinkSync(targetPath);
-  }
-
   return { binDir, targetPath };
 }
 
 function symlinkBinary(sourcePath, targetPath) {
-  // Ensure source binary is executable (npm tarball doesn't preserve execute bit)
   try {
     fs.chmodSync(sourcePath, 0o755);
   } catch (e) {
     // Ignore chmod errors (may not have permission)
   }
-  
-  fs.symlinkSync(sourcePath, targetPath);
-  console.log(`IMPULSE binary symlinked: ${targetPath} -> ${sourcePath}`);
+
+  const tempPath = targetPath + ".tmp-" + process.pid;
+
+  fs.symlinkSync(sourcePath, tempPath);
+
+  try {
+    fs.renameSync(tempPath, targetPath);
+  } catch (renameError) {
+    // Clean up temp symlink on failure
+    try { fs.unlinkSync(tempPath); } catch (e) {}
+    throw renameError;
+  }
 
   if (!fs.existsSync(targetPath)) {
     throw new Error(`Failed to symlink binary to ${targetPath}`);
@@ -112,29 +116,24 @@ function symlinkBinary(sourcePath, targetPath) {
 }
 
 async function main() {
-  try {
-    if (os.platform() === "win32") {
-      console.log("Windows detected: using packaged executable");
-      return;
-    }
-
-    const { binaryPath, binaryName } = findBinary();
-    const { targetPath } = prepareBinDirectory(binaryName);
-    
-    // Create symlink to the platform-specific binary
-    symlinkBinary(binaryPath, targetPath);
-    
-    console.log(`IMPULSE installed successfully!`);
-  } catch (error) {
-    console.error("Failed to setup IMPULSE binary:", error.message);
-    console.error("You may need to install Bun and run IMPULSE directly:");
-    console.error("  curl -fsSL https://bun.sh/install | bash");
-    console.error("  bun x @spenceriam/impulse");
-    process.exit(1);
+  if (os.platform() === "win32") {
+    console.log("Windows detected: using packaged executable");
+    return;
   }
+
+  const { binaryPath, binaryName } = findBinary();
+  const { targetPath } = prepareBinDirectory(binaryName);
+
+  symlinkBinary(binaryPath, targetPath);
+
+  console.log(`IMPULSE binary symlinked: ${targetPath} -> ${binaryPath}`);
+  console.log(`IMPULSE installed successfully!`);
 }
 
 main().catch((error) => {
-  console.error("Postinstall script error:", error.message);
-  process.exit(0);
+  console.error("Failed to setup IMPULSE binary:", error.message);
+  console.error("You may need to install Bun and run IMPULSE directly:");
+  console.error("  curl -fsSL https://bun.sh/install | bash");
+  console.error("  bun x @spenceriam/impulse");
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary

Hotfix for v1.0.0 packaging regression. Root `package.json` was accidentally published instead of the CLI wrapper, breaking global installs.

## What broke

- v1.0.0 published the root development workspace (`dist/index.js`) as the binary entry point, requiring Bun at runtime
- The correct architecture is the CLI wrapper (`packages/cli/bin/impulse`) which is Node-compatible and spawns the platform-specific compiled binary
- Postinstall had a double `process.exit` handler causing silent failures
- Postinstall deleted the wrapper before creating the symlink — if symlink failed, the shim was left broken

## Changes

- **`packages/cli/postinstall.mjs`** — Single error handler (`exit(1)`), atomic temp-then-rename symlink pattern, no delete-before-create
- **`package.json` (root)** — Marked `private: true` to prevent accidental publish, bumped to 1.0.1
- **`packages/cli/package.json`** — Bumped to 1.0.1 with updated optionalDeps
- **`CHANGELOG.md`** — Added v1.0.1 entry