### PR TITLE
fix: correct context window accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Context usage counter** — completed turns now prefer provider usage tokens and live updates no longer drop to a lower local estimate unless compaction actually runs
   - **Compaction estimates** — pre-request compaction checks now include the active system prompt and tool definitions so thresholds better match the real chat payload
   - **Auto-compaction retries** — automatic compaction now skips repeated same-state attempts when fixed request overhead keeps usage above the threshold
+  - **Compacted context bar** — after auto-compaction, the footer keeps using the full request estimate instead of dropping to a messages-only count
 
 ## [1.3.2] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-06-03
+
+  **Type:** patch
+  **Title:** Fix context window metadata and usage accounting
+
+  ### Fixed
+  - **Model context windows** — context limits now resolve from provider model metadata when available and fall back to models.dev, including close model-id aliases, instead of staying at the old 200k default
+  - **Context usage counter** — completed turns now prefer provider usage tokens and live updates no longer drop to a lower local estimate unless compaction actually runs
+  - **Compaction estimates** — pre-request compaction checks now include the active system prompt and tool definitions so thresholds better match the real chat payload
+
 ## [1.3.2] - 2026-06-02
 
   **Type:** patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Model context windows** — context limits now resolve from provider model metadata when available and fall back to models.dev, including close model-id aliases, instead of staying at the old 200k default
   - **Context usage counter** — completed turns now prefer provider usage tokens and live updates no longer drop to a lower local estimate unless compaction actually runs
   - **Compaction estimates** — pre-request compaction checks now include the active system prompt and tool definitions so thresholds better match the real chat payload
+  - **Auto-compaction retries** — automatic compaction now skips repeated same-state attempts when fixed request overhead keeps usage above the threshold
 
 ## [1.3.2] - 2026-06-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -113,7 +113,7 @@ export interface LoopEvents {
   ) => Promise<TaskBatchDecision>;
   /** Context compaction */
   onCompacting(): void;
