### PR TITLE
hotfix: v1.0.2 — bundle ripgrep binary with compiled output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,18 @@ jobs:
             chmod +x packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/impulse
           fi
 
+      - name: Bundle rg binary
+        shell: bash
+        run: |
+          RG_PLATFORM="${{ matrix.platform == 'windows' && 'win32' || matrix.platform }}"
+          RG_PKG="@vscode/ripgrep-${RG_PLATFORM}-${{ matrix.arch }}"
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            cp "node_modules/${RG_PKG}/bin/rg.exe" "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg.exe"
+          else
+            cp "node_modules/${RG_PKG}/bin/rg" "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg"
+            chmod +x "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg"
+          fi
+
       - name: Create platform package.json
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-05-18
+
+  **Type:** patch
+  **Title:** Hotfix — bundle ripgrep binary with compiled output
+
+  ### Fixed
+  - Compiled binary crashed at startup because `@vscode/ripgrep` native binary was not bundled — `bun build --compile` only embeds JavaScript modules, not native executables from `node_modules`
+  - Grep tool now resolves ripgrep relative to the compiled binary location, with fallback to `@vscode/ripgrep` for development mode
+  - CI pipeline copies the platform-matching `rg` binary alongside the compiled `impulse` binary so it's included in the platform package
+
 ## [1.0.1] - 2026-05-18
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Terminal-based provider-flexible AI coding agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provider-flexible terminal AI coding agent",
   "license": "MIT",
   "bin": {
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.0.1",
-    "@spenceriam/impulse-linux-arm64": "1.0.1",
-    "@spenceriam/impulse-darwin-x64": "1.0.1",
-    "@spenceriam/impulse-darwin-arm64": "1.0.1",
-    "@spenceriam/impulse-windows-x64": "1.0.1"
+    "@spenceriam/impulse-linux-x64": "1.0.2",
+    "@spenceriam/impulse-linux-arm64": "1.0.2",
+    "@spenceriam/impulse-darwin-x64": "1.0.2",
+    "@spenceriam/impulse-darwin-arm64": "1.0.2",
+    "@spenceriam/impulse-windows-x64": "1.0.2"
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -33,6 +33,16 @@ if (!result.success) {
   process.exit(1);
 }
 
+// Copy ripgrep binary to dist for compiled binary resolution
+const { rgPath } = await import("@vscode/ripgrep");
+if (existsSync(rgPath)) {
+  const destRg = join(distDir, process.platform === "win32" ? "rg.exe" : "rg");
+  cpSync(rgPath, destRg);
+  console.log(`  Bundled rg: ${destRg}`);
+} else {
+  console.warn("  Warning: @vscode/ripgrep binary not found at", rgPath);
+}
+
 // Add shebang to the output file
 const outputPath = join(distDir, "index.js");
 const content = readFileSync(outputPath, "utf-8");

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,10 +1,28 @@
 import { z } from "zod";
-import { rgPath } from "@vscode/ripgrep";
+import { existsSync } from "fs";
+import { dirname } from "path";
 import { Tool, ToolResult } from "./registry";
 import { sanitizePath } from "../util/path";
 
 const MAX_RESULTS = 100;
 const MAX_CONTENT_LENGTH = 120;
+
+function resolveRgPath(): string | null {
+  // Check for bundled rg alongside the compiled binary
+  const execDir = dirname(process.execPath);
+  const bundledRg = `${execDir}/rg${process.platform === "win32" ? ".exe" : ""}`;
+  if (existsSync(bundledRg)) return bundledRg;
+
+  return null;
+}
+
+async function resolveRgPathDev(): Promise<string | null> {
+  try {
+    const { rgPath } = await import("@vscode/ripgrep");
+    if (existsSync(rgPath)) return rgPath;
+  } catch {}
+  return null;
+}
 
 const DESCRIPTION = `Search file contents with a regex.
 
@@ -36,6 +54,17 @@ export const grepTool: Tool<GrepInput> = Tool.define(
   GrepSchema,
   async (input: GrepInput): Promise<ToolResult> => {
     try {
+      let rgPath = resolveRgPath();
+      if (!rgPath) {
+        rgPath = await resolveRgPathDev();
+      }
+      if (!rgPath) {
+        return {
+          success: false,
+          output: "ripgrep binary not found. Install ripgrep (https://github.com/BurntSushi/ripgrep) or reinstall impulse.",
+        };
+      }
+
       const searchPath = sanitizePath(input.path ?? ".");
 
       // Build command args properly as array elements


### PR DESCRIPTION
## Summary

The compiled binary crashed at startup because `@vscode/ripgrep`'s native `rg` binary was never embedded into the standalone binary. `bun build --compile` bundles JavaScript modules but does not include native executables from `node_modules`.

## Root cause

`@vscode/ripgrep` exports a filesystem path to the native `rg` binary. In a compiled binary, this path points into a `node_modules` tree that does not exist at runtime.

## Changes

- `src/tools/grep.ts` — Replaced static import with runtime resolution. Checks for `rg` alongside the compiled binary, falls back to `@vscode/ripgrep` dynamic import for dev mode.
- `.github/workflows/release.yml` — New step copies the platform ripgrep binary next to the compiled impulse binary.
- `scripts/build.ts` — Same copy step for local builds.
- Version bumps to 1.0.2 across root and packages/cli.
