### PR TITLE
fix: republish 1.2.1 with verified macOS npm platform tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,9 +223,26 @@ jobs:
           
           for platform_dir in artifacts/impulse-*/; do
             platform_name=$(basename "$platform_dir")
-            echo "Publishing $platform_name..."
+            pkg="@spenceriam/${platform_name}"
+            echo "Publishing ${pkg}@${VERSION}..."
             cd "$platform_dir"
-            npm publish --access public || echo "Failed to publish $platform_name (may already exist)"
+            npm publish --access public
+            tarball_url=$(npm view "${pkg}@${VERSION}" dist.tarball)
+            echo "Verifying tarball: ${tarball_url}"
+            ok=false
+            for attempt in 1 2 3 4 5 6; do
+              if curl -fsSL -o /dev/null "${tarball_url}"; then
+                ok=true
+                break
+              fi
+              echo "Tarball not downloadable yet (attempt ${attempt}/6), waiting 15s..."
+              sleep 15
+            done
+            if [ "${ok}" != "true" ]; then
+              echo "::error::Published ${pkg}@${VERSION} but tarball is missing (npm registry 404)."
+              exit 1
+            fi
+            echo "Tarball verified for ${pkg}@${VERSION}"
             cd -
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-29
+
+  **Type:** patch
+  **Title:** Fix missing macOS npm platform tarballs for 1.2.0
+
+  ### Fixed
+  - **npm install on macOS** — `@spenceriam/impulse-darwin-arm64` and `impulse-darwin-x64` at 1.2.0 had registry metadata but no downloadable tarball (404), so global `npm i -g @spenceriam/impulse@latest` failed postinstall on Apple Silicon and Intel Macs
+  - **Release CI** — fail the publish job when a platform tarball is not downloadable after publish (no silent `|| echo` skip)
+
 ## [1.2.0] - 2026-05-29
 
   **Type:** minor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.1.3",
-    "@spenceriam/impulse-linux-arm64": "1.1.3",
-    "@spenceriam/impulse-darwin-x64": "1.1.3",
-    "@spenceriam/impulse-darwin-arm64": "1.1.3",
-    "@spenceriam/impulse-windows-x64": "1.1.3"
+    "@spenceriam/impulse-linux-x64": "1.2.1",
+    "@spenceriam/impulse-linux-arm64": "1.2.1",
+    "@spenceriam/impulse-darwin-x64": "1.2.1",
+    "@spenceriam/impulse-darwin-arm64": "1.2.1",
+    "@spenceriam/impulse-windows-x64": "1.2.1"
   }
 }

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -76,7 +76,15 @@ function findBinary() {
 
     return { binaryPath, binaryName };
   } catch (error) {
-    throw new Error(`Could not find package ${packageName}: ${error.message}`);
+    const wrapperPkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+    );
+    throw new Error(
+      `Could not find package ${packageName}: ${error.message}\n` +
+        `The platform optional dependency may have failed to install (for example npm 404 on a broken publish).\n` +
+        `Try: npm cache clean --force && npm i -g @spenceriam/impulse@${wrapperPkg.version}\n` +
+        `Or use the macOS/Linux/Windows archives from the GitHub release for v${wrapperPkg.version}.`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

v1.2.1 — fixes broken `npm i -g @spenceriam/impulse@latest` on macOS after the 1.2.0 release.

### Problem

- `@spenceriam/impulse-darwin-arm64@1.2.0` and `impulse-darwin-x64@1.2.0` had npm registry metadata but **404 tarballs**
- Optional platform deps failed to install; `postinstall.mjs` could not symlink the binary
- Linux and Windows 1.2.0 platform packages were fine

### Changes

- Bump version to **1.2.1** (`package.json`, `packages/cli/package.json`, `CHANGELOG.md`)
- **Release CI** — after each platform `npm publish`, curl-verify the tarball is downloadable (retry up to ~90s); fail the job instead of swallowing publish errors
- **postinstall** — clearer error when the platform optional dependency is missing

### After merge

1. Merge to `main` (or run **Actions → Release** with version `1.2.1`)
2. Confirm all six platform packages publish and tarball checks pass
3. Publish the draft GitHub Release
4. Verify locally: `npm cache clean --force && npm i -g @spenceriam/impulse@latest`


Made with [Cursor](https://cursor.com)