### PR TITLE
fix: use provider streaming usage for context bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-06-04
+
+  **Type:** patch
+  **Title:** Fix streaming provider token usage for context bar
+
+  ### Fixed
+  - **Streaming usage** — all OpenAI-compatible providers now send `stream_options.include_usage` so real `prompt_tokens` / `completion_tokens` are available on the final stream chunk
+  - **Usage chunk handling** — agent loop reads `chunk.usage` before skipping empty `choices` (usage-only final chunk)
+  - **Live context bar** — footer counter no longer double-counts tool output during a turn or drops at turn end; uses provider usage when available
+
 ## [1.3.3] - 2026-06-03
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -544,13 +544,14 @@ export class AgentLoop {
             ) {
               const toolStart = Date.now();
               events.onToolStart(item.tc.id, "task", item.args);
+              const durationMs = Date.now() - toolStart;
+              await persistToolResult(item.tc.id, ADVISOR_GATE_MESSAGE);
               events.onToolEnd(
                 item.tc.id,
                 "task",
                 { success: false, output: ADVISOR_GATE_MESSAGE },
-                Date.now() - toolStart
+                durationMs
               );
-              await persistToolResult(item.tc.id, ADVISOR_GATE_MESSAGE);
               allSucceeded = false;
               continue;
             }
@@ -561,13 +562,14 @@ export class AgentLoop {
                 `PLAN mode only allows explore subagents. Use subagent_type="explore" for research-only delegation.`;
               const toolStart = Date.now();
               events.onToolStart(item.tc.id, "task", item.args);
+              const durationMs = Date.now() - toolStart;
+              await persistToolResult(item.tc.id, planMsg);
               events.onToolEnd(
                 item.tc.id,
                 "task",
                 { success: false, output: planMsg },
-                Date.now() - toolStart
+                durationMs
               );
-              await persistToolResult(item.tc.id, planMsg);
               allSucceeded = false;
               continue;
             }
@@ -634,9 +636,10 @@ export class AgentLoop {
             if (!skipResult) continue;
             const toolStart = Date.now();
             events.onToolStart(item.tc.id, "task", item.args);
-            events.onToolEnd(item.tc.id, "task", skipResult, Date.now() - toolStart);
+            const durationMs = Date.now() - toolStart;
             allSucceeded = false;
             await persistToolResult(item.tc.id, skipResult.output);
+            events.onToolEnd(item.tc.id, "task", skipResult, durationMs);
           }
 
           if (toRun.length === 0) return;
@@ -681,8 +684,8 @@ export class AgentLoop {
               allSucceeded = false;
             }
 
-            events.onToolEnd(item.tc.id, "task", result, durationMs);
             await persistToolResult(item.tc.id, result.output);
+            events.onToolEnd(item.tc.id, "task", result, durationMs);
           }
         };
 
@@ -704,10 +707,6 @@ export class AgentLoop {
           ) {
             if (shouldBlockBeforeAdvisor(tc.name, args)) {
               events.onToolStart(tc.id, tc.name, args);
-              events.onToolEnd(tc.id, tc.name, {
-                success: false,
-                output: ADVISOR_GATE_MESSAGE,
-              }, 0);
               allSucceeded = false;
 
               const blockedMsg = {
@@ -717,6 +716,10 @@ export class AgentLoop {
                 timestamp: new Date().toISOString(),
               } as unknown as Message;
               await SessionManager.addMessage(blockedMsg as unknown as Message);
+              events.onToolEnd(tc.id, tc.name, {
+                success: false,
+                output: ADVISOR_GATE_MESSAGE,
+              }, 0);
               continue;
             }
           }
@@ -772,12 +775,7 @@ export class AgentLoop {
                 })
               : `Advisor error: ${advisorResult.error ?? "unknown error"}`;
 
