### PR TITLE
feat: v1.3.0 settings overlay and preserved thinking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,20 @@
 ### Identity
 
 - **Name:** impulse
-- **Version:** v1.2.0
+- **Version:** v1.3.0
 - **Tagline:** Provider-flexible terminal AI co-partner agent
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
 
 ## Current State
 
-**Status:** v1.2.0 (2026-05-29) — startup splash, shell mode, parallel sub-agents, gutter/anchor layout
+**Status:** v1.3.0 (2026-05-30) — `/settings`, thinking visibility, preserved reasoning in API history
+
+### v1.3.0 (2026-05-30)
+
+- [x] `/settings` overlay (`/config` alias) — main/subagent thinking visibility, optional subagent model
+- [x] Preserved thinking — `reasoning_content` forwarded in `buildChatMessages()` for tool continuations
+- [x] Compaction distills prior `reasoning_content` into summaries
 
 ### v1.2.0 (2026-05-29)
 
@@ -840,7 +846,7 @@ Both tools try direct web access first and fall back to bundled `agent-browser` 
 | `/mode` | Switch mode (alt to Tab) |
 | `/engage` | Toggle high-autonomy execution profile |
 | `/instruct` | Edit project instructions |
-| `/config` | Basic settings overlay |
+| `/settings` | Thinking visibility and subagent model (`/config` alias) |
 | `/stats` | Session statistics |
 | `/help` | Categorized help overlay |
 | `/think` | Toggle thinking mode |
@@ -984,7 +990,7 @@ This ensures:
 - **API Message Format for Tool Calls** - Conversation history must include tool_calls and tool results
   - After tool execution, don't just send back-to-back assistant messages
   - Correct format: `assistant (with tool_calls array)` -> `tool (results)` -> `assistant (continuation)`
-  - Conversation history is built in `src/agent/loop.ts` via `buildChatMessages()`
+  - Conversation history is built via `buildChatMessages()` in `src/agent/build-chat-messages.ts` (called from `src/agent/loop.ts`)
   - Tool results use `role: "tool"` with `tool_call_id` matching the original call
 
 ### Streaming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-05-30
