### PR TITLE
ci: fix release tarball verification after npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,22 +224,28 @@ jobs:
           for platform_dir in artifacts/impulse-*/; do
             platform_name=$(basename "$platform_dir")
             pkg="@spenceriam/${platform_name}"
-            echo "Publishing ${pkg}@${VERSION}..."
+            tarball_url="https://registry.npmjs.org/@spenceriam/${platform_name}/-/${platform_name}-${VERSION}.tgz"
             cd "$platform_dir"
-            npm publish --access public
-            tarball_url=$(npm view "${pkg}@${VERSION}" dist.tarball)
+
+            if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${pkg}@${VERSION} already on npm — skipping publish, verifying tarball only"
+            else
+              echo "Publishing ${pkg}@${VERSION}..."
+              npm publish --access public
+            fi
+
             echo "Verifying tarball: ${tarball_url}"
             ok=false
-            for attempt in 1 2 3 4 5 6; do
+            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
               if curl -fsSL -o /dev/null "${tarball_url}"; then
                 ok=true
                 break
               fi
-              echo "Tarball not downloadable yet (attempt ${attempt}/6), waiting 15s..."
+              echo "Tarball not downloadable yet (attempt ${attempt}/12), waiting 15s..."
               sleep 15
             done
             if [ "${ok}" != "true" ]; then
-              echo "::error::Published ${pkg}@${VERSION} but tarball is missing (npm registry 404)."
+              echo "::error::${pkg}@${VERSION} tarball still missing after publish (npm registry 404)."
               exit 1
             fi
             echo "Tarball verified for ${pkg}@${VERSION}"


### PR DESCRIPTION
## Summary

Fixes the failed **Release** run for v1.2.1 where `npm publish` succeeded for `impulse-darwin-arm64` but the job exited immediately on `npm view` (registry not updated yet).

- Build the tarball URL directly instead of calling `npm view` right after publish
- Retry `curl` for up to ~3 minutes (registry propagation)
- Skip `npm publish` when the version already exists so a re-run can finish the remaining platforms

### After merge

Re-run **Actions → Release** with version `1.2.1` to publish the remaining platform packages and the CLI wrapper.


Made with [Cursor](https://cursor.com)