-            events.onToolEnd(
-              tc.id,
-              "consult_advisor",
-              { success: advisorResult.success, output: resultText },
-              Date.now() - toolStart
-            );
+            const durationMs = Date.now() - toolStart;
 
             const advisorToolMsg = {
               role: "tool" as const,
@@ -786,6 +784,12 @@ export class AgentLoop {
               timestamp: new Date().toISOString(),
             } as unknown as Message;
             await SessionManager.addMessage(advisorToolMsg as unknown as Message);
+            events.onToolEnd(
+              tc.id,
+              "consult_advisor",
+              { success: advisorResult.success, output: resultText },
+              durationMs
+            );
 
             advisorCalledThisTurn = true;
             continue;
@@ -814,8 +818,6 @@ export class AgentLoop {
             trackDebugEdit(tc.name, args);
           }
 
-          events.onToolEnd(tc.id, tc.name, result, durationMs);
-
           // Add tool result to session
           const toolResultMsg = {
             role: "tool" as const,
@@ -824,6 +826,7 @@ export class AgentLoop {
             timestamp: new Date().toISOString(),
           };
           await SessionManager.addMessage(toolResultMsg as unknown as Message);
+          events.onToolEnd(tc.id, tc.name, result, durationMs);
 
           // Auto-stuck: trigger advisor if too many consecutive failures
           if (

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -400,6 +400,15 @@ export class AgentLoop {
         for await (const chunk of manager.stream(streamOptions)) {
           if (signal.aborted) break;
 
+          // Usage may arrive on a usage-only final chunk that carries an empty
+          // choices array (OpenAI-compatible stream_options.include_usage).
+          // Read it before the choice guard so we don't skip it.
+          if (chunk.usage) {
+            chunkOutputTokens = chunk.usage.completion_tokens ?? 0;
+            latestPromptTokens = chunk.usage.prompt_tokens;
+            latestCompletionTokens = chunk.usage.completion_tokens ?? 0;
+          }
+
           const choice = chunk.choices[0];
           if (!choice) continue;
 
@@ -441,13 +450,6 @@ export class AgentLoop {
                 if (tc.function?.arguments) partial.argumentsJson += tc.function.arguments;
               }
             }
-          }
-
-          // Token usage
-          if (chunk.usage) {
-            chunkOutputTokens = chunk.usage.completion_tokens ?? 0;
-            latestPromptTokens = chunk.usage.prompt_tokens;
-            latestCompletionTokens = chunk.usage.completion_tokens ?? 0;
           }
         }
 

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -183,6 +183,7 @@ export class GeminiProvider implements AIProvider {
           model: geminiModel,
           messages: this.toGeminiMessages(options.messages),
           stream: true,
+          stream_options: { include_usage: true },
         };
 
         if (options.temperature !== undefined) request.temperature = options.temperature;

--- a/src/api/providers/groq.ts
+++ b/src/api/providers/groq.ts
@@ -161,6 +161,7 @@ export class GroqProvider implements AIProvider {
           model: options.model ?? this.config.defaultModel ?? "llama-3.3-70b-versatile",
           messages: options.messages as OpenAI.ChatCompletionMessageParam[],
           stream: true,
+          stream_options: { include_usage: true },
         };
 
         if (options.temperature !== undefined) request.temperature = options.temperature;

--- a/src/api/providers/nous.ts
+++ b/src/api/providers/nous.ts
@@ -165,6 +165,7 @@ export class NousProvider implements AIProvider {
           model,
           messages: options.messages as OpenAI.ChatCompletionMessageParam[],
           stream: true,
+          stream_options: { include_usage: true },
         };
 
         if (options.temperature !== undefined) request.temperature = options.temperature;

--- a/src/api/providers/ollama.ts
+++ b/src/api/providers/ollama.ts
@@ -279,6 +279,7 @@ export class OllamaProvider implements AIProvider {
         model,
         messages: options.messages as OpenAI.ChatCompletionMessageParam[],
         stream: true,
+        stream_options: { include_usage: true },
       };
 
       applyCommonOptions(req, options);

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -159,6 +159,7 @@ export class OpenAIProvider implements AIProvider {
           model: options.model ?? this.config.defaultModel,
           messages: options.messages as OpenAI.ChatCompletionMessageParam[],
           stream: true,
+          stream_options: { include_usage: true },
         };
         
         if (options.temperature !== undefined) request.temperature = options.temperature;

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -144,6 +144,7 @@ export class OpenRouterProvider implements AIProvider {
         model,
         messages: options.messages as OpenAI.ChatCompletionMessageParam[],
         stream: true,
+        stream_options: { include_usage: true },
       };
       if (options.temperature !== undefined) req.temperature = options.temperature;
       if (options.top_p !== undefined) req.top_p = options.top_p;

--- a/src/api/providers/zai.ts
+++ b/src/api/providers/zai.ts
@@ -163,6 +163,7 @@ export class ZAIProvider implements AIProvider {
           model: options.model ?? this.config.defaultModel,
           messages: options.messages as OpenAI.ChatCompletionMessageParam[],
           stream: true,
+          stream_options: { include_usage: true },
         };
         
         if (options.temperature !== undefined) request.temperature = options.temperature;

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -1857,22 +1857,25 @@ export class ImpulseRenderer {
     this.lastLiveMetricsAt = 0;
   }
 
-  private updateLiveMetrics(extraContextChars = 0, force = false): void {
+  private updateLiveMetrics(_extraContextChars = 0, force = false): void {
     const now = Date.now();
     if (!force && now - this.lastLiveMetricsAt < 250) return;
 
     this.lastLiveMetricsAt = now;
-    const liveChars = this.streamingRaw.length + this.thinkingRaw.length + extraContextChars;
-    const localContextTokens =
-      Math.max(this.contextTokens, this.estimateCurrentSessionTokens()) +
-      Math.ceil(liveChars / 4);
+    // Live context = committed baseline (never drops below the last
+    // authoritative count) plus the in-flight streaming/thinking buffer.
+    // Persisted tool results are already reflected by the session estimate,
+    // so we must NOT fold tool output (extraContextChars) in again or the
+    // counter balloons and then snaps back down at turn end.
+    const transientChars = this.streamingRaw.length + this.thinkingRaw.length;
+    const baseTokens = Math.max(this.contextTokens, this.estimateCurrentSessionTokens());
+    const displayTokens = baseTokens + Math.ceil(transientChars / 4);
     const generatedTokens = Math.ceil(this.liveGeneratedChars / 4);
     const elapsedMs = Math.max(1, now - this.liveTurnStartedAt);
     const tokensPerSecond = generatedTokens > 0 ? Math.round((generatedTokens / elapsedMs) * 1000) : undefined;
 
-    this.contextTokens = localContextTokens;
     this.contextBar.update({
-      contextTokens: localContextTokens,
+      contextTokens: displayTokens,
       contextWindow: this.contextWindow,
       isRunning: this.isRunning,
       ...(this.speedoEnabled && tokensPerSecond !== undefined


### PR DESCRIPTION
## Summary

Fixes #53

Follow-up to v1.3.3 context accounting (PR #52 / #51). The footer now uses **real provider token usage** from streaming when available, and live updates no longer inflate then drop at turn end.

## Changes

- Add `stream_options: { include_usage: true }` to streaming requests in ollama, zai, openai, groq, gemini, nous, openrouter
- Read `chunk.usage` before the `choices` guard so usage-only final chunks are not skipped (`src/agent/loop.ts`)
- Rewrite `updateLiveMetrics` to display `max(committed, sessionEstimate) + transient streaming` without persisting inflated values (`src/cli/renderer.ts`)
- Bump version to **1.3.4** + CHANGELOG entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to streaming request flags, usage chunk parsing, and footer token display logic with no auth or persistence schema changes.
> 
> **Overview**
> **Patch 1.3.4** improves how the footer context meter reflects real API usage during streaming turns.
> 
> OpenAI-compatible streaming requests now set `stream_options: { include_usage: true }` across providers (OpenAI, OpenRouter, Ollama, Groq, Gemini, Nous, Z.ai, etc.) so the final stream chunk can carry `prompt_tokens` / `completion_tokens`. The agent loop reads `chunk.usage` **before** skipping chunks with no `choices`, so usage-only final chunks are not dropped.
> 
> The CLI live metrics path no longer adds tool-output bytes on top of the session estimate (which inflated the bar mid-turn and snapped down at turn end). It shows `max(committed baseline, session estimate) + in-flight streaming/thinking` only, while completed turns still prefer provider usage from the loop.
> 
> Tool UI ordering is tightened so several paths persist tool results to the session before `onToolEnd`, keeping the counter consistent with what is already stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ef1c2b665a9da0d56401e43a5c802b088804e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->