+
+  **Type:** minor
+  **Title:** Settings overlay, thinking visibility, and preserved reasoning
+
+  ### Added
+  - **`/settings`** overlay (alias **`/config`**) — True/False controls for main-agent thinking stream vs static `Thinking...`, subagent `thinking...` progress lines, and an optional dedicated subagent provider/model
+  - **Subagent model override** — when enabled, task subagents use `subagentModel` from `~/.impulse/config.json` instead of the main session model
+
+  ### Changed
+  - **Preserved thinking** — assistant `reasoning_content` is included in API history on every tool continuation (reduces repetitive re-reasoning across tool rounds)
+  - **Compaction** — summaries ingest truncated prior reasoning and distill decisions into the handoff text
+
+  ### Fixed
+  - **`/config`** — was registered but unwired in the pi-tui CLI; now opens the same overlay as `/settings`
+
 ## [1.2.2] - 2026-05-29
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/agent/build-chat-messages.ts
+++ b/src/agent/build-chat-messages.ts
@@ -1,0 +1,43 @@
+import type { ChatMessage } from "../api/types.js";
+import type { Message } from "../session/store.js";
+
+/** Build provider chat messages from session history (includes preserved reasoning). */
+export function buildChatMessages(
+  sessionMessages: Message[],
+  systemPrompt: string
+): ChatMessage[] {
+  const result: ChatMessage[] = [{ role: "system", content: systemPrompt }];
+  for (const m of sessionMessages) {
+    if (m.role === "system") continue;
+    if (m.role === "user" || m.role === "assistant") {
+      const content =
+        m.role === "user" && m.apiContent !== undefined
+          ? m.apiContent
+          : (m.content ?? "");
+      const msg: ChatMessage = { role: m.role, content };
+      if (m.role === "assistant" && m.reasoning_content?.trim()) {
+        msg.reasoning_content = m.reasoning_content;
+      }
+      if (m.tool_calls && m.tool_calls.length > 0) {
+        msg.tool_calls = m.tool_calls.map((tc) => ({
+          id: tc.id ?? `call_${tc.tool}`,
+          type: "function" as const,
+          function: { name: tc.tool, arguments: JSON.stringify(tc.arguments) },
+        }));
+      }
+      result.push(msg);
+    } else if (m.role === "tool" as string) {
+      const toolMsg = m as unknown as {
+        role: "tool";
+        content: string;
+        tool_call_id: string;
+      };
+      result.push({
+        role: "tool",
+        content: toolMsg.content,
+        tool_call_id: toolMsg.tool_call_id,
+      });
+    }
+  }
+  return result;
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -18,7 +18,12 @@ import type { ChatMessage, ToolDefinition } from "../api/types";
 import type { StreamCompletionOptions } from "../api/provider";
 import { getProviderManager } from "../api/manager";
 import { runAdvisorConsultation } from "./advisor.js";
-import { isExperimentalAdvisorEnabled, load as loadConfig } from "../util/config";
+import {
+  isExperimentalAdvisorEnabled,
+  load as loadConfig,
+  resolveSubagentModel,
+} from "../util/config";
+import { buildChatMessages } from "./build-chat-messages.js";
 import * as fs from "fs";
 import * as path from "path";
 import { Global } from "../global.js";
@@ -132,33 +137,6 @@ interface PartialToolCall {
   id: string;
   name: string;
   argumentsJson: string;
-}
-
-function buildChatMessages(sessionMessages: Message[], systemPrompt: string): ChatMessage[] {
-  const result: ChatMessage[] = [{ role: "system", content: systemPrompt }];
-  for (const m of sessionMessages) {
-    if (m.role === "system") continue; // system prompt already added above
-    if (m.role === "user" || m.role === "assistant") {
-      const content =
-        m.role === "user" && m.apiContent !== undefined
-          ? m.apiContent
-          : (m.content ?? "");
-      const msg: ChatMessage = { role: m.role, content };
-      if (m.tool_calls && m.tool_calls.length > 0) {
-        msg.tool_calls = m.tool_calls.map((tc) => ({
-          id: tc.id ?? `call_${tc.tool}`,
-          type: "function" as const,
-          function: { name: tc.tool, arguments: JSON.stringify(tc.arguments) },
-        }));
-      }
-      result.push(msg);
-    } else if (m.role === "tool" as string) {
-      // Tool result messages — stored as role:"tool" in session
-      const toolMsg = m as unknown as { role: "tool"; content: string; tool_call_id: string };
-      result.push({ role: "tool", content: toolMsg.content, tool_call_id: toolMsg.tool_call_id });
-    }
-  }
-  return result;
 }
 
 function estimateTokens(messages: ChatMessage[]): number {
@@ -495,6 +473,7 @@ export class AgentLoop {
         type PendingTaskItem = { tc: PartialToolCall; args: Record<string, unknown> };
         const pendingTaskBatch: PendingTaskItem[] = [];
         let subagentThinkingEnabled: boolean | undefined;
+        let subagentModelResolved: string | undefined;
 
         const persistToolResult = async (
           toolCallId: string,
@@ -632,13 +611,18 @@ export class AgentLoop {
             thoroughness: item.args["thoroughness"] as TaskCallSpec["thoroughness"],
           }));
 
+          const subagentModel = resolveSubagentModel(config, model);
           if (subagentThinkingEnabled === undefined) {
-            subagentThinkingEnabled = await resolveSubagentThinkingEnabled(config, model);
+            subagentThinkingEnabled =
+              config.showSubagentThinking &&
+              (await resolveSubagentThinkingEnabled(config, subagentModel));
           }
+          subagentModelResolved = subagentModel;
 
           const results = await runTaskBatch(specs, {
             maxConcurrent: MAX_CONCURRENT_SUBAGENTS,
             signal,
+            model: subagentModelResolved,
             subagentThinkingEnabled,
             onTaskStatus: (id, status) => events.onSubagentTaskStatus?.(id, status),
           });

--- a/src/agent/task-pool.ts
+++ b/src/agent/task-pool.ts
@@ -45,6 +45,8 @@ export type TaskBatchRunOptions = {
   startStaggerMs?: number;
   /** When false, sub-agents do not publish thinking... progress lines. */
   subagentThinkingEnabled?: boolean;
+  /** Provider/model for all subagents in this batch. */
+  model?: string;
   onTaskStatus?: (toolCallId: string, status: "queued" | "running" | "done") => void;
 };
 
@@ -130,6 +132,7 @@ export async function runTaskBatch(
           parentToolCallId: spec.toolCallId,
           signal: options.signal,
           subagentThinkingEnabled: options.subagentThinkingEnabled,
+          model: options.model,
         }
       );
       results.set(spec.toolCallId, {

--- a/src/agent/task-runner.ts
+++ b/src/agent/task-runner.ts
@@ -84,6 +84,7 @@ export type ExecuteSubagentOptions = {
   parentToolCallId: string;
   signal?: AbortSignal;
   subagentThinkingEnabled?: boolean;
+  model?: string;
 };
 
 export type SubagentPreCompleteProgress = {
@@ -182,6 +183,9 @@ export async function executeSubagent(
     const afterTools = messages[messages.length - 1]?.role === "tool";
 
     const completionOptions: CompletionOptions = { messages, signal };
+    if (options.model?.trim()) {
+      completionOptions.model = options.model.trim();
+    }
     if (filteredTools.length > 0) {
       completionOptions.tools = filteredTools;
     }
@@ -205,11 +209,18 @@ export async function executeSubagent(
           ? ""
           : JSON.stringify(assistantMessage.content);
 
-    messages.push({
+    const assistantMsg: ChatMessage = {
       role: "assistant",
       content: assistantContent,
       tool_calls: assistantMessage.tool_calls,
-    });
+    };
+    const reasoning = (
+      assistantMessage as { reasoning_content?: string | null }
+    ).reasoning_content;
+    if (typeof reasoning === "string" && reasoning.trim()) {
+      assistantMsg.reasoning_content = reasoning;
+    }
+    messages.push(assistantMsg);
 
     const hasToolCalls =
       choice.finish_reason === "tool_calls" && !!assistantMessage.tool_calls?.length;

--- a/src/cli/components/settings-overlay.ts
+++ b/src/cli/components/settings-overlay.ts
@@ -1,0 +1,209 @@
+import { visibleWidth, type Component } from "@mariozechner/pi-tui";
+import {
+  intrinsicFramedBoxWidth,
+  overlayAnsi,
+  overlayBottomBorder,
+  overlayEmptyLine,
+  overlayMuted,
+  overlayPushWrapped,
+  overlayRenderBoxWidth,
+  overlaySideLine,
+  overlayTitleLine,
+  OVERLAY_SELECT_BG,
+  OVERLAY_SELECT_FG,
+} from "./overlay-theme.js";
+
+export interface SettingsValues {
+  showMainThinking: boolean;
+  showSubagentThinking: boolean;
+  useSubagentModel: boolean;
+  subagentModel?: string;
+}
+
+export interface SettingsOverlayOptions {
+  values: SettingsValues;
+}
+
+type SettingsRowKey =
+  | "showMainThinking"
+  | "showSubagentThinking"
+  | "useSubagentModel";
+
+const SETTINGS_FOOTER =
+  "↑/↓ move   Space: True/False   Enter: save (model row: pick)   Esc: cancel";
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+function formatBool(value: boolean): string {
+  return value ? overlayAnsi.fg(39, "True") : overlayMuted("False");
+}
+
+function formatSettingRowInner(
+  label: string,
+  value: boolean,
+  selected: boolean,
+  innerWidth: number
+): string {
+  const pointer = selected ? overlayAnsi.fg(39, ">") : " ";
+  const labelText = selected ? label : overlayMuted(label);
+  const valueText = formatBool(value);
+  const left = ` ${pointer} ${labelText}`;
+  const gap = Math.max(1, innerWidth - visibleWidth(stripAnsi(left)) - visibleWidth(stripAnsi(valueText)));
+  return `${left}${" ".repeat(gap)}${valueText}`;
+}
+
+export class SettingsOverlay implements Component {
+  private values: SettingsValues;
+  private selectedIndex = 0;
+  private measureTerminalWidth: number | null = null;
+
+  private readonly rows: Array<{ key: SettingsRowKey; label: string; hint: string }> = [
+    {
+      key: "showMainThinking",
+      label: "Show thinking in main agent",
+      hint: "True: stream reasoning; False: Thinking... only (still in context)",
+    },
+    {
+      key: "showSubagentThinking",
+      label: "Show thinking in subagent",
+      hint: "True: thinking... lines inside task tool rows",
+    },
+    {
+      key: "useSubagentModel",
+      label: "Use different model for subagent",
+      hint: "True: task subagents use a separate provider/model",
+    },
+  ];
+
+  /** User pressed Enter on the subagent model row while enabled. */
+  onPickSubagentModel?: () => void;
+  /** User set useSubagentModel False → True (open picker). */
+  onEnableSubagentModel?: () => void;
+  onSubmit?: (values: SettingsValues) => void;
+  onAbort?: () => void;
+
+  constructor(opts: SettingsOverlayOptions) {
+    this.values = { ...opts.values };
+  }
+
+  getValues(): SettingsValues {
+    return { ...this.values };
+  }
+
+  setSubagentModel(model: string): void {
+    this.values.subagentModel = model;
+    this.values.useSubagentModel = true;
+  }
+
+  setMeasureTerminalWidth(cols: number): void {
+    this.measureTerminalWidth = cols;
+  }
+
+  preferredBoxWidth(terminalWidth: number): number {
+    const terminal = this.measureTerminalWidth ?? terminalWidth;
+    const modelLine = this.subagentModelLine();
+    const widths = [
+      visibleWidth(formatSettingRowInner("Show thinking in main agent", true, true, 60)),
+      visibleWidth(this.rows[0]!.hint),
+      visibleWidth(modelLine),
+      visibleWidth(SETTINGS_FOOTER),
+    ];
+    return intrinsicFramedBoxWidth(terminal, "Settings", widths);
+  }
+
+  invalidate(): void {}
+
+  handleInput(data: string): void {
+    if (data === "\x1b") {
+      this.onAbort?.();
+      return;
+    }
+    if (data === "\r") {
+      const row = this.rows[this.selectedIndex];
+      if (row?.key === "useSubagentModel" && this.values.useSubagentModel) {
+        this.onPickSubagentModel?.();
+        return;
+      }
+      this.onSubmit?.({ ...this.values });
+      return;
+    }
+    if (data === "\x1b[A" || data === "k") {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+      return;
+    }
+    if (data === "\x1b[B" || data === "j") {
+      this.selectedIndex = Math.min(this.rows.length - 1, this.selectedIndex + 1);
+      return;
+    }
+    if (data === " ") {
+      const row = this.rows[this.selectedIndex];
+      if (!row) return;
+      const wasFalse = !this.values[row.key];
+      this.values[row.key] = !this.values[row.key];
+      if (row.key === "useSubagentModel" && wasFalse && this.values.useSubagentModel) {
+        this.onEnableSubagentModel?.();
+      }
+    }
+  }
+
+  private subagentModelLine(): string {
+    if (!this.values.useSubagentModel) return "";
+    const model = this.values.subagentModel?.trim();
+    return model
+      ? `Subagent model: ${model}`
+      : "Subagent model: (not set — Enter to choose)";
+  }
+
+  render(width: number): string[] {
+    const boxWidth = overlayRenderBoxWidth(width);
+    const innerWidth = Math.max(20, boxWidth - 4);
+    const lines: string[] = [];
+
+    lines.push(overlayTitleLine("Settings", boxWidth));
+    lines.push(overlayEmptyLine(boxWidth));
+
+    for (let i = 0; i < this.rows.length; i++) {
+      const row = this.rows[i]!;
+      const selected = i === this.selectedIndex;
+      const inner = formatSettingRowInner(
+        row.label,
+        this.values[row.key],
+        selected,
+        innerWidth
+      );
+      const hint = `     ${overlayMuted(row.hint)}`;
+      lines.push(
+        selected
+          ? padSelectedSideLine(inner, innerWidth, boxWidth)
+          : overlaySideLine(inner, innerWidth, boxWidth)
+      );
+      lines.push(overlaySideLine(hint, innerWidth, boxWidth));
+
+      if (row.key === "useSubagentModel" && this.values.useSubagentModel) {
+        const modelInner = `     ${overlayMuted(this.subagentModelLine())}`;
+        lines.push(overlaySideLine(modelInner, innerWidth, boxWidth));
+      }
+    }
+
+    lines.push(overlayEmptyLine(boxWidth));
+    overlayPushWrapped(lines, SETTINGS_FOOTER, innerWidth, boxWidth);
+    lines.push(overlayBottomBorder(boxWidth));
+    return lines;
+  }
+}
+
+function padSelectedSideLine(
+  inner: string,
+  innerWidth: number,
+  boxWidth: number
+): string {
+  const plainLen = visibleWidth(stripAnsi(inner));
+  const pad = Math.max(0, innerWidth - plainLen);
+  const body = overlayAnsi.bg(
+    OVERLAY_SELECT_BG,
+    overlayAnsi.fg(OVERLAY_SELECT_FG, `${inner}${" ".repeat(pad)}`)
+  );
+  return overlaySideLine(body, innerWidth, boxWidth);
+}

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3026,6 +3026,7 @@ export class ImpulseRenderer {
   private async openModelPicker(opts: {
     purpose: "worker" | "vision" | "subagent";
     onSubagentPicked?: (fullModel: string) => void | Promise<void>;
+    onComplete?: () => void | Promise<void>;
   }): Promise<void> {
     try {
       const config = await loadConfig();
@@ -3050,7 +3051,10 @@ export class ImpulseRenderer {
         this.dismissListOverlay(this.modelPickerHandle);
         this.modelPickerHandle = null;
         const parsed = parseModelPickerSelection(compoundId);
-        if (!parsed) return;
+        if (!parsed) {
+          await opts.onComplete?.();
+          return;
+        }
 
         const fullModel = parsed.modelId.includes("/")
           ? parsed.modelId
@@ -3089,12 +3093,14 @@ export class ImpulseRenderer {
           this.addChatLine(modelStatusLine(`Model: ${fullModel}`));
         }
         this.tui.requestRender();
+        await opts.onComplete?.();
       };
 
-      state.overlay.onCancel = () => {
+      state.overlay.onCancel = async () => {
         this.dismissListOverlay(this.modelPickerHandle);
         this.modelPickerHandle = null;
         this.tui.setFocus(this.promptInput);
+        await opts.onComplete?.();
       };
 
       state.onRowsUpdated = () => this.tui.requestRender();
@@ -3502,6 +3508,17 @@ export class ImpulseRenderer {
 
       const openSubagentPicker = () => {
         void (async () => {
+          // Save current values before dismissing overlay
+          const currentValues = overlay.getValues();
+          config.showMainThinking = currentValues.showMainThinking;
+          config.showSubagentThinking = currentValues.showSubagentThinking;
+          config.useSubagentModel = currentValues.useSubagentModel;
+          if (currentValues.subagentModel !== undefined) {
+            config.subagentModel = currentValues.subagentModel;
+          }
+          await saveConfig(config);
+          this.syncDisplaySettingsFromConfig(config);
+
           this.dismissSettingsOverlay();
           if (countConfiguredProviders(await loadConfig()) === 0) {
             await this.startModelSetup(await loadConfig(), "subagent");
@@ -3512,6 +3529,9 @@ export class ImpulseRenderer {
               onSubagentPicked: async () => {
                 this.tui.setFocus(this.promptInput);
                 this.tui.requestRender();
+              },
+              onComplete: () => {
+                finish();
               }
             });
           }

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -104,6 +104,7 @@ import { SelectableListOverlay } from "./components/selectable-list-overlay.js";
 import { PlanApprovalOverlay } from "./components/plan-approval-overlay.js";
 import { AllowAllDisclaimerOverlay } from "./components/allow-all-disclaimer-overlay.js";
 import { ExperimentalOverlay } from "./components/experimental-overlay.js";
+import { SettingsOverlay } from "./components/settings-overlay.js";
 import { HelpOverlay } from "./components/help-overlay.js";
 import { SideOverlay } from "./components/side-overlay.js";
 import {
@@ -254,14 +255,44 @@ class SeparatorLine implements Component {
   }
 }
 
+const MAX_THINKING_DISPLAY_CHARS = 8000;
+const MAX_THINKING_DISPLAY_LINES = 40;
+
 class ThinkingBlock implements Component {
   private raw = "";
+  private placeholder = false;
+  private truncateDisplay = false;
+  private hiddenCharCount = 0;
+
+  setPlaceholder(): void {
+    this.placeholder = true;
+    this.raw = "";
+    this.truncateDisplay = false;
+    this.hiddenCharCount = 0;
+  }
+
+  setTruncateDisplay(enabled: boolean): void {
+    this.truncateDisplay = enabled;
+  }
 
   setText(text: string): void {
+    this.placeholder = false;
     this.raw = text;
+    if (this.truncateDisplay && text.length > MAX_THINKING_DISPLAY_CHARS) {
+      this.hiddenCharCount = text.length - MAX_THINKING_DISPLAY_CHARS;
+      this.raw = text.slice(0, MAX_THINKING_DISPLAY_CHARS);
+    } else {
+      this.hiddenCharCount = 0;
+    }
   }
 
   render(width: number): string[] {
+    if (this.placeholder) {
+      const prefix = GUTTER;
+      const line = `${prefix}\x1b[38;5;94mThinking...${A.reset}`;
+      return [truncateGutterLine(line, width)];
+    }
+
     const prefix = GUTTER;
     const label = "Thinking:";
     const firstPrefix = `${prefix}\x1b[38;5;94m${label}\x1b[0m `;
@@ -289,6 +320,16 @@ class ThinkingBlock implements Component {
         );
         isFirstOutputLine = false;
       }
+    }
+
+    if (this.truncateDisplay && lines.length > MAX_THINKING_DISPLAY_LINES) {
+      const omitted = lines.length - MAX_THINKING_DISPLAY_LINES;
+      lines.length = MAX_THINKING_DISPLAY_LINES;
+      const foot = `${continuationPrefix}${A.dim}… ${omitted} more lines hidden (/settings)${A.reset}`;
+      lines.push(truncateGutterLine(foot, width));
+    } else if (this.hiddenCharCount > 0) {
+      const foot = `${continuationPrefix}${A.dim}… ${this.hiddenCharCount} more characters hidden (/settings)${A.reset}`;
+      lines.push(truncateGutterLine(foot, width));
     }
 
     return lines.length > 0 ? lines : [truncateGutterLine(firstPrefix, width)];
@@ -325,7 +366,7 @@ interface ModelSetupState {
   models: string[];
   discovery?: ModelDiscoveryResult;
   isAdvisorMode?: boolean;  // @deprecated use setupPurpose
-  setupPurpose?: "worker" | "vision" | "advisor";
+  setupPurpose?: "worker" | "vision" | "advisor" | "subagent";
   selectedModel?: string;   // Model selected in "model" step, used in reasoning step
   pendingRemoveProvider?: ModelProviderOption;
   editingProvider?: boolean;
@@ -766,7 +807,7 @@ export class ImpulseRenderer {
     state.selectedModel = selectedModel;
 
     const purpose = this.setupPurpose(state);
-    if (purpose === "vision" || purpose === "advisor") {
+    if (purpose === "vision" || purpose === "advisor" || purpose === "subagent") {
       await this.finishModelSetup(selectedModel, "off");
       return;
     }
@@ -825,7 +866,9 @@ export class ImpulseRenderer {
         ? "Select vision model"
         : purpose === "advisor"
           ? "Select advisor model"
-          : "Select model";
+          : purpose === "subagent"
+            ? "Select subagent model"
+            : "Select model";
     const overlay = new SelectableListOverlay({
       title,
       rows,
@@ -1197,7 +1240,11 @@ export class ImpulseRenderer {
   private planApprovalInputCleanup: (() => void) | null = null;
   private helpInputCleanup: (() => void) | null = null;
   private experimentalOverlayHandle: OverlayHandle | null = null;
+  private settingsOverlayHandle: OverlayHandle | null = null;
+  private settingsInputCleanup: (() => void) | null = null;
   private experimentalAdvisorEnabled = false;
+  private showMainThinking = true;
+  private responsePreference = "concise";
   /** Session-local turn speed display on context bar (/speedo); not persisted. */
   private speedoEnabled = false;
   private userName = "you"; // User's display name (loaded from config)
@@ -1222,6 +1269,7 @@ export class ImpulseRenderer {
     this.reasoningLevel = config.reasoningLevel ?? (config.thinking ? "medium" : "off");
     this.reasoningCapability = await this.reasoningCapabilityForProvider(config.defaultProvider);
     this.userName = config.userProfile?.name || "you";
+    this.syncDisplaySettingsFromConfig(config);
     await this.normalizeReasoningLevel();
 
     setCurrentMode(this.mode);
@@ -1949,23 +1997,8 @@ export class ImpulseRenderer {
         this.tui.requestRender();
       },
       onThinking: (text) => {
-        this.setBusyStatus("thinking?", BUSY_PROCESSING);
         debugLog(`onThinking: ${text.length} chars`);
-        if (!this.thinkingOpen) {
-          this.thinkingRaw = "";
-          this.thinkingText = null;
-        }
-        if (!this.thinkingText) {
-          debugLog(`Thinking block started`);
-          this.addSectionGap();
-          this.thinkingText = new ThinkingBlock();
-          this.chat.addChild(this.thinkingText);
-          this.hasTrailingGap = false;
-          this.thinkingOpen = true;
-        }
-        this.thinkingRaw += filterThinkingForDisplay(text);
-        this.thinkingText.setText(this.thinkingRaw);
-        this.noteLiveGeneration(text);
+        this.appendWorkerThinking(text);
         this.tui.requestRender();
       },
       onAdvisorStart: (_model) => {
@@ -2314,6 +2347,10 @@ export class ImpulseRenderer {
     switch (cmd) {
       case "advisor": await this.cmdAdvisor(arg); break;
       case "experimental": await this.cmdExperimental(); break;
+      case "settings":
+      case "config":
+        await this.cmdSettings();
+        break;
       case "update":  await this.cmdUpdate();     break;
       case "model":   await this.cmdModel(arg);   break;
       case "vision":  await this.cmdVision(arg);  break;
@@ -2791,6 +2828,34 @@ export class ImpulseRenderer {
       return;
     }
 
+    if (purpose === "subagent") {
+      const providers = { ...(state.config.providers as Record<string, StoredProviderConfig | undefined>) };
+      providers[effectiveKey] = {
+        ...(state.existing ?? {}),
+        apiKey,
+        ...(state.baseUrl ? { baseUrl: state.baseUrl } : {}),
+        ...(provider.customType ? { type: provider.customType } : {}),
+      };
+      state.config.providers = providers as Config["providers"];
+      state.config.subagentModel = selectedModel;
+      state.config.useSubagentModel = true;
+      await saveConfig(state.config);
+      await saveHomeEnv(provider, apiKey, state.baseUrl);
+      resetProviderManager();
+      if (this.modelSetupInputListener) {
+        this.modelSetupInputListener();
+        this.modelSetupInputListener = null;
+      }
+      this.promptInput.getEditor().setAutocompleteProvider(ImpulseRenderer.VOID_AUTOCOMPLETE);
+      this.modelSetup = null;
+      this.modelSetupText.setText("");
+      this.promptInput.setSecretMode(false);
+      this.promptInput.clear();
+      this.addChatLine(modelStatusLine(`Subagent model: ${selectedModel}`));
+      this.requestBottomAnchorRefresh();
+      return;
+    }
+
     // Advisor mode: only save advisorModel, don't change default provider/model
     if (purpose === "advisor" || state.isAdvisorMode) {
       // Save API key to providers config
@@ -2900,16 +2965,51 @@ export class ImpulseRenderer {
     process.exit(0);
   }
 
-  private setupPurpose(state: ModelSetupState): "worker" | "vision" | "advisor" {
+  private setupPurpose(state: ModelSetupState): "worker" | "vision" | "advisor" | "subagent" {
     if (state.setupPurpose) return state.setupPurpose;
     if (state.isAdvisorMode) return "advisor";
     return "worker";
+  }
+
+  private syncDisplaySettingsFromConfig(config: Config): void {
+    this.showMainThinking = config.showMainThinking;
+    this.responsePreference = config.userProfile?.responsePreference?.trim() || "concise";
+  }
+
+  private thinkingTruncateDisplay(): boolean {
+    return this.responsePreference === "concise";
+  }
+
+  private appendWorkerThinking(text: string): void {
+    this.setBusyStatus("thinking?", BUSY_PROCESSING);
+    if (!this.thinkingOpen) {
+      this.thinkingRaw = "";
+      this.thinkingText = null;
+    }
+    if (!this.thinkingText) {
+      this.addSectionGap();
+      this.thinkingText = new ThinkingBlock();
+      this.thinkingText.setTruncateDisplay(this.thinkingTruncateDisplay());
+      this.chat.addChild(this.thinkingText);
+      this.hasTrailingGap = false;
+      this.thinkingOpen = true;
+    }
+    this.thinkingRaw += filterThinkingForDisplay(text);
+    if (!this.showMainThinking) {
+      this.thinkingText.setPlaceholder();
+      this.noteLiveGeneration(text);
+      return;
+    }
+    this.thinkingText.setTruncateDisplay(this.thinkingTruncateDisplay());
+    this.thinkingText.setText(this.thinkingRaw);
+    this.noteLiveGeneration(text);
   }
 
   private setupTitle(state: ModelSetupState): string {
     const p = this.setupPurpose(state);
     if (p === "vision") return "VISION SETUP";
     if (p === "advisor") return "ADVISOR SETUP";
+    if (p === "subagent") return "SUBAGENT MODEL SETUP";
     return "MODEL SETUP";
   }
 
@@ -2924,7 +3024,8 @@ export class ImpulseRenderer {
   }
 
   private async openModelPicker(opts: {
-    purpose: "worker" | "vision";
+    purpose: "worker" | "vision" | "subagent";
+    onSubagentPicked?: (fullModel: string) => void | Promise<void>;
   }): Promise<void> {
     try {
       const config = await loadConfig();
@@ -2967,6 +3068,13 @@ export class ImpulseRenderer {
               `Vision ON — ${fullModel.split("/").pop() ?? fullModel}`
             )
           );
+        } else if (opts.purpose === "subagent") {
+          const cfg = await loadConfig();
+          cfg.subagentModel = fullModel;
+          cfg.useSubagentModel = true;
+          await saveConfig(cfg);
+          await opts.onSubagentPicked?.(fullModel);
+          this.addChatLine(modelStatusLine(`Subagent model: ${fullModel}`));
         } else {
           const cfg = await loadConfig();
           cfg.defaultProvider = parsed.providerKey;
@@ -3148,7 +3256,7 @@ export class ImpulseRenderer {
 
   private async rebuildModelSetupProviders(
     config: Config,
-    purpose: "worker" | "vision" | "advisor"
+    purpose: "worker" | "vision" | "advisor" | "subagent"
   ): Promise<void> {
     const configured: ProviderEntry[] = [];
     const unconfigured: ProviderEntry[] = [];
@@ -3224,7 +3332,7 @@ export class ImpulseRenderer {
 
   private async startModelSetup(
     config: Config,
-    purpose: "worker" | "vision" | "advisor"
+    purpose: "worker" | "vision" | "advisor" | "subagent"
   ): Promise<void> {
     const configured: ProviderEntry[] = [];
     const unconfigured: ProviderEntry[] = [];
@@ -3352,6 +3460,78 @@ export class ImpulseRenderer {
   private dismissExperimentalOverlay(): void {
     this.experimentalOverlayHandle?.hide();
     this.experimentalOverlayHandle = null;
+  }
+
+  private dismissSettingsOverlay(): void {
+    this.settingsInputCleanup?.();
+    this.settingsInputCleanup = null;
+    this.settingsOverlayHandle?.hide();
+    this.settingsOverlayHandle = null;
+  }
+
+  private async cmdSettings(): Promise<void> {
+    if (this.isRunning || !this.tui) return;
+    const config = await loadConfig();
+
+    const overlay = new SettingsOverlay({
+      values: {
+        showMainThinking: config.showMainThinking,
+        showSubagentThinking: config.showSubagentThinking,
+        useSubagentModel: config.useSubagentModel,
+        subagentModel: config.subagentModel,
+      },
+    });
+
+    await new Promise<void>((resolve) => {
+      const handle = this.showContentSizedOverlay(overlay, { maxHeight: 20 });
+      this.settingsOverlayHandle = handle;
+
+      const cleanupNav = this.tui.addInputListener((data: string) => {
+        overlay.handleInput(data);
+        this.tui.requestRender();
+        return { consume: true };
+      });
+      this.settingsInputCleanup = cleanupNav;
+
+      const finish = () => {
+        this.dismissSettingsOverlay();
+        this.tui.setFocus(this.promptInput);
+        this.tui.requestRender();
+        resolve();
+      };
+
+      const openSubagentPicker = () => {
+        void (async () => {
+          this.dismissSettingsOverlay();
+          if (countConfiguredProviders(await loadConfig()) === 0) {
+            await this.startModelSetup(await loadConfig(), "subagent");
+          } else {
+            await this.openModelPicker({ purpose: "subagent" });
+          }
+          finish();
+        })();
+      };
+
+      overlay.onAbort = () => finish();
+
+      overlay.onEnableSubagentModel = openSubagentPicker;
+      overlay.onPickSubagentModel = openSubagentPicker;
+
+      overlay.onSubmit = (values) => {
+        void (async () => {
+          config.showMainThinking = values.showMainThinking;
+          config.showSubagentThinking = values.showSubagentThinking;
+          config.useSubagentModel = values.useSubagentModel;
+          if (values.subagentModel !== undefined) {
+            config.subagentModel = values.subagentModel;
+          }
+          await saveConfig(config);
+          this.syncDisplaySettingsFromConfig(config);
+          this.addChatLine(statusOk("Settings saved"));
+          finish();
+        })();
+      };
+    });
   }
 
   private async cmdAdvisor(arg: string): Promise<void> {
@@ -4105,7 +4285,12 @@ export class ImpulseRenderer {
         if (!filtered.trim()) break;
         this.addSectionGap();
         const block = new ThinkingBlock();
-        block.setText(filtered);
+        if (!this.showMainThinking) {
+          block.setPlaceholder();
+        } else {
+          block.setTruncateDisplay(this.thinkingTruncateDisplay());
+          block.setText(filtered);
+        }
         this.chat.addChild(block);
         this.hasTrailingGap = false;
         break;
@@ -4223,13 +4408,7 @@ export class ImpulseRenderer {
         this.requestBottomAnchorRefresh();
       },
       onThinking: (text) => {
-        this.setBusyStatus("thinking?", BUSY_PROCESSING);
-        if (!this.thinkingText) {
-          this.thinkingText = new ThinkingBlock();
-          this.chat.addChild(this.thinkingText);
-        }
-        this.thinkingRaw += filterThinkingForDisplay(text);
-        this.thinkingText.setText(this.thinkingRaw);
+        this.appendWorkerThinking(text);
         this.requestBottomAnchorRefresh();
       },
       onAdvisorStart: () => {},

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3505,10 +3505,16 @@ export class ImpulseRenderer {
           this.dismissSettingsOverlay();
           if (countConfiguredProviders(await loadConfig()) === 0) {
             await this.startModelSetup(await loadConfig(), "subagent");
+            finish();
           } else {
-            await this.openModelPicker({ purpose: "subagent" });
+            await this.openModelPicker({ 
+              purpose: "subagent",
+              onSubagentPicked: async () => {
+                this.tui.setFocus(this.promptInput);
+                this.tui.requestRender();
+              }
+            });
           }
-          finish();
         })();
       };
 

--- a/src/cli/slash-commands.ts
+++ b/src/cli/slash-commands.ts
@@ -87,6 +87,17 @@ export function buildSlashCommandDefs(
       helpDetail: "Browse and resume a saved session",
     },
     {
+      cmd: "/settings",
+      hint: "thinking visibility and subagent model",
+      helpDetail:
+        "Show thinking in main agent or subagents; optional separate subagent model (/config alias)",
+    },
+    {
+      cmd: "/config",
+      hint: "alias for /settings",
+      helpDetail: "Open settings overlay (alias for /settings)",
+    },
+    {
       cmd: "/show",
       hint: "restore chat view from session history",
       helpDetail: "Restore the on-screen chat from session history",

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -95,7 +95,7 @@ async function handleHelp() {
 async function handleConfig() {
   return {
     success: true,
-    output: "Config command not yet implemented",
+    output: "Use /settings in the TUI (alias: /config) for thinking visibility and subagent model.",
   };
 }
 

--- a/src/session/compact.ts
+++ b/src/session/compact.ts
@@ -211,6 +211,10 @@ class CompactManagerImpl {
         }
       }
 
+      if (msg.reasoning_content?.trim()) {
+        text += `\n  Prior reasoning (summary input): ${truncateText(msg.reasoning_content, 400)}`;
+      }
+
       conversationParts.push(text);
 
       if (msg.role === "user" && msg.content) {
@@ -264,6 +268,7 @@ List ALL errors encountered and how they were fixed:
 
 ### 5. Problem Solving
 Document problems solved and any ongoing troubleshooting efforts.
+Distill key decisions and plans from any "Prior reasoning" excerpts above into this section — do not copy reasoning verbatim.
 
 ### 6. All User Messages (CRITICAL)
 These are all the user's messages (not tool results). Preserve user feedback and intent:

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -56,6 +56,18 @@ const ConfigSchema = z.object({
   /** Vision mode — toggle for automatic image→text translation */
   visionMode: z.boolean().default(false).describe("Whether vision translation is active"),
 
+  /** Stream full thinking blocks in the main agent UI */
+  showMainThinking: z.boolean().default(true).describe("Show reasoning stream in main chat"),
+
+  /** Show thinking... progress lines inside subagent task tool rows */
+  showSubagentThinking: z.boolean().default(true).describe("Show subagent thinking progress"),
+
+  /** When true, task subagents use subagentModel instead of the main session model */
+  useSubagentModel: z.boolean().default(false).describe("Use dedicated subagent model"),
+
+  /** Model for task subagents when useSubagentModel is true (retained when toggled off) */
+  subagentModel: z.string().optional().describe("Subagent model override"),
+
   /** Default mode: AGENT, EXPLORE, PLAN, DEBUG */
   defaultMode: z.string().default("AGENT").describe("Default agent mode"),
 
@@ -240,6 +252,14 @@ export function applySessionVision(config: Config): Config {
 /** Whether the user has saved a default model (required before chat). */
 export function isModelConfigured(config: Config): boolean {
   return Boolean(config.modelExplicitlySet && config.defaultModel?.trim());
+}
+
+/** Model string for task subagents (main session model unless override is enabled). */
+export function resolveSubagentModel(config: Config, mainModel: string): string {
+  if (config.useSubagentModel && config.subagentModel?.trim()) {
+    return config.subagentModel.trim();
+  }
+  return mainModel.trim();
 }
 
 export async function save(config: Config): Promise<void> {

--- a/tests/build-chat-messages.test.ts
+++ b/tests/build-chat-messages.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { buildChatMessages } from "../src/agent/build-chat-messages.js";
+import type { Message } from "../src/session/store.js";
+
+describe("buildChatMessages", () => {
+  test("forwards reasoning_content on assistant messages", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        role: "assistant",
+        content: "hi",
+        reasoning_content: "internal plan: check tests first",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "system");
+    expect(chat).toHaveLength(3);
+    expect(chat[0]?.role).toBe("system");
+    expect(chat[2]?.role).toBe("assistant");
+    expect(chat[2]?.reasoning_content).toBe("internal plan: check tests first");
+  });
+
+  test("omits empty reasoning_content", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "ok",
+        reasoning_content: "   ",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "sys");
+    const assistant = chat.find((m) => m.role === "assistant");
+    expect(assistant?.reasoning_content).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Ship **v1.3.0**: `/settings` for thinking visibility and subagent model, preserved reasoning in API history, and compaction that distills prior thinking.

### Settings (`/settings`, alias `/config`)

- **Show thinking in main agent** — True: stream `Thinking:` block; False: static `Thinking...` (reasoning still stored and sent to the API)
- **Show thinking in subagent** — True: `thinking...` under task rows; False: hidden
- **Use different model for subagent** — optional `subagentModel` via model picker
- Overlay uses **True/False** labels (Space flips on focused row)

### Agent / context

- **`buildChatMessages`** forwards assistant `reasoning_content` on tool continuations
- **Compaction** includes truncated prior reasoning in the summary prompt
- Subagent loop preserves reasoning on in-memory messages; subagent batch respects override model

### Docs / version

- `CHANGELOG.md` and `package.json` at **1.3.0**
- `AGENTS.md` updated (commands, preserved-thinking note)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how conversation history and subagent models are built for every tool continuation; mis-forwarding reasoning could affect model behavior, but scope is additive config and message shaping with tests for buildChatMessages.
> 
> **Overview**
> **v1.3.0** adds a TUI **`/settings`** overlay (alias **`/config`**) for three persisted toggles: stream vs placeholder main-agent thinking, subagent `thinking...` lines, and an optional **subagent model** via the existing model picker/setup flow.
> 
> **API context:** `buildChatMessages` is extracted to its own module and now attaches assistant **`reasoning_content`** to outbound chat history (including tool rounds). Subagent runs use **`resolveSubagentModel`** and pass reasoning through on in-memory messages. **Compaction** feeds truncated prior reasoning into the summary prompt and instructs distillation instead of verbatim copy.
> 
> **UI:** Main thinking can show a static `Thinking...` while reasoning still accumulates; concise profile can truncate long thinking display. **`/config`** in the pi-tui CLI is wired to the overlay (fixes previously registered but unwired command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3512f275a04dc0ebe4624fbcf7dcc688cc51b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->