### PR TITLE
fix: Remove hardcoded 60-char table column width limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2026-05-29
+
+  **Type:** patch
+  **Title:** Fix table column truncation in wide viewports
+
+  ### Fixed
+  - **Table column width** — Markdown tables now scale to use available viewport width instead of being hardcoded to 60 characters per column. Tables will expand up to 80% of available width, allowing content to display fully in wide terminals while still maintaining readability and wrapping when needed.
+
 ## [1.1.3] - 2026-05-28
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "description": "Terminal-based provider-flexible AI coding agent for fast software development",
   "type": "module",

--- a/src/cli/markdown-table.ts
+++ b/src/cli/markdown-table.ts
@@ -98,13 +98,15 @@ export function tableTotalWidth(widths: number[]): number {
   return widths.reduce((sum, width) => sum + width, 0) + widths.length * 3 + 1;
 }
 
-export function tableColumnWidths(table: MarkdownTable): number[] {
+export function tableColumnWidths(table: MarkdownTable, maxWidth?: number): number[] {
   return table.header.map((header, column) => {
     const rowMax = table.rows.reduce(
       (max, row) => Math.max(max, visibleWidth(row[column] ?? "")),
       0
     );
-    return Math.max(3, Math.min(60, Math.max(visibleWidth(header), rowMax)));
+    const naturalWidth = Math.max(visibleWidth(header), rowMax);
+    const maxColWidth = maxWidth ? Math.floor(maxWidth * 0.8) : 120;
+    return Math.max(3, Math.min(maxColWidth, naturalWidth));
   });
 }
 
@@ -176,7 +178,7 @@ function stripAnsi(s: string): string {
 }
 
 export function renderTable(table: MarkdownTable, width: number): string[] {
-  const widths = tableColumnWidths(table);
+  const widths = tableColumnWidths(table, width);
   if (tableTotalWidth(widths) <= width) {
     return renderWideTable(table, widths);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When using Impulse for analysis tasks (codebase exploration, data summaries, etc.), table content was being truncated at 60 characters per column even when the viewport had sufficient width to display more content. This made it difficult to read analysis results and data presentations in wide terminal windows.

**Example:** A user reported that table content was being truncated despite having a viewport width of 1677px, with the suggestion that tables should scale width-wise up to a reasonable gutter/padding on left and right.

## Solution

Modified the `tableColumnWidths` function in `src/cli/markdown-table.ts` to:
- Accept an optional `maxWidth` parameter to dynamically calculate column widths based on available viewport space
- Use 80% of available width as the maximum for any single column (prevents one column from dominating)
- Increase default maximum from 60 to 120 characters when width is not specified (backwards compatible for callers not passing width)
- Pass available width from `renderTable` to `tableColumnWidths` so tables can scale appropriately

## Changes

### `src/cli/markdown-table.ts`
- **Line 101**: Updated `tableColumnWidths` function signature to accept optional `maxWidth` parameter
- **Line 107**: Dynamic column width calculation using `maxWidth ? Math.floor(maxWidth * 0.8) : 120` instead of hardcoded 60
- **Line 181**: Pass `width` parameter to `tableColumnWidths` from `renderTable`

### `CHANGELOG.md`
- Added v1.1.4 entry documenting the fix

### `package.json`
- Bumped version to 1.1.4

## Testing

- ✅ All existing markdown-table tests pass (11/11)
- ✅ Tables still wrap to stacked layout when width is insufficient
- ✅ No new TypeScript errors introduced
- ✅ Backwards compatible - callers not passing width get 120 char default (up from 60)

## Behavior

### Before
- Table columns capped at 60 characters
- Content truncated with `…` even in wide terminals
- Inconsistent use of available space

### After
- Tables scale to use up to 80% of available viewport width per column
- Content displays fully when space allows
- Better utilization of wide terminals
- Graceful fallback to stacked layout on narrow terminals (unchanged)

## Screenshots

The original issue included this screenshot showing truncation:

<img width="1677" height="615" alt="Image" src="https://github.com/user-attachments/assets/624acfd5-c2f9-433b-97f8-b8af63062ea2" />
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-339fdb18-33ed-4050-88df-8a12b72b2e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-339fdb18-33ed-4050-88df-8a12b72b2e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

