### PR TITLE
release: clean 1.2.2 (consistent cross-platform npm publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,37 +220,61 @@ jobs:
       - name: Publish platform packages
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          
+
+          # Publish all platform packages first. Verification happens in a
+          # later step so npm CDN propagation for early packages overlaps with
+          # publishing the rest (avoids racing a per-package 404 right after publish).
           for platform_dir in artifacts/impulse-*/; do
             platform_name=$(basename "$platform_dir")
             pkg="@spenceriam/${platform_name}"
-            tarball_url="https://registry.npmjs.org/@spenceriam/${platform_name}/-/${platform_name}-${VERSION}.tgz"
             cd "$platform_dir"
 
             if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
-              echo "${pkg}@${VERSION} already on npm — skipping publish, verifying tarball only"
+              echo "${pkg}@${VERSION} already on npm — skipping publish"
             else
               echo "Publishing ${pkg}@${VERSION}..."
               npm publish --access public
             fi
 
+            cd - >/dev/null
+          done
+
+      - name: Verify platform tarballs
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Gate before publishing the wrapper: every platform tarball the
+          # wrapper's optionalDependencies point at must be downloadable.
+          # Generous retry (~10 min total) tolerates normal registry propagation;
+          # only a genuine ghost publish (permanent 404) fails the job.
+          fail=0
+          for platform_dir in artifacts/impulse-*/; do
+            platform_name=$(basename "$platform_dir")
+            pkg="@spenceriam/${platform_name}"
+            tarball_url="https://registry.npmjs.org/@spenceriam/${platform_name}/-/${platform_name}-${VERSION}.tgz"
+
             echo "Verifying tarball: ${tarball_url}"
             ok=false
-            for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            for attempt in $(seq 1 40); do
               if curl -fsSL -o /dev/null "${tarball_url}"; then
                 ok=true
                 break
               fi
-              echo "Tarball not downloadable yet (attempt ${attempt}/12), waiting 15s..."
+              echo "Tarball not downloadable yet (attempt ${attempt}/40), waiting 15s..."
               sleep 15
             done
             if [ "${ok}" != "true" ]; then
-              echo "::error::${pkg}@${VERSION} tarball still missing after publish (npm registry 404)."
-              exit 1
+              echo "::error::${pkg}@${VERSION} tarball still missing after ~10m (npm registry 404)."
+              fail=1
+            else
+              echo "Tarball verified for ${pkg}@${VERSION}"
             fi
-            echo "Tarball verified for ${pkg}@${VERSION}"
-            cd -
           done
+
+          if [ "${fail}" != "0" ]; then
+            echo "::error::One or more platform tarballs are missing; not publishing the wrapper."
+            exit 1
+          fi
 
       - name: Create CLI wrapper package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-05-29
+
+  **Type:** patch
+  **Title:** Clean cross-platform republish and propagation-safe release verification
+
+  ### Fixed
+  - **Consistent npm install on every OS** — republish all six platform packages and the `@spenceriam/impulse` wrapper at one matching version, so `npm i -g @spenceriam/impulse@latest` resolves to a working binary on macOS (arm64/x64), Linux (x64/arm64), and Windows. (The split 1.2.0/1.2.1 state, including the broken darwin 1.2.0 tarballs, is superseded.)
+  - **Release CI** — publish all platform packages first, then verify every tarball is downloadable with a generous (~10 min) retry before publishing the wrapper. Verification no longer races npm CDN propagation and aborts a successful publish.
+
 ## [1.2.1] - 2026-05-29
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.2.1",
-    "@spenceriam/impulse-linux-arm64": "1.2.1",
-    "@spenceriam/impulse-darwin-x64": "1.2.1",
-    "@spenceriam/impulse-darwin-arm64": "1.2.1",
-    "@spenceriam/impulse-windows-x64": "1.2.1"
+    "@spenceriam/impulse-linux-x64": "1.2.2",
+    "@spenceriam/impulse-linux-arm64": "1.2.2",
+    "@spenceriam/impulse-darwin-x64": "1.2.2",
+    "@spenceriam/impulse-darwin-arm64": "1.2.2",
+    "@spenceriam/impulse-windows-x64": "1.2.2"
   }
 }


### PR DESCRIPTION
## Summary

Recovers the split npm state and ships a clean **1.2.2** where all six platform packages and the wrapper publish at one matching version, so `npm i -g @spenceriam/impulse@latest` installs a working binary on every OS.

### Why

`@latest` (wrapper 1.2.0) pinned platforms to 1.2.0, and the darwin 1.2.0 tarballs were a broken ghost-publish (404). darwin 1.2.1 existed but was orphaned (no wrapper pointed at it). Result: macOS installs failed.

### Changes

- Bump to **1.2.2** in `package.json` and `packages/cli/package.json` (incl. optionalDependencies)
- **Release CI** — publish all platform packages first, then verify every tarball is downloadable with a generous (~10 min) retry before publishing the wrapper. Verification no longer races npm CDN propagation and kills a successful publish mid-run.
- CHANGELOG entry for 1.2.2

### After merge

`release-on-main` auto-tags `v1.2.2` and dispatches **Release**. All six `@spenceriam/impulse-*@1.2.2` packages publish and verify, then the wrapper publishes. Publish the draft GitHub Release, then verify on macOS: `npm cache clean --force && npm i -g @spenceriam/impulse@latest`.


Made with [Cursor](https://cursor.com)