-  onCompacted(removedCount: number, summary: string): void;
+  onCompacted(removedCount: number, summary: string, contextTokens?: number): void;
   /** Turn complete */
   onTurnEnd(usage: {
     inputTokens: number;
@@ -357,14 +357,18 @@ export class AgentLoop {
         if (shouldTryCompact) {
           events.onCompacting();
           const result = await CompactManager.compact(session.id, false, { force: true });
-          if (result.compacted) {
-            events.onCompacted(result.removedCount, result.summary);
-          }
           // Refresh session after compaction
           session = SessionManager.getCurrentSession()!;
           const compactedMessages = session.messages ?? [];
           chatMessages = buildChatMessages(compactedMessages, systemPrompt);
           const compactedEstimatedTokens = estimateRequestTokens(chatMessages, toolDefs);
+          if (result.compacted) {
+            events.onCompacted(
+              result.removedCount,
+              result.summary,
+              compactedEstimatedTokens
+            );
+          }
           lastUnproductiveCompact =
             !result.compacted || compactedEstimatedTokens >= estimatedTokens
               ? {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -139,9 +139,16 @@ interface PartialToolCall {
   argumentsJson: string;
 }
 
-function estimateTokens(messages: ChatMessage[]): number {
+function estimateTokens(value: unknown): number {
   // Rough estimate: 1 token ≈ 4 chars
-  return Math.ceil(JSON.stringify(messages).length / 4);
+  return Math.ceil(JSON.stringify(value).length / 4);
+}
+
+function estimateRequestTokens(messages: ChatMessage[], tools: ToolDefinition[]): number {
+  return estimateTokens({
+    messages,
+    ...(tools.length > 0 ? { tools } : {}),
+  });
 }
 
 export interface RunTurnOptions {
@@ -301,6 +308,8 @@ export class AgentLoop {
       let activeStreamingMs = 0;
       let estimatedGeneratedTokens = 0;
       let lastSystemPrompt = "";
+      let latestPromptTokens: number | undefined;
+      let latestCompletionTokens = 0;
       let languageRetryUsed = false;
       let consecutiveTodoOnlyRounds = 0;
       let allowAllTodoNudgeUsed = false;
@@ -321,9 +330,15 @@ export class AgentLoop {
       while (continueLoop && !signal.aborted) {
         await this.flushTurnInjections();
 
-        // Check compaction before each iteration
         const currentMessages = (SessionManager.getCurrentSession()?.messages ?? []);
-        const estimatedTokens = estimateTokens(buildChatMessages(currentMessages, ""));
+        const systemPrompt = await generateSystemPrompt(mode, undefined, config);
+        lastSystemPrompt = systemPrompt;
+        let chatMessages = buildChatMessages(currentMessages, systemPrompt);
+
+        // Check compaction before each iteration using the same request shape
+        // sent to the provider: system prompt, history, preserved reasoning,
+        // tool calls/results, and tool definitions.
+        const estimatedTokens = estimateRequestTokens(chatMessages, toolDefs);
         const contextPct = estimatedTokens / contextWindow;
 
         if (contextPct >= COMPACT_TRIGGER_THRESHOLD) {
@@ -334,13 +349,9 @@ export class AgentLoop {
           }
           // Refresh session after compaction
           session = SessionManager.getCurrentSession()!;
+          const compactedMessages = session.messages ?? [];
+          chatMessages = buildChatMessages(compactedMessages, systemPrompt);
         }
-
-        // Build messages for API call
-        const freshMessages = (SessionManager.getCurrentSession()?.messages ?? []);
-        const systemPrompt = await generateSystemPrompt(mode, undefined, config);
-        lastSystemPrompt = systemPrompt;
-        const chatMessages = buildChatMessages(freshMessages, systemPrompt);
 
         // ── Stream response ─────────────────────────────────────────────────
         const streamOptions: StreamCompletionOptions = {
@@ -408,6 +419,8 @@ export class AgentLoop {
           // Token usage
           if (chunk.usage) {
             chunkOutputTokens = chunk.usage.completion_tokens ?? 0;
+            latestPromptTokens = chunk.usage.prompt_tokens;
+            latestCompletionTokens = chunk.usage.completion_tokens ?? 0;
           }
         }
 
@@ -893,16 +906,23 @@ export class AgentLoop {
         ? Math.round((estimatedGeneratedTokens / generationMs) * 1000)
         : 0;
       const finalMessages = SessionManager.getCurrentSession()?.messages ?? [];
-      const estimatedContextTokens = estimateTokens(buildChatMessages(finalMessages, lastSystemPrompt));
+      const estimatedContextTokens = estimateRequestTokens(
+        buildChatMessages(finalMessages, lastSystemPrompt),
+        toolDefs
+      );
+      const providerContextTokens = latestPromptTokens !== undefined
+        ? latestPromptTokens + latestCompletionTokens
+        : undefined;
+      const contextTokens = providerContextTokens ?? estimatedContextTokens;
       const debugInstrumentationNudge =
         mode === "DEBUG"
           ? buildDebugInstrumentationNudge([...debugEditedFiles])
           : undefined;
 
       events.onTurnEnd({
-        inputTokens: estimatedContextTokens,
+        inputTokens: contextTokens,
         outputTokens,
-        contextPct: Math.min(1, estimatedContextTokens / contextWindow),
+        contextPct: Math.min(1, contextTokens / contextWindow),
         tokensPerSecond,
         durationMs,
         ...(debugInstrumentationNudge

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -314,6 +314,9 @@ export class AgentLoop {
       let languageRetryUsed = false;
       let consecutiveTodoOnlyRounds = 0;
       let allowAllTodoNudgeUsed = false;
+      let lastUnproductiveCompact:
+        | { tokens: number; messageCount: number }
+        | undefined;
       const debugEditedFiles = new Set<string>();
 
       const noteGeneratedChunk = (text: string): void => {
@@ -343,7 +346,15 @@ export class AgentLoop {
         const contextWindow = getContextWindow();
         const contextPct = estimatedTokens / contextWindow;
 
-        if (contextPct >= COMPACT_TRIGGER_THRESHOLD) {
+        const shouldTryCompact =
+          contextPct >= COMPACT_TRIGGER_THRESHOLD &&
+          (
+            lastUnproductiveCompact === undefined ||
+            currentMessages.length > lastUnproductiveCompact.messageCount ||
+            estimatedTokens < lastUnproductiveCompact.tokens
+          );
+
+        if (shouldTryCompact) {
           events.onCompacting();
           const result = await CompactManager.compact(session.id, false, { force: true });
           if (result.compacted) {
@@ -353,6 +364,14 @@ export class AgentLoop {
           session = SessionManager.getCurrentSession()!;
           const compactedMessages = session.messages ?? [];
           chatMessages = buildChatMessages(compactedMessages, systemPrompt);
+          const compactedEstimatedTokens = estimateRequestTokens(chatMessages, toolDefs);
+          lastUnproductiveCompact =
+            !result.compacted || compactedEstimatedTokens >= estimatedTokens
+              ? {
+                  tokens: estimatedTokens,
+                  messageCount: compactedMessages.length,
+                }
+              : undefined;
         }
 
         // ── Stream response ─────────────────────────────────────────────────

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -301,7 +301,8 @@ export class AgentLoop {
       // ── Agentic loop ───────────────────────────────────────────────────────
       let continueLoop = true;
       let outputTokens = 0;
-      const contextWindow = session.context_window || 200000;
+      const getContextWindow = (): number =>
+        SessionManager.getCurrentSession()?.context_window || session?.context_window || 200000;
       const turnStart = Date.now();
       let firstGenerationTime: number | null = null;
       let lastGeneratedAt: number | null = null;
@@ -339,11 +340,12 @@ export class AgentLoop {
         // sent to the provider: system prompt, history, preserved reasoning,
         // tool calls/results, and tool definitions.
         const estimatedTokens = estimateRequestTokens(chatMessages, toolDefs);
+        const contextWindow = getContextWindow();
         const contextPct = estimatedTokens / contextWindow;
 
         if (contextPct >= COMPACT_TRIGGER_THRESHOLD) {
           events.onCompacting();
-          const result = await CompactManager.compact(session.id);
+          const result = await CompactManager.compact(session.id, false, { force: true });
           if (result.compacted) {
             events.onCompacted(result.removedCount, result.summary);
           }
@@ -924,7 +926,7 @@ export class AgentLoop {
       events.onTurnEnd({
         inputTokens: contextTokens,
         outputTokens,
-        contextPct: Math.min(1, contextTokens / contextWindow),
+        contextPct: Math.min(1, contextTokens / getContextWindow()),
         tokensPerSecond,
         durationMs,
         ...(debugInstrumentationNudge

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -369,6 +369,8 @@ export class AgentLoop {
         let accumulatedThinking = "";
         let finishReason: string | null = null;
         let chunkOutputTokens = 0;
+        latestPromptTokens = undefined;
+        latestCompletionTokens = 0;
 
         for await (const chunk of manager.stream(streamOptions)) {
           if (signal.aborted) break;

--- a/src/cli/model-catalog.ts
+++ b/src/cli/model-catalog.ts
@@ -377,12 +377,12 @@ export function enrichModelId(
     displayName = titleCaseSlug(bare);
   }
 
-  const info = {
+  const info: Omit<ModelInfo, "pickerLine"> = {
     id: modelId.includes("/") ? modelId : bare,
     vendor,
     displayName,
-    contextTokens,
-    addedAt,
+    ...(contextTokens !== undefined ? { contextTokens } : {}),
+    ...(addedAt !== undefined ? { addedAt } : {}),
   };
   return { ...info, pickerLine: formatModelPickerLine(info) };
 }
@@ -403,12 +403,10 @@ export function sortModelInfos(models: ModelInfo[]): ModelInfo[] {
 /** Raw model IDs when models.dev enrichment is unavailable. */
 export function fallbackModelInfosFromIds(modelIds: string[]): ModelInfo[] {
   return modelIds.map((id) => {
-    const info = {
+    const info: Omit<ModelInfo, "pickerLine"> = {
       id,
       vendor: "—",
       displayName: id,
-      contextTokens: undefined as number | undefined,
-      addedAt: undefined as Date | undefined,
     };
     return { ...info, pickerLine: formatModelPickerLine(info) };
   });

--- a/src/cli/model-catalog.ts
+++ b/src/cli/model-catalog.ts
@@ -235,6 +235,78 @@ function lookupInBucket(
   return undefined;
 }
 
+function normalizedComparableKey(id: string): string {
+  return id
+    .toLowerCase()
+    .replace(/^(ollama|openrouter|openai|anthropic|groq|gemini|nous|z\.ai)\//, "")
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+  const current = Array.from({ length: b.length + 1 }, () => 0);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1]! + 1,
+        previous[j]! + 1,
+        previous[j - 1]! + cost
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[b.length] ?? Number.MAX_SAFE_INTEGER;
+}
+
+function isVeryCloseModelMatch(query: string, candidate: string): boolean {
+  const q = normalizedComparableKey(query);
+  const c = normalizedComparableKey(candidate);
+  if (!q || !c) return false;
+  if (q === c) return true;
+
+  const shorter = Math.min(q.length, c.length);
+  const longer = Math.max(q.length, c.length);
+  if (shorter < 8) return false;
+
+  // Accept only near aliases, not broad family matches (for example gpt4 vs gpt41).
+  const distance = levenshteinDistance(q, c);
+  return distance <= Math.max(2, Math.floor(longer * 0.08));
+}
+
+function lookupFuzzyInCatalog(
+  data: CatalogData,
+  preferredBucket: string,
+  id: string
+): ModelsDevRecord | undefined {
+  const buckets: Array<Record<string, ModelsDevRecord> | undefined> = [
+    data[preferredBucket]?.models,
+    ...Object.entries(data)
+      .filter(([bucket]) => bucket !== preferredBucket)
+      .map(([, provider]) => provider.models),
+  ];
+
+  for (const bucket of buckets) {
+    if (!bucket) continue;
+    for (const [key, record] of Object.entries(bucket)) {
+      const recordId = String(record.id ?? key);
+      const candidates = new Set([...normKeys(recordId), ...normKeys(key)]);
+      for (const candidate of candidates) {
+        if (isVeryCloseModelMatch(id, candidate)) return record;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function stripImpulseProviderPrefix(
   impulseProviderKey: string,
   modelId: string
@@ -243,12 +315,11 @@ function stripImpulseProviderPrefix(
   return modelId.startsWith(prefix) ? modelId.slice(prefix.length) : modelId;
 }
 
-export function enrichModelId(
+export function resolveModelsDevRecord(
   impulseProviderKey: string,
   modelId: string,
-  catalog: CatalogData,
-  apiMeta?: ProviderModelEntry
-): ModelInfo {
+  catalog: CatalogData
+): ModelsDevRecord | undefined {
   const bare = stripImpulseProviderPrefix(impulseProviderKey, modelId);
   const catalogKey = CATALOG_ALIASES[impulseProviderKey] ?? impulseProviderKey;
   const bucket = catalog[catalogKey]?.models;
@@ -267,11 +338,23 @@ export function enrichModelId(
     }
   }
 
+  return record ?? lookupFuzzyInCatalog(catalog, catalogKey, bare);
+}
+
+export function enrichModelId(
+  impulseProviderKey: string,
+  modelId: string,
+  catalog: CatalogData,
+  apiMeta?: ProviderModelEntry
+): ModelInfo {
+  const bare = stripImpulseProviderPrefix(impulseProviderKey, modelId);
+  const record = resolveModelsDevRecord(impulseProviderKey, modelId, catalog);
+
   let vendor: string;
   let displayName: string;
   const contextTokens =
-    record?.limit?.context ??
-    apiMeta?.context_length;
+    apiMeta?.context_length ??
+    record?.limit?.context;
   const addedAt = parseAddedAt(record, apiMeta);
 
   if (record) {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -161,10 +161,17 @@ import {
   removeProviderFromHomeEnv,
   countConfiguredProviders,
   modelUsesProvider,
+  getCachedModelInfos,
+  resolveCustomProviderOption,
   type ModelDiscoveryResult,
   type ModelProviderOption,
   type StoredProviderConfig,
 } from "./model-setup.js";
+import {
+  enrichModelId,
+  formatContextK,
+  loadModelsDevCatalog,
+} from "./model-catalog.js";
 import { Bus } from "../bus/index.js";
 import { HeaderEvents, ModeEvents, QuestionEvents, SubagentEvents } from "../bus/events.js";
 import { PermissionEvents, respond, type PermissionRequest } from "../permission/index.js";
@@ -1572,6 +1579,7 @@ export class ImpulseRenderer {
     this.tui.start();
     // Discover reasoning capabilities in background (non-blocking)
     void this.refreshReasoningCapability();
+    void this.refreshActiveContextWindow(config, { discover: true });
 
     if (this.startupResume === "picker") {
       await this.cmdResume("");
@@ -1650,6 +1658,91 @@ export class ImpulseRenderer {
   private providerKeyForModel(modelId: string, config: Config): string {
     if (modelId.includes("/")) return modelId.split("/")[0] ?? config.defaultProvider;
     return config.defaultProvider;
+  }
+
+  private findCachedContextWindow(providerKey: string, modelId: string): number | undefined {
+    const cached = getCachedModelInfos(providerKey);
+    if (!cached) return undefined;
+
+    const bare = modelId.startsWith(`${providerKey}/`)
+      ? modelId.slice(providerKey.length + 1)
+      : modelId;
+    const info = cached.find((entry) =>
+      entry.id === modelId ||
+      entry.id === bare ||
+      `${providerKey}/${entry.id}` === modelId
+    );
+    return info?.contextTokens;
+  }
+
+  private providerOptionForKey(providerKey: string, config: Config): ModelProviderOption {
+    return (
+      MODEL_PROVIDERS.find((provider) => provider.key === providerKey) ??
+      resolveCustomProviderOption(providerKey, config)
+    );
+  }
+
+  private async resolveContextWindowForModel(
+    modelId: string,
+    config: Config,
+    opts?: { discover?: boolean }
+  ): Promise<number | undefined> {
+    const providerKey = this.providerKeyForModel(modelId, config);
+    const cached = this.findCachedContextWindow(providerKey, modelId);
+    if (cached && cached > 0) return cached;
+
+    if (opts?.discover) {
+      const stored = providerConfig(config, providerKey);
+      if (stored.apiKey) {
+        const provider = this.providerOptionForKey(providerKey, config);
+        try {
+          await discoverModels(provider, stored.apiKey, stored.baseUrl);
+          const discovered = this.findCachedContextWindow(providerKey, modelId);
+          if (discovered && discovered > 0) return discovered;
+        } catch {
+          // Fall through to models.dev; discovery is best-effort for runtime metadata.
+        }
+      }
+    }
+
+    try {
+      const catalog = await loadModelsDevCatalog();
+      const info = enrichModelId(providerKey, modelId, catalog);
+      return info.contextTokens && info.contextTokens > 0 ? info.contextTokens : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async refreshActiveContextWindow(
+    config?: Config,
+    opts?: { discover?: boolean; announce?: boolean }
+  ): Promise<void> {
+    const cfg = config ?? await loadConfig();
+    const activeModel = this.activeModelId(cfg);
+    if (!activeModel) return;
+
+    const resolved = await this.resolveContextWindowForModel(activeModel, cfg, opts);
+    if (!resolved || resolved <= 0) return;
+
+    const session = SessionManager.getCurrentSession();
+    const sessionNeedsUpdate = session?.context_window !== resolved;
+    if (this.contextWindow === resolved && !sessionNeedsUpdate) return;
+
+    this.contextWindow = resolved;
+    SessionManager.setOptions({ initialContextWindow: resolved });
+    if (sessionNeedsUpdate) {
+      await SessionManager.update({ context_window: resolved });
+    }
+
+    this.contextBar?.update({
+      contextTokens: this.contextTokens,
+      contextWindow: resolved,
+    });
+    if (opts?.announce) {
+      this.addChatLine(modelStatusLine(`Context window: ${formatContextK(resolved)}`));
+    }
+    this.tui?.requestRender();
   }
 
   private async refreshReasoningCapability(): Promise<void> {
@@ -1770,7 +1863,9 @@ export class ImpulseRenderer {
 
     this.lastLiveMetricsAt = now;
     const liveChars = this.streamingRaw.length + this.thinkingRaw.length + extraContextChars;
-    const localContextTokens = this.estimateCurrentSessionTokens() + Math.ceil(liveChars / 4);
+    const localContextTokens =
+      Math.max(this.contextTokens, this.estimateCurrentSessionTokens()) +
+      Math.ceil(liveChars / 4);
     const generatedTokens = Math.ceil(this.liveGeneratedChars / 4);
     const elapsedMs = Math.max(1, now - this.liveTurnStartedAt);
     const tokensPerSecond = generatedTokens > 0 ? Math.round((generatedTokens / elapsedMs) * 1000) : undefined;
@@ -1975,7 +2070,10 @@ export class ImpulseRenderer {
     const events: LoopEvents = {
       onTurnStart: () => {
         this.clearCtrlCPending();
-        this.contextTokens = this.estimateCurrentSessionTokens();
+        this.contextTokens = Math.max(
+          this.contextTokens,
+          this.estimateCurrentSessionTokens()
+        );
         this.contextBar.update({
           contextTokens: this.contextTokens,
           contextWindow: this.contextWindow,
@@ -2087,10 +2185,15 @@ export class ImpulseRenderer {
         this.tui.requestRender();
       },
       onCompacted: (removedCount) => {
+        this.contextTokens = this.estimateCurrentSessionTokens();
         this.addChatLine(
           `${clr.success("[OK]")} ${clr.dim(`compacted ? removed ${removedCount} messages`)}`
         );
         this.setBusyStatus("thinking?", BUSY_PROCESSING);
+        this.contextBar.update({
+          contextTokens: this.contextTokens,
+          contextWindow: this.contextWindow,
+        });
         this.tui.requestRender();
       },
       onTurnEnd: (usage) => {
@@ -2915,6 +3018,7 @@ export class ImpulseRenderer {
     if (SessionManager.getCurrentSession()) {
       await SessionManager.update({ model: selectedModel });
     }
+    await this.refreshActiveContextWindow(state.config);
 
     this.reasoningCapability = await this.reasoningCapabilityForProvider(effectiveKey);
     await this.normalizeReasoningLevel();
@@ -3093,6 +3197,7 @@ export class ImpulseRenderer {
           resetProviderManager();
           SessionManager.setOptions({ defaultModel: fullModel });
           await SessionManager.update({ model: fullModel });
+          await this.refreshActiveContextWindow(cfg);
           void this.refreshReasoningCapability();
           this.contextBar.update({ workerModel: fullModel });
           this.addChatLine(modelStatusLine(`Model: ${fullModel}`));
@@ -4276,6 +4381,7 @@ export class ImpulseRenderer {
     void loadConfig().then((cfg) => {
       this.syncAdvisorFromConfig(cfg);
       this.syncVisionFromConfig(cfg);
+      void this.refreshActiveContextWindow(cfg, { discover: true });
       this.contextBar.update({
         mode: this.mode,
         contextTokens: this.contextTokens,

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -2184,8 +2184,8 @@ export class ImpulseRenderer {
         this.setBusyStatus("compacting context?", BUSY_PROCESSING);
         this.tui.requestRender();
       },
-      onCompacted: (removedCount) => {
-        this.contextTokens = this.estimateCurrentSessionTokens();
+      onCompacted: (removedCount, _summary, contextTokens) => {
+        this.contextTokens = contextTokens ?? this.estimateCurrentSessionTokens();
         this.addChatLine(
           `${clr.success("[OK]")} ${clr.dim(`compacted ? removed ${removedCount} messages`)}`
         );

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -2242,6 +2242,8 @@ export class ImpulseRenderer {
       },
     };
 
+    await this.refreshActiveContextWindow(config, { discover: true });
+
     await this.loop.run(userMessage, this.mode, events, {
       displayMessage,
       segments: payload.segments,

--- a/src/commands/utility.ts
+++ b/src/commands/utility.ts
@@ -134,7 +134,7 @@ async function handleCompact(args: Record<string, unknown>) {
 
   if (parsed.force || (await CompactManager.shouldCompact(sessionID))) {
     // Manual compact - will generate "what next?" prompt
-    const result = await CompactManager.compact(sessionID, true);
+    const result = await CompactManager.compact(sessionID, true, { force: parsed.force === true });
 
     if (result.compacted) {
       return {

--- a/src/session/compact.ts
+++ b/src/session/compact.ts
@@ -22,6 +22,10 @@ export interface CompactResult {
   continuationPrompt?: string  // Prompt to continue conversation after compact
 }
 
+interface CompactOptions {
+  force?: boolean
+}
+
 interface CacheEntry {
   value: number
   timestamp: number
@@ -365,7 +369,11 @@ IMPORTANT: This summary replaces the entire conversation history. Be thorough an
    * @param sessionID Session to compact
    * @param isManual If true, generates "what next?" prompt instead of continuation
    */
-  async compact(sessionID: string, isManual: boolean = false): Promise<CompactResult> {
+  async compact(
+    sessionID: string,
+    isManual: boolean = false,
+    options: CompactOptions = {}
+  ): Promise<CompactResult> {
     if (this.inProgress.has(sessionID)) {
       throw new Error(`Compaction already in progress for session ${sessionID}`);
     }
@@ -380,8 +388,12 @@ IMPORTANT: This summary replaces the entire conversation history. Be thorough an
       const session = await SessionStoreInstance.read(sessionID);
       const messages = session.messages;
       const todos = session.todos || [];
+      const keepRecentCount =
+        options.force && messages.length <= this.config.keepRecentCount
+          ? Math.max(1, Math.floor(messages.length / 2))
+          : this.config.keepRecentCount;
 
-      if (messages.length <= this.config.keepRecentCount) {
+      if (messages.length <= keepRecentCount) {
         // Nothing to compact - still generate a "what next?" prompt for manual compacts
         const result: CompactResult = {
           compacted: false,
@@ -406,8 +418,8 @@ IMPORTANT: This summary replaces the entire conversation history. Be thorough an
         return result;
       }
 
-      const messagesToCompact = messages.slice(0, -this.config.keepRecentCount);
-      const recentMessages = messages.slice(-this.config.keepRecentCount);
+      const messagesToCompact = messages.slice(0, -keepRecentCount);
+      const recentMessages = messages.slice(-keepRecentCount);
 
       const summary = await this.summarizeMessages(messagesToCompact, todos);
 

--- a/src/session/compact.ts
+++ b/src/session/compact.ts
@@ -385,6 +385,7 @@ IMPORTANT: This summary replaces the entire conversation history. Be thorough an
     });
 
     try {
+      await SessionStoreInstance.flushSave(sessionID);
       const session = await SessionStoreInstance.read(sessionID);
       const messages = session.messages;
       const todos = session.todos || [];

--- a/src/session/compact.ts
+++ b/src/session/compact.ts
@@ -73,8 +73,8 @@ class CompactManagerImpl {
    * - Tool call arguments and results
    * - Tool definitions JSON (~1500 tokens)
    * 
-   * Note: This is an estimate. The actual token count is available after each
-   * API call in the prompt_tokens field, which the StatusLine now uses.
+   * Note: This is an estimate used before a request is sent. The footer prefers
+   * provider usage after a turn completes, then falls back to request estimates.
    */
   async calculateContextUsage(sessionID: string): Promise<number> {
     const cached = this.usageCache.get(sessionID);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -25,7 +25,16 @@ class SessionManagerImpl {
     initialContextWindow: 200000,
   };
 
-  private constructor() {}
+  private constructor() {
+    Bus.subscribe((event) => {
+      if (event.type !== SessionEvents.Updated.name) return;
+
+      const payload = event.properties as { sessionID?: unknown; session?: unknown };
+      if (payload.sessionID !== this.currentSession?.id) return;
+
+      this.currentSession = payload.session as Session;
+    });
+  }
 
   static getInstance(): SessionManagerImpl {
     if (!SessionManagerImpl.instance) {

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { enrichModelId } from "../src/cli/model-catalog.js";
+
+describe("model catalog context resolution", () => {
+  test("prefers provider API context_length over models.dev context", () => {
+    const catalog = {
+      openrouter: {
+        models: {
+          "vendor/model-x": {
+            id: "vendor/model-x",
+            name: "Model X",
+            family: "vendor",
+            limit: { context: 200_000 },
+          },
+        },
+      },
+    };
+
+    const info = enrichModelId(
+      "openrouter",
+      "openrouter/vendor/model-x",
+      catalog,
+      { id: "vendor/model-x", context_length: 1_000_000 }
+    );
+
+    expect(info.contextTokens).toBe(1_000_000);
+  });
+
+  test("falls back to a very close models.dev match", () => {
+    const catalog = {
+      "the-grid-ai": {
+        models: {
+          "code-max": {
+            id: "code-max",
+            name: "Code Max",
+            family: "code",
+            limit: { context: 1_000_000 },
+          },
+        },
+      },
+    };
+
+    const info = enrichModelId("custom-grid", "code_max", catalog);
+
+    expect(info.contextTokens).toBe(1_000_000);
+  });
+
+  test("does not fuzzy match broad family names", () => {
+    const catalog = {
+      openai: {
+        models: {
+          "gpt-4.1-long": {
+            id: "gpt-4.1-long",
+            name: "GPT 4.1 Long",
+            family: "openai",
+            limit: { context: 1_000_000 },
+          },
+        },
+      },
+    };
+
+    const info = enrichModelId("openai", "gpt-4", catalog);
+
+    expect(info.contextTokens).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Resolve active model context windows from provider metadata when available, falling back to models.dev with close alias matching.
- Persist resolved context windows into session state on startup/resume and model changes.
- Prefer provider usage tokens for completed-turn context accounting and prevent live estimates from dropping below the last provider-backed count unless compaction runs.
- Include system prompt and tool definitions in pre-request compaction estimates.
- Apply Bugbot follow-ups for stale provider usage, stale context limits during turns, stale compacted-session state, repeated unproductive auto-compaction attempts, and compacted footer estimates that omitted request overhead.
- Add changelog entry and bump package version to 1.3.3.

## Tests
- `npx --yes bun test test/model-catalog.test.ts` — pass
- `npx --yes bun test` — pass (60 tests)
- `npx --yes bun run build` — pass
- `npx --yes bun run typecheck` — fails on existing project-wide strict optional-property/unused errors; no new errors from the latest Bugbot fix were identified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-468004b5-2fb9-485b-ad28-4df3596be26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-468004b5-2fb9-485b-ad28-4df3596be26c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

