### PR TITLE
feat: PLAN research, revisions, and thinking polish (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,11 @@ packages/windows-*/
 .env.*.local
 
 # AI coding tool configs (tool-local, not project source)
+.agents/
 .codex/
 .commandcode/
 .opencode/
+skills-lock.json
 
 # IDE
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,32 @@
 ### Identity
 
 - **Name:** impulse
-- **Version:** v1.3.0
+- **Version:** v1.4.1
 - **Tagline:** Provider-flexible terminal AI co-partner agent
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
 
 ## Current State
 
-**Status:** v1.3.0 (2026-05-30) — `/settings`, thinking visibility, preserved reasoning in API history
+**Status:** v1.4.1 (2026-06-04) — PLAN research (#55), plan revisions, thinking UI polish, hardened `install_skill`
+
+### v1.4.1 (2026-06-04)
+
+- [x] Thinking blocks auto-collapse to **Thought for (duration)** when a reasoning phase ends
+- [x] `/show-think` and `/hide-think` — session-local expand/collapse; works with `/settings` main thinking off (content still stored for API history)
+- [x] `thinking_duration_ms` persisted on assistant messages; session replay shows collapsed thinking
+- [x] `/settings` Enter with no changes → **Settings unchanged**
+- [x] Slash Tab cycles ambiguous prefixes (e.g. `/show` ↔ `/show-think`); longer commands appear when prefix matches
+- [x] Subagent max iterations **150** (was 50); subagent progress respects reasoning capability + detail settings
+- [x] `install_skill` — non-interactive `-y`, reject repo-only sources, skip when `.agents/skills/<name>/SKILL.md` exists
+
+### v1.4.0 (2026-06-04)
+
+- [x] PLAN mode research (#55) — web tools on main + explore subagents; `file_edit` for active plan revision
+- [x] Plan revisions under `.impulse/plans/<sessionId>/revisions/`; `plan_revision` tool; latest revision injected each turn
+- [x] `install_skill` (utility tool, all modes; PLAN prompts emphasize it) via `npx skills@latest add`
+- [x] Repository context in system prompt; `github_issue` tool (gh-only)
+- [x] Skills on disk: `.agents/skills/<slug>/SKILL.md` (not auto-listed — agent reads on demand after install or reference)
 
 ### v1.3.0 (2026-05-30)
 
@@ -190,6 +208,8 @@
 - [x] Question overlay uses radio/checkbox selection without numeric hotkeys
 - [x] Assistant markdown tables render terminal-natively with narrow fallback
 - [x] Footer context/token-speed telemetry updates during active turns
+- [x] PLAN revisions, `plan_revision`, `install_skill`, `github_issue`, repo context (#55 / v1.4.0)
+- [x] Thinking blocks collapse to Thought for…; `/show-think` / `/hide-think`; settings unchanged feedback (v1.4.1)
 - [x] Tool Input Repair Layer — validate-then-repair in [`src/tools/input-repair/`](src/tools/input-repair/) via [`Tool.execute`](src/tools/registry.ts); see [`docs/tool-input-repair.md`](docs/tool-input-repair.md)
 - [x] Branded tool schemas — `zFilePath`, `zGlobPattern`, `zCodeEdit`, `zCommandString` on file_read, bash, file_edit, file_write, glob, grep
 - [x] Relational `Note:` defaults — [`src/tools/tool-notes.ts`](src/tools/tool-notes.ts) for file_read, glob, grep, web_fetch, web_search, task
@@ -850,6 +870,8 @@ Both tools try direct web access first and fall back to bundled `agent-browser` 
 | `/stats` | Session statistics |
 | `/help` | Categorized help overlay |
 | `/think` | Toggle thinking mode |
+| `/show-think` | Expand thinking blocks in chat (session-local) |
+| `/hide-think` | Collapse thinking blocks to Thought for… |
 | `/changelog` | View release changelog |
 | `/quit` | Exit with summary |
 | `/exit` | Exit with summary |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`plan_revision` tool** — create a new revision when reworking a plan (superseded revisions stay read-only)
   - **`install_skill` tool** — install skills via `npx skills@latest add` in PLAN without full bash access
   - **Explore subagent web tools** — `web_search` and `web_fetch` on explore subagents for parallel external research
+  - **Repository context** — system prompt injects GitHub `owner/repo` and issue URL pattern from `package.json` / `git origin`
+  - **`github_issue` tool** — read issues via GitHub CLI (`gh`); gh-only (no in-tool web fallback)
+  - **GitHub CLI status** — prompt shows whether `gh` is installed and authenticated
 
   ### Changed
   - **PLAN mode writes** — `file_write` / `file_edit` target active revision only (`design.md`, `spec.md`, `tasks.md`; `PRD.md` after TDD confirmed via question tool)
   - **PLAN prompts** — full web research instructions; active plan paths injected each turn
+  - **GitHub issue references** — same-repo "issue #N" must use Repository context / `github_issue` / canonical `web_fetch`, not blind `web_search`
+  - **Question tool docs** — document built-in "Type your own answer" for repo names and URLs
 
   ### Fixed
   - **PLAN mode research (#55)** — main and delegated explore agents can research the codebase and the web; `file_edit` available in PLAN for plan files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-06-04
+
+  **Type:** minor
+  **Title:** PLAN mode research and revision-based plan artifacts
+
+  ### Added
+  - **Plan revisions** — spec-driven plans under `.impulse/plans/<sessionId>/revisions/`; latest revision is always active context for the main agent
+  - **`plan_revision` tool** — create a new revision when reworking a plan (superseded revisions stay read-only)
+  - **`install_skill` tool** — install skills via `npx skills@latest add` in PLAN without full bash access
+  - **Explore subagent web tools** — `web_search` and `web_fetch` on explore subagents for parallel external research
+
+  ### Changed
+  - **PLAN mode writes** — `file_write` / `file_edit` target active revision only (`design.md`, `spec.md`, `tasks.md`; `PRD.md` after TDD confirmed via question tool)
+  - **PLAN prompts** — full web research instructions; active plan paths injected each turn
+
+  ### Fixed
+  - **PLAN mode research (#55)** — main and delegated explore agents can research the codebase and the web; `file_edit` available in PLAN for plan files
+
 ## [1.3.4] - 2026-06-04
 
   **Type:** patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-06-04
+
+  **Type:** patch
+  **Title:** Thinking UI polish, install_skill hardening, subagent limits
+
+  ### Added
+  - **`/show-think` / `/hide-think`** — session-local expand or collapse thinking blocks after auto-collapse to **Thought for (duration)**
+  - **`thinking_duration_ms`** on assistant messages; collapsed thinking on session replay
+
+  ### Changed
+  - **Main thinking display** — `/settings` off still accumulates reasoning for API history; `/show-think` reveals stored content
+  - **Subagent iterations** — max **150** per subagent run (was 50)
+  - **Subagent progress** — respects provider reasoning capability and settings detail vs placeholder
+  - **`install_skill`** — non-interactive `-y`, rejects repo-only sources, skips when skill already under `.agents/skills/`
+  - **PLAN prompts** — full skill paths, `question` tool required for grill/interview flows
+  - **Slash autocomplete** — Tab cycles `/show` vs `/show-think`; prefix matches surface longer command names
+
+  ### Fixed
+  - **`/settings`** — Enter with no changes shows **Settings unchanged** instead of a false save
+
 ## [1.4.0] - 2026-06-04
 
   **Type:** minor

--- a/docs/tools/github-issue.md
+++ b/docs/tools/github-issue.md
@@ -1,0 +1,22 @@
+# github_issue
+
+Read a GitHub issue using GitHub CLI (`gh`). **Requires `gh` installed and authenticated** — no web_fetch fallback inside this tool.
+
+## Parameters
+
+- `number` (required): Issue number
+- `owner`, `repo` (optional): default to workspace repo from Repository context
+- `url` (optional): full issue URL (parses owner/repo/number)
+
+## When to use
+
+- User asks about **issue #N** in the current project and `gh` is available
+- Prefer over blind `web_search` for issue numbers
+
+## When gh is unavailable
+
+The tool returns the canonical issue URL. Use `web_fetch` on that URL, or install/auth `gh`.
+
+## PLAN mode
+
+Available in PLAN (read-only). Does not require bash.

--- a/docs/tools/install-skill.md
+++ b/docs/tools/install-skill.md
@@ -1,13 +1,23 @@
 # install_skill
 
-Install an agent skill package via `npx skills@latest add`.
+Install a **single** agent skill via `npx skills@latest add` (non-interactive, `-y`).
 
 ## Parameters
 
-- `source` (required): e.g. `mattpocock/skills` or a skill path from the registry
-- `global` (optional): install globally when supported
+- `source` (required): Full skill path or GitHub tree URL — **not** the repo root alone
+  - Good: `mattpocock/skills/skills/engineering/grill-with-docs`
+  - Bad: `mattpocock/skills` (rejected; would install all skills)
+- `global` (optional): install globally (`-g`) when supported
+
+## Behavior
+
+- Normalizes GitHub `tree/` and `blob/` URLs to `owner/repo/path/to/skill`
+- Skips `npx` when `.agents/skills/<skill>/SKILL.md` already exists
+- Verifies `SKILL.md` exists after install
+- Returns the path to `SKILL.md` and reminds the agent to use the **question** tool for interview flows
 
 ## Notes
 
 - Available in PLAN mode without enabling full `bash`
 - Requires permission approval (same as shell commands)
+- After install, read and follow `SKILL.md`; grilling skills must use `question`, not chat markdown

--- a/docs/tools/install-skill.md
+++ b/docs/tools/install-skill.md
@@ -1,0 +1,13 @@
+# install_skill
+
+Install an agent skill package via `npx skills@latest add`.
+
+## Parameters
+
+- `source` (required): e.g. `mattpocock/skills` or a skill path from the registry
+- `global` (optional): install globally when supported
+
+## Notes
+
+- Available in PLAN mode without enabling full `bash`
+- Requires permission approval (same as shell commands)

--- a/docs/tools/plan-revision.md
+++ b/docs/tools/plan-revision.md
@@ -1,0 +1,18 @@
+# plan_revision
+
+Create a new plan revision in PLAN mode. The latest revision is always the active context for the main agent.
+
+## When to use
+
+- User asks to revise or rework the plan
+- Switching to TDD after confirming with the `question` tool
+
+## Parameters
+
+- `revises` (optional): prior revision id
+- `planning_style` (optional): `spec` (default) or `tdd`
+
+## Notes
+
+- First plan write auto-creates revision `initial` if none exists
+- Do not overwrite files in superseded revisions

--- a/docs/tools/question.md
+++ b/docs/tools/question.md
@@ -11,4 +11,13 @@ Opens the interactive question overlay to collect structured user input.
 
 - Use this instead of plain-text questions
 - Provide concise labels and clear descriptions
-- Users can always type a custom answer
+- **Free-text answers:** every topic includes a built-in **"Type your own answer"** row (last option). The user can enter `owner/repo`, a full URL, or any custom text — do not add a dummy option like "I will tell you later" that forces a second message.
+
+## Example: ambiguous GitHub repo
+
+When issue #N could refer to an unknown repository:
+
+- **topic:** Repository
+- **question:** Which GitHub repo does issue #N refer to?
+- **options:** one label for the detected workspace repo (e.g. `This repo (owner/name)`), optional second concrete choice if known
+- User can select an option or use **Type your own answer** for `other-org/other-repo` or `https://github.com/.../issues/N`

--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -12,8 +12,8 @@ Launches a subagent for autonomous task execution.
 ## Subagent Types
 
 explore (read-only, fast)
-- Tools: file_read, glob, grep
-- Use for: locating code, understanding patterns, answering "where/what/how" questions
+- Tools: file_read, glob, grep, web_search, web_fetch
+- Use for: locating code, understanding patterns, external research, answering "where/what/how" questions
 
 general (full access)
 - Tools: file_read, file_write, file_edit, glob, grep, bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/prompts/agents/explore.md
+++ b/prompts/agents/explore.md
@@ -1,4 +1,4 @@
-You are an explore subagent for impulse. Your job is to quickly search and analyze codebases.
+You are an explore subagent for impulse. Your job is to quickly search and analyze codebases and external sources.
 
 IMPORTANT: Always respond in English regardless of the input language.
 
@@ -6,9 +6,12 @@ You have access to READ-ONLY tools:
 - file_read: Read files
 - glob: Find files by pattern
 - grep: Search file contents
+- web_search: Discover current external sources
+- web_fetch: Read exact URLs from search results
 
 Guidelines:
 - Be fast and focused - answer the specific question asked
+- Use web_search + web_fetch when the task needs current docs or external context
 - Return structured, actionable information
 - Include file paths and line numbers when relevant
 - Summarize findings concisely - the main agent will process your output

--- a/prompts/modes/plan.md
+++ b/prompts/modes/plan.md
@@ -1,21 +1,45 @@
 ## Mode: PLAN
 
-Planning and documentation mode. Focus on requirements, architecture, and implementation plans.
+Planning mode. Research the problem, then produce spec-driven plan artifacts under the active plan revision.
 
-### PLAN Capabilities
+### Core rule: latest revision wins
 
-- Read-only exploration and research
-- Write planning artifacts in `docs/` and `PRD.md`
-- Delegate exploration with `task` using `subagent_type: "explore"`
-- Produce design docs, task breakdowns, and rollout plans
+- If planning runs more than once in this session, the **latest** plan revision is the only current context.
+- To rework a plan, call `plan_revision` first, then write new files — do **not** overwrite superseded revisions.
+- Older revisions are historical (readable if the user asks).
 
-### Use PLAN When
+### PLAN capabilities
 
-- Scope spans multiple modules/systems
-- You need tradeoff analysis or architecture choices
-- Requirements are ambiguous and need clarification before coding
+- Read-only codebase exploration: `file_read`, `glob`, `grep`
+- External research: `web_search`, `web_fetch`
+- Parallel research: `task` with `subagent_type: "explore"` (explore agents also have web tools)
+- Plan artifacts: `file_write` / `file_edit` only in the **active** revision under `.impulse/plans/<sessionId>/revisions/`
+- New revision: `plan_revision`
+- Skills: `install_skill` when a referenced skill is not available
+- Clarification: `question` tool (required before assuming TDD)
 
-### When to Suggest Mode Switches
+### Spec-driven artifacts (default)
 
-- Plan is approved and user wants implementation -> Suggest WORK
-- User asks for bug triage and reproduction -> Suggest DEBUG
+In the active revision directory, write:
+
+| File | Purpose |
+|------|---------|
+| `design.md` | Technical architecture, UI/UX workflow |
+| `spec.md` | Detailed requirements and behavior |
+| `tasks.md` | Executable task breakdown (BMAD-style chunks) |
+
+### Test-driven development (TDD)
+
+- Default is spec-driven (design + spec + tasks).
+- If the user mentions TDD or test-driven development, use the **question** tool to confirm before switching.
+- After confirmation, call `plan_revision` with `planning_style: "tdd"` and you may add `PRD.md` in the active revision.
+
+### `/advisor` vs Tab PLAN
+
+- `consult_advisor` and `~/.impulse/advisor-plans/` are for experimental `/advisor` only.
+- Tab PLAN files live in the project `.impulse/plans/` tree — separate systems.
+
+### When to suggest mode switches
+
+- Plan approved and user wants implementation → Suggest AGENT (WORK)
+- User asks for bug triage → Suggest DEBUG

--- a/prompts/modes/plan.md
+++ b/prompts/modes/plan.md
@@ -16,8 +16,22 @@ Planning mode. Research the problem, then produce spec-driven plan artifacts und
 - Parallel research: `task` with `subagent_type: "explore"` (explore agents also have web tools)
 - Plan artifacts: `file_write` / `file_edit` only in the **active** revision under `.impulse/plans/<sessionId>/revisions/`
 - New revision: `plan_revision`
-- Skills: `install_skill` when a referenced skill is not available
-- Clarification: `question` tool (required before assuming TDD)
+- Skills: `install_skill` when a referenced skill is not available (see below)
+- Clarification: `question` tool — **required** for preferences, grilling, and interviews (never plain-text "Question N:" in chat)
+
+### Skills (`install_skill`)
+
+- Pass the **full skill path**, not the repo root (e.g. `mattpocock/skills/skills/engineering/grill-with-docs`).
+- Repo-only sources (e.g. `mattpocock/skills`) are rejected — they would install every skill or hang on interactive pickers.
+- GitHub tree URLs to a skill folder are accepted.
+- After install (or if already present), read `.agents/skills/<name>/SKILL.md` and follow it.
+- Skills that say "interview" or "one question at a time" → **question** tool with **one topic per call**; wait for answers between calls.
+
+### Grilling / interview flows
+
+- Do **not** write questions in assistant markdown. The user will not get an overlay.
+- Use `question({ context: "...", questions: [{ topic: "...", question: "...", options: [...] }] })` with one topic when the skill says one-at-a-time.
+- Provide your recommended answer in each question's options/descriptions when the skill asks for it.
 
 ### Spec-driven artifacts (default)
 

--- a/prompts/modes/plan.md
+++ b/prompts/modes/plan.md
@@ -11,7 +11,8 @@ Planning mode. Research the problem, then produce spec-driven plan artifacts und
 ### PLAN capabilities
 
 - Read-only codebase exploration: `file_read`, `glob`, `grep`
-- External research: `web_search`, `web_fetch`
+- External research: `web_search`, `web_fetch`, `github_issue` (when GitHub CLI is available)
+- GitHub issues: for "issue #N" in this repo, use Repository context — never blind `web_search` for issue numbers
 - Parallel research: `task` with `subagent_type: "explore"` (explore agents also have web tools)
 - Plan artifacts: `file_write` / `file_edit` only in the **active** revision under `.impulse/plans/<sessionId>/revisions/`
 - New revision: `plan_revision`

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -335,7 +335,9 @@ export class AgentLoop {
         await this.flushTurnInjections();
 
         const currentMessages = (SessionManager.getCurrentSession()?.messages ?? []);
-        const systemPrompt = await generateSystemPrompt(mode, undefined, config);
+        const systemPrompt = await generateSystemPrompt(mode, undefined, config, {
+          sessionId: session.id,
+        });
         lastSystemPrompt = systemPrompt;
         let chatMessages = buildChatMessages(currentMessages, systemPrompt);
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -394,10 +394,18 @@ export class AgentLoop {
         const partialToolCalls = new Map<number, PartialToolCall>();
         let accumulatedText = "";
         let accumulatedThinking = "";
+        let thinkingPhaseStartedAt: number | null = null;
+        let thinkingDurationMs = 0;
         let finishReason: string | null = null;
         let chunkOutputTokens = 0;
         latestPromptTokens = undefined;
         latestCompletionTokens = 0;
+
+        const closeThinkingPhase = () => {
+          if (thinkingPhaseStartedAt === null) return;
+          thinkingDurationMs += Date.now() - thinkingPhaseStartedAt;
+          thinkingPhaseStartedAt = null;
+        };
 
         for await (const chunk of manager.stream(streamOptions)) {
           if (signal.aborted) break;
@@ -419,6 +427,7 @@ export class AgentLoop {
 
           // Text token
           if (delta.content) {
+            closeThinkingPhase();
             noteGeneratedChunk(delta.content);
             accumulatedText += delta.content;
             events.onToken(delta.content);
@@ -426,6 +435,9 @@ export class AgentLoop {
 
           // Thinking token
           if (delta.reasoning_content) {
+            if (thinkingPhaseStartedAt === null) {
+              thinkingPhaseStartedAt = Date.now();
+            }
             noteGeneratedChunk(delta.reasoning_content);
             accumulatedThinking += delta.reasoning_content;
             events.onThinking(delta.reasoning_content);
@@ -434,6 +446,7 @@ export class AgentLoop {
 
           // Tool call fragments
           if (delta.tool_calls) {
+            closeThinkingPhase();
             for (const tc of delta.tool_calls) {
               const idx = tc.index ?? 0;
               if (!partialToolCalls.has(idx)) {
@@ -457,6 +470,11 @@ export class AgentLoop {
 
         if (signal.aborted) break;
 
+        if (thinkingPhaseStartedAt !== null) {
+          thinkingDurationMs += Date.now() - thinkingPhaseStartedAt;
+          thinkingPhaseStartedAt = null;
+        }
+
         outputTokens += chunkOutputTokens;
 
         // ── Persist assistant message ───────────────────────────────────────
@@ -464,7 +482,14 @@ export class AgentLoop {
         const assistantMsg: Message = {
           role: "assistant",
           content: accumulatedText,
-          ...(accumulatedThinking ? { reasoning_content: accumulatedThinking } : {}),
+          ...(accumulatedThinking
+            ? {
+                reasoning_content: accumulatedThinking,
+                ...(thinkingDurationMs > 0
+                  ? { thinking_duration_ms: thinkingDurationMs }
+                  : {}),
+              }
+            : {}),
           timestamp: new Date().toISOString(),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls.map((tc) => ({
                 id: tc.id,
@@ -660,9 +685,10 @@ export class AgentLoop {
 
           const subagentModel = resolveSubagentModel(config, model);
           if (subagentThinkingEnabled === undefined) {
-            subagentThinkingEnabled =
-              config.showSubagentThinking &&
-              (await resolveSubagentThinkingEnabled(config, subagentModel));
+            subagentThinkingEnabled = await resolveSubagentThinkingEnabled(
+              config,
+              subagentModel
+            );
           }
           subagentModelResolved = subagentModel;
 
@@ -670,7 +696,8 @@ export class AgentLoop {
             maxConcurrent: MAX_CONCURRENT_SUBAGENTS,
             signal,
             model: subagentModelResolved,
-            subagentThinkingEnabled,
+            subagentReasoningCapable: subagentThinkingEnabled,
+            showSubagentThinkingDetail: config.showSubagentThinking,
             onTaskStatus: (id, status) => events.onSubagentTaskStatus?.(id, status),
           });
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -88,12 +88,6 @@ You have provider-neutral web tools when current information or exact URL conten
 Legacy Z.ai web, vision, and repository-reader integrations are unavailable. Use only the built-in web tools for external research.
 `;
 
-const WEB_RESEARCH_LITE = `
-## External Research Tools
-
-Use \`web_search\` for current source discovery and \`web_fetch\` for exact URLs.
-`;
-
 /**
  * Subagent delegation instructions for execution modes
  * 
@@ -417,25 +411,21 @@ This helps you understand where the conversation is heading.
   PLAN: `
 ## Mode: PLAN
 
-Planning and documentation mode. Focus on requirements, architecture, and implementation plans.
+Planning mode — research first, then write spec-driven plan artifacts. Latest plan revision is always current context.
 
-### PLAN Capabilities
+See injected "Active plan" block below for revision paths. Use \`plan_revision\` when the user reworks the plan.
 
-- Read-only exploration and research
-- Write planning artifacts in \`docs/\` and \`PRD.md\`
-- Delegate exploration with \`task\` using \`subagent_type: "explore"\`
-- Produce design docs, task breakdowns, and rollout plans
+### Capabilities
 
-### Use PLAN When
-
-- Scope spans multiple modules/systems
-- You need tradeoff analysis or architecture choices
-- Requirements are ambiguous and need clarification before coding
+- Research: \`web_search\`, \`web_fetch\`, \`file_read\`, \`glob\`, \`grep\`
+- Delegate: parallel \`task\` with \`subagent_type: "explore"\` (includes web tools)
+- Write: \`file_write\` / \`file_edit\` only in active revision (\`design.md\`, \`spec.md\`, \`tasks.md\`; \`PRD.md\` after TDD confirmed via \`question\`)
+- \`plan_revision\`, \`install_skill\`, \`question\`
 
 ### When to Suggest Mode Switches
 
-- Plan is approved and user wants implementation -> Suggest WORK
-- User asks for bug triage and reproduction -> Suggest DEBUG
+- Plan approved and user wants implementation -> Suggest AGENT
+- Bug triage -> Suggest DEBUG
 `,
   DEBUG: `
 ## Mode: DEBUG
@@ -495,7 +485,12 @@ When the user gave a clear multi-step task, call real tools in parallel on the f
  * @param cwd - The current working directory (optional, defaults to process.cwd())
  * @param config - Optional config object (if not provided, will be loaded)
  */
-export async function generateSystemPrompt(mode: Mode, cwd?: string, config?: Config): Promise<string> {
+export async function generateSystemPrompt(
+  mode: Mode,
+  cwd?: string,
+  config?: Config,
+  options?: { sessionId?: string }
+): Promise<string> {
   const workingDir = cwd || process.cwd();
   const cfg = config ?? await loadConfig();
 
@@ -566,11 +561,13 @@ Advisor output is ADVISORY — trust-but-verify against code and logs.`);
     parts.push(getPrompt("core", "subagent-delegation", SUBAGENT_DELEGATION));
   }
 
-  // Add web research instructions based on mode
-  if (mode === "AGENT" || mode === "DEBUG" || mode === "EXPLORE") {
+  if (mode === "AGENT" || mode === "DEBUG" || mode === "EXPLORE" || mode === "PLAN") {
     parts.push(getPrompt("core", "web-full", WEB_RESEARCH_FULL));
-  } else if (mode === "PLAN") {
-    parts.push(getPrompt("core", "web-lite", WEB_RESEARCH_LITE));
+  }
+
+  if (mode === "PLAN" && options?.sessionId) {
+    const { buildPlanModeContextBlock } = await import("../plan/revisions.js");
+    parts.push(buildPlanModeContextBlock(options.sessionId, workingDir));
   }
 
   const allowAllBlock = buildAllowAllBypassPromptBlock();
@@ -585,10 +582,8 @@ Advisor output is ADVISORY — trust-but-verify against code and logs.`);
  * Get just the web research instructions (for appending to existing prompts)
  */
 export function getResearchInstructions(mode: Mode): string {
-  if (mode === "AGENT" || mode === "DEBUG" || mode === "EXPLORE") {
+  if (mode === "AGENT" || mode === "DEBUG" || mode === "EXPLORE" || mode === "PLAN") {
     return getPrompt("core", "web-full", WEB_RESEARCH_FULL).trim();
-  } else if (mode === "PLAN") {
-    return getPrompt("core", "web-lite", WEB_RESEARCH_LITE).trim();
   }
   return "";
 }
@@ -603,17 +598,17 @@ export function getResearchInstructions(mode: Mode): string {
 /**
  * Explore subagent - read-only codebase exploration
  */
-const EXPLORE_AGENT_PROMPT = `You are an explore subagent for Impulse. Your job is to quickly search and analyze codebases.
+const EXPLORE_AGENT_PROMPT = `You are an explore subagent for Impulse. Your job is to quickly search and analyze codebases and external sources.
 
 IMPORTANT: Always respond in English regardless of the input language.
 
 You have access to READ-ONLY tools:
-- file_read: Read files
-- glob: Find files by pattern
-- grep: Search file contents
+- file_read, glob, grep
+- web_search, web_fetch
 
 Guidelines:
 - Be fast and focused - answer the specific question asked
+- Use web_search + web_fetch when current external information is needed
 - Return structured, actionable information
 - Include file paths and line numbers when relevant
 - Summarize findings concisely - the main agent will process your output
@@ -674,7 +669,7 @@ export function getSubagentPrompt(type: "explore" | "general"): string {
 export function getSubagentTools(type: "explore" | "general"): string[] {
   switch (type) {
     case "explore":
-      return ["file_read", "glob", "grep"];
+      return ["file_read", "glob", "grep", "web_search", "web_fetch"];
     case "general":
       return ["file_read", "file_write", "file_edit", "glob", "grep", "bash"];
     default:

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -83,7 +83,19 @@ You have provider-neutral web tools when current information or exact URL conten
 
 2. Use \`web_fetch\` to read exact URLs from search results or user-provided links.
 
-3. Do not guess web content. Search first unless the user supplied a URL.
+3. Do not guess web content. Search first unless the user supplied a URL or a resolvable same-repo GitHub issue (see below).
+
+### GitHub issues
+
+When the user mentions **issue #N** or **#N** without naming another repository:
+
+- Use the **Repository (git)** block in this prompt for owner/repo and the issue URL pattern.
+- **Do not** \`web_search\` for generic queries like "github issue N" — that returns the wrong repo.
+- If GitHub CLI is installed and authenticated, prefer \`github_issue\` with \`number: N\`.
+- If \`github_issue\` is unavailable, \`web_fetch\` the canonical issue URL from the Repository block.
+- If no repository is detected, use the \`question\` tool; the user can pick a suggested repo or **Type your own answer** with \`owner/repo\` or a full issue URL.
+
+When the user provides a full \`https://github.com/.../issues/N\` URL, use \`github_issue\` (with \`url\`) or \`web_fetch\` on that URL.
 
 Legacy Z.ai web, vision, and repository-reader integrations are unavailable. Use only the built-in web tools for external research.
 `;
@@ -512,9 +524,19 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
 - If you need to create a file, the path should be within ${workingDir}
 `;
 
+  const { resolveRepoContext, formatRepoContextPromptBlock } = await import(
+    "../git/repo-context.js"
+  );
+  const { probeGhCli, formatGhCliPromptBlock } = await import("../git/gh-cli.js");
+
+  const repoContext = resolveRepoContext(workingDir);
+  const ghStatus = probeGhCli();
+
   const parts: string[] = [
     getPrompt("core", "base", BASE_PROMPT),
     cwdContext,
+    formatRepoContextPromptBlock(repoContext),
+    formatGhCliPromptBlock(ghStatus),
   ];
 
   // Add user profile context if available

--- a/src/agent/task-pool.ts
+++ b/src/agent/task-pool.ts
@@ -43,8 +43,10 @@ export type TaskBatchRunOptions = {
   signal?: AbortSignal;
   /** Override stagger for tests; defaults to SUBAGENT_START_STAGGER_MS. */
   startStaggerMs?: number;
-  /** When false, sub-agents do not publish thinking... progress lines. */
-  subagentThinkingEnabled?: boolean;
+  /** When true, sub-agents may publish thinking progress (API reasoning enabled). */
+  subagentReasoningCapable?: boolean;
+  /** When true, use thinking...; when false, Thinking... placeholder (if capable). */
+  showSubagentThinkingDetail?: boolean;
   /** Provider/model for all subagents in this batch. */
   model?: string;
   onTaskStatus?: (toolCallId: string, status: "queued" | "running" | "done") => void;
@@ -131,7 +133,8 @@ export async function runTaskBatch(
         {
           parentToolCallId: spec.toolCallId,
           signal: options.signal,
-          subagentThinkingEnabled: options.subagentThinkingEnabled,
+          subagentReasoningCapable: options.subagentReasoningCapable,
+          showSubagentThinkingDetail: options.showSubagentThinkingDetail,
           model: options.model,
         }
       );

--- a/src/agent/task-runner.ts
+++ b/src/agent/task-runner.ts
@@ -7,13 +7,16 @@ import type { CompletionOptions } from "../api/provider";
 import { getSubagentPrompt, getSubagentTools } from "./prompts";
 import type { ToolDefinition } from "../api/types";
 import { Tool } from "../tools/registry";
+import { formatDurationMs } from "../cli/format-helpers.js";
 import {
   SUBAGENT_PROGRESS_THINKING,
+  SUBAGENT_PROGRESS_THINKING_PLACEHOLDER,
   SUBAGENT_PROGRESS_WRAPPING_UP,
 } from "../cli/subagent-progress-labels.js";
 import type { ChatMessage } from "../api/types";
 
-const MAX_ITERATIONS = 50;
+/** Subagent tool loop cap (each iteration = one model completion + tool batch). */
+export const SUBAGENT_MAX_ITERATIONS = 150;
 
 export type SubagentType = "explore" | "general";
 export type Thoroughness = "quick" | "medium" | "thorough";
@@ -83,7 +86,10 @@ export type SubagentRunResult = {
 export type ExecuteSubagentOptions = {
   parentToolCallId: string;
   signal?: AbortSignal;
-  subagentThinkingEnabled?: boolean;
+  /** API reasoning enabled for this subagent run. */
+  subagentReasoningCapable?: boolean;
+  /** When true, show thinking...; when false, Thinking... placeholder. */
+  showSubagentThinkingDetail?: boolean;
   model?: string;
 };
 
@@ -95,19 +101,20 @@ export type SubagentPreCompleteProgress = {
 /** Resolve progress line to show before the next sub-agent completion call. */
 export function resolvePreCompleteProgress(
   messages: ChatMessage[],
-  subagentThinkingEnabled: boolean
+  reasoningCapable: boolean,
+  showDetail: boolean
 ): SubagentPreCompleteProgress | null {
+  if (!reasoningCapable) return null;
+
+  const content = showDetail
+    ? SUBAGENT_PROGRESS_THINKING
+    : SUBAGENT_PROGRESS_THINKING_PLACEHOLDER;
+
   const last = messages[messages.length - 1];
   if (last?.role === "tool") {
-    if (subagentThinkingEnabled) {
-      return { type: "thinking", content: SUBAGENT_PROGRESS_THINKING };
-    }
-    return null;
+    return { type: "thinking", content };
   }
-  if (subagentThinkingEnabled) {
-    return { type: "thinking", content: SUBAGENT_PROGRESS_THINKING };
-  }
-  return null;
+  return { type: "thinking", content };
 }
 
 /** True when the sub-agent should publish a final wrapping-up line after complete(). */
@@ -163,9 +170,10 @@ export async function executeSubagent(
     });
   };
 
-  const thinkingEnabled = options.subagentThinkingEnabled ?? false;
+  const reasoningCapable = options.subagentReasoningCapable ?? false;
+  const showDetail = options.showSubagentThinkingDetail ?? true;
 
-  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+  for (let iteration = 0; iteration < SUBAGENT_MAX_ITERATIONS; iteration++) {
     if (signal?.aborted) {
       return {
         success: false,
@@ -175,7 +183,9 @@ export async function executeSubagent(
       };
     }
 
-    const preComplete = resolvePreCompleteProgress(messages, thinkingEnabled);
+    const inferenceStart = Date.now();
+    const preComplete = resolvePreCompleteProgress(messages, reasoningCapable, showDetail);
+    const publishedThinking = preComplete?.type === "thinking";
     if (preComplete) {
       publish({ type: preComplete.type, content: preComplete.content });
     }
@@ -191,6 +201,14 @@ export async function executeSubagent(
     }
 
     const response = await manager.complete(completionOptions);
+
+    if (publishedThinking) {
+      publish({
+        type: "status",
+        content: `Thought for ${formatDurationMs(Date.now() - inferenceStart)}`,
+      });
+    }
+
     const choice = response.choices[0];
     if (!choice) {
       return {
@@ -293,7 +311,7 @@ export async function executeSubagent(
 
   return {
     success: false,
-    output: "Subagent reached maximum iterations without completing",
+    output: `Subagent reached maximum iterations (${SUBAGENT_MAX_ITERATIONS}) without completing`,
     summary: actionSummary,
     actions: actionEntries,
   };

--- a/src/cli/components/settings-overlay.ts
+++ b/src/cli/components/settings-overlay.ts
@@ -20,6 +20,16 @@ export interface SettingsValues {
   subagentModel?: string;
 }
 
+/** True when overlay values match what was loaded at open (no toggle edits). */
+export function settingsValuesEqual(a: SettingsValues, b: SettingsValues): boolean {
+  return (
+    a.showMainThinking === b.showMainThinking &&
+    a.showSubagentThinking === b.showSubagentThinking &&
+    a.useSubagentModel === b.useSubagentModel &&
+    (a.subagentModel?.trim() ?? "") === (b.subagentModel?.trim() ?? "")
+  );
+}
+
 export interface SettingsOverlayOptions {
   values: SettingsValues;
 }
@@ -63,12 +73,12 @@ export class SettingsOverlay implements Component {
     {
       key: "showMainThinking",
       label: "Show thinking in main agent",
-      hint: "True: stream reasoning; False: Thinking... only (still in context)",
+      hint: "True: stream reasoning, then Thought for…; False: Thinking… then Thought for…",
     },
     {
       key: "showSubagentThinking",
       label: "Show thinking in subagent",
-      hint: "True: thinking... lines inside task tool rows",
+      hint: "True: thinking… under tasks; False: Thinking… then Thought for…",
     },
     {
       key: "useSubagentModel",

--- a/src/cli/components/thinking-block.ts
+++ b/src/cli/components/thinking-block.ts
@@ -83,9 +83,8 @@ export class ThinkingBlock implements Component {
 
   render(width: number): string[] {
     if (this.phase === "finalized" && !this.expanded) {
-      const marker = "▶";
       const summary = formatThoughtSummary(this.durationMs);
-      const line = `${GUTTER}${THINKING_COLOR}${marker} ${summary}${RESET}`;
+      const line = `${GUTTER}${THINKING_COLOR}${summary}${RESET}`;
       return [truncateGutterLine(line, width)];
     }
 

--- a/src/cli/components/thinking-block.ts
+++ b/src/cli/components/thinking-block.ts
@@ -1,0 +1,149 @@
+import { wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
+import { formatDurationMs } from "../format-helpers.js";
+import { GUTTER, innerWidth, truncateGutterLine } from "../gutter.js";
+import { formatThinkingBodyPart } from "../thinking-style.js";
+
+const THINKING_BLOCK_TAG = Symbol("thinkingBlock");
+
+const MAX_THINKING_DISPLAY_CHARS = 8000;
+const MAX_THINKING_DISPLAY_LINES = 40;
+
+const THINKING_COLOR = "\x1b[38;5;94m";
+const RESET = "\x1b[0m";
+const DIM = "\x1b[2m\x1b[38;5;90m";
+
+export function formatThoughtSummary(durationMs?: number): string {
+  if (durationMs !== undefined && durationMs > 0) {
+    return `Thought for ${formatDurationMs(durationMs)}`;
+  }
+  return "Thought";
+}
+
+export class ThinkingBlock implements Component {
+  readonly [THINKING_BLOCK_TAG] = true;
+
+  private phase: "streaming" | "finalized" = "streaming";
+  private streamingMode: "body" | "placeholder" = "body";
+  private expanded = false;
+  private raw = "";
+  private truncateDisplay = false;
+  private hiddenCharCount = 0;
+  private durationMs: number | undefined;
+
+  /** Hide streamed body in the UI but keep accumulating content for finalize /show-think. */
+  setPlaceholder(): void {
+    this.phase = "streaming";
+    this.streamingMode = "placeholder";
+  }
+
+  /** Append reasoning tokens without clearing prior content (placeholder or body). */
+  appendContent(chunk: string): void {
+    if (!chunk) return;
+    this.phase = "streaming";
+    const combined = this.raw + chunk;
+    this.applyRawText(combined);
+  }
+
+  setTruncateDisplay(enabled: boolean): void {
+    this.truncateDisplay = enabled;
+  }
+
+  setText(text: string): void {
+    this.phase = "streaming";
+    this.streamingMode = "body";
+    this.applyRawText(text);
+  }
+
+  private applyRawText(text: string): void {
+    if (this.truncateDisplay && text.length > MAX_THINKING_DISPLAY_CHARS) {
+      this.hiddenCharCount = text.length - MAX_THINKING_DISPLAY_CHARS;
+      this.raw = text.slice(0, MAX_THINKING_DISPLAY_CHARS);
+    } else {
+      this.hiddenCharCount = 0;
+      this.raw = text;
+    }
+  }
+
+  finalize(durationMs: number): void {
+    this.phase = "finalized";
+    this.durationMs = durationMs > 0 ? durationMs : undefined;
+    this.expanded = false;
+  }
+
+  setExpanded(expanded: boolean): void {
+    if (this.phase !== "finalized") return;
+    this.expanded = expanded;
+  }
+
+  isFinalized(): boolean {
+    return this.phase === "finalized";
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    if (this.phase === "finalized" && !this.expanded) {
+      const marker = "▶";
+      const summary = formatThoughtSummary(this.durationMs);
+      const line = `${GUTTER}${THINKING_COLOR}${marker} ${summary}${RESET}`;
+      return [truncateGutterLine(line, width)];
+    }
+
+    if (this.phase === "streaming" && this.streamingMode === "placeholder") {
+      const line = `${GUTTER}${THINKING_COLOR}Thinking...${RESET}`;
+      return [truncateGutterLine(line, width)];
+    }
+
+    const prefix = GUTTER;
+    const label = this.phase === "finalized" ? "▼ Thinking:" : "Thinking:";
+    const firstPrefix = `${prefix}${THINKING_COLOR}${label}${RESET} `;
+    const continuationPrefix = " ".repeat(prefix.length + label.length + 1);
+    const textWidth = Math.max(8, innerWidth(width) - label.length - 1);
+    const lines: string[] = [];
+    let isFirstOutputLine = true;
+
+    for (const paragraph of this.raw.replace(/\r\n/g, "\n").split("\n")) {
+      if (paragraph.length === 0) {
+        lines.push(continuationPrefix);
+        isFirstOutputLine = false;
+        continue;
+      }
+
+      const available = isFirstOutputLine ? textWidth : textWidth;
+      const wrapped = wrapTextWithAnsi(paragraph, available);
+
+      for (const part of wrapped) {
+        const linePrefix = isFirstOutputLine ? firstPrefix : continuationPrefix;
+        lines.push(
+          truncateGutterLine(`${linePrefix}${formatThinkingBodyPart(part)}`, width)
+        );
+        isFirstOutputLine = false;
+      }
+    }
+
+    if (this.truncateDisplay && lines.length > MAX_THINKING_DISPLAY_LINES) {
+      const omitted = lines.length - MAX_THINKING_DISPLAY_LINES;
+      lines.length = MAX_THINKING_DISPLAY_LINES;
+      const foot = `${continuationPrefix}${DIM}… ${omitted} more lines hidden (/settings)${RESET}`;
+      lines.push(truncateGutterLine(foot, width));
+    } else if (this.hiddenCharCount > 0) {
+      const foot = `${continuationPrefix}${DIM}… ${this.hiddenCharCount} more characters hidden (/settings)${RESET}`;
+      lines.push(truncateGutterLine(foot, width));
+    }
+
+    if (lines.length > 0) {
+      return lines;
+    }
+
+    if (this.phase === "finalized" && this.expanded) {
+      const empty = `${continuationPrefix}${DIM}(reasoning was hidden in /settings — no text stored)${RESET}`;
+      return [truncateGutterLine(firstPrefix, width), truncateGutterLine(empty, width)];
+    }
+
+    return [truncateGutterLine(firstPrefix, width)];
+  }
+}
+
+export function isThinkingBlock(component: Component): component is ThinkingBlock {
+  return (component as ThinkingBlock)[THINKING_BLOCK_TAG] === true;
+}

--- a/src/cli/components/thinking-block.ts
+++ b/src/cli/components/thinking-block.ts
@@ -94,7 +94,7 @@ export class ThinkingBlock implements Component {
     }
 
     const prefix = GUTTER;
-    const label = this.phase === "finalized" ? "▼ Thinking:" : "Thinking:";
+    const label = "Thinking:";
     const firstPrefix = `${prefix}${THINKING_COLOR}${label}${RESET} `;
     const continuationPrefix = " ".repeat(prefix.length + label.length + 1);
     const textWidth = Math.max(8, innerWidth(width) - label.length - 1);

--- a/src/cli/components/tool-block.ts
+++ b/src/cli/components/tool-block.ts
@@ -658,6 +658,16 @@ export class ToolBlock implements Component {
   }
 
   appendSubagentLine(line: SubagentProgressLine): void {
+    const last = this.subagentLines[this.subagentLines.length - 1];
+    if (
+      line.type === "status" &&
+      line.content.startsWith("Thought for") &&
+      last?.type === "thinking"
+    ) {
+      this.subagentLines[this.subagentLines.length - 1] = line;
+      return;
+    }
+
     this.subagentLines.push(line);
     if (this.subagentLines.length > 10) {
       this.subagentLines = this.subagentLines.slice(-10);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -33,9 +33,10 @@ import {
 } from "./prompt-input.js";
 import { shouldTreatAsSlashCommand } from "./image-paths.js";
 import {
-  completeSlashCommand,
+  completeSlashCommandTab,
   isSlashCommandInput,
   shouldShowSlashAutocomplete,
+  type SlashCompleteCycle,
 } from "./slash-autocomplete.js";
 import { buildSlashCommandList } from "./slash-commands.js";
 import { WelcomeHintBlock } from "./components/welcome-hint-block.js";
@@ -104,7 +105,11 @@ import { SelectableListOverlay } from "./components/selectable-list-overlay.js";
 import { PlanApprovalOverlay } from "./components/plan-approval-overlay.js";
 import { AllowAllDisclaimerOverlay } from "./components/allow-all-disclaimer-overlay.js";
 import { ExperimentalOverlay } from "./components/experimental-overlay.js";
-import { SettingsOverlay } from "./components/settings-overlay.js";
+import {
+  SettingsOverlay,
+  settingsValuesEqual,
+  type SettingsValues,
+} from "./components/settings-overlay.js";
 import { HelpOverlay } from "./components/help-overlay.js";
 import { SideOverlay } from "./components/side-overlay.js";
 import {
@@ -117,7 +122,7 @@ import type { SideExchange } from "../session/store.js";
 import crypto from "crypto";
 import { SHIMMER_FRAME_MS, shimmerText } from "./shimmer-text.js";
 import { pickUniqueShipName } from "./starfleet-ship-names.js";
-import { formatThinkingBodyPart } from "./thinking-style.js";
+import { ThinkingBlock, isThinkingBlock } from "./components/thinking-block.js";
 import { filterThinkingForDisplay } from "../util/thinking-filter.js";
 import { buildReplaySteps, type ReplayStep } from "./session-replay.js";
 import type { Session } from "../session/store.js";
@@ -260,89 +265,6 @@ class SeparatorLine implements Component {
   render(width: number): string[] {
     return [A.dim + gutterSeparator(width) + A.reset];
   }
-}
-
-const MAX_THINKING_DISPLAY_CHARS = 8000;
-const MAX_THINKING_DISPLAY_LINES = 40;
-
-class ThinkingBlock implements Component {
-  private raw = "";
-  private placeholder = false;
-  private truncateDisplay = false;
-  private hiddenCharCount = 0;
-
-  setPlaceholder(): void {
-    this.placeholder = true;
-    this.raw = "";
-    this.truncateDisplay = false;
-    this.hiddenCharCount = 0;
-  }
-
-  setTruncateDisplay(enabled: boolean): void {
-    this.truncateDisplay = enabled;
-  }
-
-  setText(text: string): void {
-    this.placeholder = false;
-    this.raw = text;
-    if (this.truncateDisplay && text.length > MAX_THINKING_DISPLAY_CHARS) {
-      this.hiddenCharCount = text.length - MAX_THINKING_DISPLAY_CHARS;
-      this.raw = text.slice(0, MAX_THINKING_DISPLAY_CHARS);
-    } else {
-      this.hiddenCharCount = 0;
-    }
-  }
-
-  render(width: number): string[] {
-    if (this.placeholder) {
-      const prefix = GUTTER;
-      const line = `${prefix}\x1b[38;5;94mThinking...${A.reset}`;
-      return [truncateGutterLine(line, width)];
-    }
-
-    const prefix = GUTTER;
-    const label = "Thinking:";
-    const firstPrefix = `${prefix}\x1b[38;5;94m${label}\x1b[0m `;
-    const continuationPrefix = " ".repeat(prefix.length + label.length + 1);
-    const textWidth = Math.max(8, innerWidth(width) - label.length - 1);
-    const firstWidth = textWidth;
-    const continuationWidth = textWidth;
-    const lines: string[] = [];
-    let isFirstOutputLine = true;
-
-    for (const paragraph of this.raw.replace(/\r\n/g, "\n").split("\n")) {
-      if (paragraph.length === 0) {
-        lines.push(continuationPrefix);
-        isFirstOutputLine = false;
-        continue;
-      }
-
-      const available = isFirstOutputLine ? firstWidth : continuationWidth;
-      const wrapped = wrapTextWithAnsi(paragraph, available);
-
-      for (const part of wrapped) {
-        const linePrefix = isFirstOutputLine ? firstPrefix : continuationPrefix;
-        lines.push(
-          truncateGutterLine(`${linePrefix}${formatThinkingBodyPart(part)}`, width)
-        );
-        isFirstOutputLine = false;
-      }
-    }
-
-    if (this.truncateDisplay && lines.length > MAX_THINKING_DISPLAY_LINES) {
-      const omitted = lines.length - MAX_THINKING_DISPLAY_LINES;
-      lines.length = MAX_THINKING_DISPLAY_LINES;
-      const foot = `${continuationPrefix}${A.dim}… ${omitted} more lines hidden (/settings)${A.reset}`;
-      lines.push(truncateGutterLine(foot, width));
-    } else if (this.hiddenCharCount > 0) {
-      const foot = `${continuationPrefix}${A.dim}… ${this.hiddenCharCount} more characters hidden (/settings)${A.reset}`;
-      lines.push(truncateGutterLine(foot, width));
-    }
-
-    return lines.length > 0 ? lines : [truncateGutterLine(firstPrefix, width)];
-  }
-
-  invalidate() {}
 }
 
 type ModelSetupStep =
@@ -1203,6 +1125,9 @@ export class ImpulseRenderer {
   private thinkingText: ThinkingBlock | null = null;
   private thinkingRaw = "";
   private thinkingOpen = false;
+  private thinkingStartedAt = 0;
+  /** Session-local: keep new thinking blocks expanded until /hide-think. */
+  private thinkingDetailExpanded = false;
   private hasTrailingGap = false;
   private toolBlocks = new Map<string, ToolBlock>();
   private taskCodenames = new Map<string, string>();
@@ -1254,6 +1179,7 @@ export class ImpulseRenderer {
   private responsePreference = "concise";
   /** Session-local turn speed display on context bar (/speedo); not persisted. */
   private speedoEnabled = false;
+  private slashTabCycle: SlashCompleteCycle | null = null;
   private userName = "you"; // User's display name (loaded from config)
   private modeChangeText: Text | null = null; // Track mode change line for in-place updates
 
@@ -1434,10 +1360,15 @@ export class ImpulseRenderer {
       if (this.modelSetup) return;
       const val = this.promptInput.getText();
       if (isSlashCommandInput(val)) {
-        const completed = completeSlashCommand(val, this.slashCommands());
-        if (completed !== null) {
-          this.promptInput.setText(completed);
-          this.updateAutocomplete(completed);
+        const { text, nextCycle } = completeSlashCommandTab(
+          val,
+          this.slashCommands(),
+          this.slashTabCycle
+        );
+        this.slashTabCycle = nextCycle;
+        if (text !== null) {
+          this.promptInput.setText(text);
+          this.updateAutocomplete(text);
           this.tui.requestRender();
         }
         return;
@@ -1521,7 +1452,10 @@ export class ImpulseRenderer {
         this.abortCurrentTurn();
       }
     };
-    this.promptInput.onChange = (val) => this.updateAutocomplete(val);
+    this.promptInput.onChange = (val) => {
+      this.resetSlashTabCycleIfNeeded(val);
+      this.updateAutocomplete(val);
+    };
     this.tui.addChild(this.promptInput);
 
     // 5. Separator BELOW input
@@ -2054,6 +1988,7 @@ export class ImpulseRenderer {
     this.thinkingRaw = "";
     this.thinkingText = null;
     this.thinkingOpen = false;
+    this.thinkingStartedAt = 0;
     this.resetLiveMetrics();
     this.loop.setImages(
       payload.orderedImages.map((i) => ({ uri: i.uri, display: i.display }))
@@ -2387,6 +2322,14 @@ export class ImpulseRenderer {
     });
   }
 
+  private resetSlashTabCycleIfNeeded(input: string): void {
+    if (!this.slashTabCycle) return;
+    const token = input.trimStart().split(/\s+/)[0]?.toLowerCase() ?? "";
+    if (!token.startsWith(this.slashTabCycle.prefix)) {
+      this.slashTabCycle = null;
+    }
+  }
+
   private updateAutocomplete(val: string): void {
     if (this.modelSetup) {
       this.autocompleteText.setText("");
@@ -2432,10 +2375,60 @@ export class ImpulseRenderer {
 
   private closeThinking(): void {
     if (this.thinkingOpen && this.thinkingText) {
-      debugLog(`Thinking block closed`);
+      const durationMs =
+        this.thinkingStartedAt > 0 ? Date.now() - this.thinkingStartedAt : 0;
+      if (this.thinkingRaw.trim()) {
+        this.thinkingText.setText(this.thinkingRaw);
+      }
+      this.thinkingText.finalize(durationMs);
+      if (this.thinkingDetailExpanded) {
+        this.thinkingText.setExpanded(true);
+      }
+      debugLog(`Thinking block closed (${durationMs}ms)`);
       this.addSectionGap();
       this.thinkingOpen = false;
+      this.thinkingStartedAt = 0;
     }
+  }
+
+  private forEachThinkingBlock(fn: (block: ThinkingBlock) => void): void {
+    const children = (this.chat as Container & { children: Component[] }).children;
+    for (const child of children) {
+      if (isThinkingBlock(child)) {
+        fn(child);
+      }
+    }
+  }
+
+  private cmdShowThink(): void {
+    this.thinkingDetailExpanded = true;
+    let expanded = 0;
+    this.forEachThinkingBlock((block) => {
+      if (block.isFinalized()) {
+        block.setExpanded(true);
+        expanded += 1;
+      }
+    });
+    if (expanded === 0) {
+      this.addChatLine(
+        clr.dim("No collapsed thinking blocks in this chat (turns may not have streamed reasoning).")
+      );
+      this.tui.requestRender();
+      return;
+    }
+    this.addChatLine(statusOk("Thinking blocks expanded — /hide-think to collapse"));
+    this.tui.requestRender();
+  }
+
+  private cmdHideThink(): void {
+    this.thinkingDetailExpanded = false;
+    this.forEachThinkingBlock((block) => {
+      if (block.isFinalized()) {
+        block.setExpanded(false);
+      }
+    });
+    this.addChatLine(statusOk("Thinking blocks collapsed"));
+    this.tui.requestRender();
   }
 
 
@@ -2557,6 +2550,12 @@ export class ImpulseRenderer {
         break;
       case "side":
         await this.cmdSide(arg);
+        break;
+      case "show-think":
+        this.cmdShowThink();
+        break;
+      case "hide-think":
+        this.cmdHideThink();
         break;
       case "quit":
       case "exit":
@@ -3088,6 +3087,21 @@ export class ImpulseRenderer {
   private syncDisplaySettingsFromConfig(config: Config): void {
     this.showMainThinking = config.showMainThinking;
     this.responsePreference = config.userProfile?.responsePreference?.trim() || "concise";
+    this.applyThinkingDisplayMode();
+  }
+
+  /** Sync in-flight thinking block UI with showMainThinking (e.g. after /settings). */
+  private applyThinkingDisplayMode(): void {
+    if (!this.thinkingOpen || !this.thinkingText) return;
+
+    if (this.showMainThinking) {
+      if (this.thinkingRaw.trim()) {
+        this.thinkingText.setText(this.thinkingRaw);
+      }
+      this.thinkingText.setTruncateDisplay(this.thinkingTruncateDisplay());
+    } else {
+      this.thinkingText.setPlaceholder();
+    }
   }
 
   private thinkingTruncateDisplay(): boolean {
@@ -3107,15 +3121,17 @@ export class ImpulseRenderer {
       this.chat.addChild(this.thinkingText);
       this.hasTrailingGap = false;
       this.thinkingOpen = true;
+      this.thinkingStartedAt = Date.now();
     }
-    this.thinkingRaw += filterThinkingForDisplay(text);
+    const filtered = filterThinkingForDisplay(text);
+    this.thinkingRaw += filtered;
+    this.thinkingText.appendContent(filtered);
     if (!this.showMainThinking) {
       this.thinkingText.setPlaceholder();
-      this.noteLiveGeneration(text);
-      return;
+    } else {
+      this.thinkingText.setTruncateDisplay(this.thinkingTruncateDisplay());
+      this.thinkingText.setText(this.thinkingRaw);
     }
-    this.thinkingText.setTruncateDisplay(this.thinkingTruncateDisplay());
-    this.thinkingText.setText(this.thinkingRaw);
     this.noteLiveGeneration(text);
   }
 
@@ -3594,14 +3610,31 @@ export class ImpulseRenderer {
     if (this.isRunning || !this.tui) return;
     const config = await loadConfig();
 
-    const overlay = new SettingsOverlay({
-      values: {
-        showMainThinking: config.showMainThinking,
-        showSubagentThinking: config.showSubagentThinking,
-        useSubagentModel: config.useSubagentModel,
-        subagentModel: config.subagentModel,
-      },
-    });
+    const initialValues: SettingsValues = {
+      showMainThinking: config.showMainThinking,
+      showSubagentThinking: config.showSubagentThinking,
+      useSubagentModel: config.useSubagentModel,
+      subagentModel: config.subagentModel,
+    };
+
+    const overlay = new SettingsOverlay({ values: initialValues });
+
+    const applySettingsValues = async (
+      values: SettingsValues
+    ): Promise<"saved" | "unchanged"> => {
+      if (settingsValuesEqual(values, initialValues)) {
+        return "unchanged";
+      }
+      config.showMainThinking = values.showMainThinking;
+      config.showSubagentThinking = values.showSubagentThinking;
+      config.useSubagentModel = values.useSubagentModel;
+      if (values.subagentModel !== undefined) {
+        config.subagentModel = values.subagentModel;
+      }
+      await saveConfig(config);
+      this.syncDisplaySettingsFromConfig(config);
+      return "saved";
+    };
 
     await new Promise<void>((resolve) => {
       const handle = this.showContentSizedOverlay(overlay, { maxHeight: 20 });
@@ -3623,16 +3656,7 @@ export class ImpulseRenderer {
 
       const openSubagentPicker = () => {
         void (async () => {
-          // Save current values before dismissing overlay
-          const currentValues = overlay.getValues();
-          config.showMainThinking = currentValues.showMainThinking;
-          config.showSubagentThinking = currentValues.showSubagentThinking;
-          config.useSubagentModel = currentValues.useSubagentModel;
-          if (currentValues.subagentModel !== undefined) {
-            config.subagentModel = currentValues.subagentModel;
-          }
-          await saveConfig(config);
-          this.syncDisplaySettingsFromConfig(config);
+          await applySettingsValues(overlay.getValues());
 
           this.dismissSettingsOverlay();
           if (countConfiguredProviders(await loadConfig()) === 0) {
@@ -3660,15 +3684,12 @@ export class ImpulseRenderer {
 
       overlay.onSubmit = (values) => {
         void (async () => {
-          config.showMainThinking = values.showMainThinking;
-          config.showSubagentThinking = values.showSubagentThinking;
-          config.useSubagentModel = values.useSubagentModel;
-          if (values.subagentModel !== undefined) {
-            config.subagentModel = values.subagentModel;
-          }
-          await saveConfig(config);
-          this.syncDisplaySettingsFromConfig(config);
-          this.addChatLine(statusOk("Settings saved"));
+          const result = await applySettingsValues(values);
+          this.addChatLine(
+            result === "saved"
+              ? statusOk("Settings saved")
+              : clr.dim("Settings unchanged")
+          );
           finish();
         })();
       };
@@ -4041,6 +4062,7 @@ export class ImpulseRenderer {
     this.thinkingRaw = "";
     this.thinkingText = null;
     this.thinkingOpen = false;
+    this.thinkingStartedAt = 0;
   }
 
   private syncAdvisorFromConfig(config: Config): void {
@@ -4427,11 +4449,11 @@ export class ImpulseRenderer {
         if (!filtered.trim()) break;
         this.addSectionGap();
         const block = new ThinkingBlock();
-        if (!this.showMainThinking) {
-          block.setPlaceholder();
-        } else {
-          block.setTruncateDisplay(this.thinkingTruncateDisplay());
-          block.setText(filtered);
+        block.setTruncateDisplay(this.thinkingTruncateDisplay());
+        block.setText(filtered);
+        block.finalize(step.durationMs ?? 0);
+        if (this.thinkingDetailExpanded) {
+          block.setExpanded(true);
         }
         this.chat.addChild(block);
         this.hasTrailingGap = false;

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -1126,6 +1126,8 @@ export class ImpulseRenderer {
   private thinkingRaw = "";
   private thinkingOpen = false;
   private thinkingStartedAt = 0;
+  /** Cumulative reasoning time this assistant stream (mirrors loop thinkingDurationMs). */
+  private thinkingElapsedMs = 0;
   /** Session-local: keep new thinking blocks expanded until /hide-think. */
   private thinkingDetailExpanded = false;
   private hasTrailingGap = false;
@@ -1989,6 +1991,7 @@ export class ImpulseRenderer {
     this.thinkingText = null;
     this.thinkingOpen = false;
     this.thinkingStartedAt = 0;
+    this.thinkingElapsedMs = 0;
     this.resetLiveMetrics();
     this.loop.setImages(
       payload.orderedImages.map((i) => ({ uri: i.uri, display: i.display }))
@@ -2089,6 +2092,7 @@ export class ImpulseRenderer {
         // Skip rendering for silent tools (e.g., set_header)
         if (ImpulseRenderer.SILENT_TOOLS.has(_name)) return;
 
+        this.thinkingElapsedMs = 0;
         this.toolsRanThisTurn = true;
 
         this.taskCodenames.delete(id);
@@ -2141,6 +2145,7 @@ export class ImpulseRenderer {
         if (this.streamingRaw) { this.addSectionGap(); }
         this.streamingRaw = ""; this.streamingText = null;
         this.thinkingRaw = "";  this.thinkingText = null;
+        this.thinkingElapsedMs = 0;
 
         this.contextTokens = usage.inputTokens;
         this.contextBar.update({
@@ -2375,8 +2380,11 @@ export class ImpulseRenderer {
 
   private closeThinking(): void {
     if (this.thinkingOpen && this.thinkingText) {
-      const durationMs =
-        this.thinkingStartedAt > 0 ? Date.now() - this.thinkingStartedAt : 0;
+      if (this.thinkingStartedAt > 0) {
+        this.thinkingElapsedMs += Date.now() - this.thinkingStartedAt;
+        this.thinkingStartedAt = 0;
+      }
+      const durationMs = this.thinkingElapsedMs;
       if (this.thinkingRaw.trim()) {
         this.thinkingText.setText(this.thinkingRaw);
       }
@@ -2387,7 +2395,6 @@ export class ImpulseRenderer {
       debugLog(`Thinking block closed (${durationMs}ms)`);
       this.addSectionGap();
       this.thinkingOpen = false;
-      this.thinkingStartedAt = 0;
     }
   }
 
@@ -4063,6 +4070,7 @@ export class ImpulseRenderer {
     this.thinkingText = null;
     this.thinkingOpen = false;
     this.thinkingStartedAt = 0;
+    this.thinkingElapsedMs = 0;
   }
 
   private syncAdvisorFromConfig(config: Config): void {

--- a/src/cli/session-replay.ts
+++ b/src/cli/session-replay.ts
@@ -15,7 +15,7 @@ export type ReplayToolResult = {
 
 export type ReplayStep =
   | { type: "user"; text: string }
-  | { type: "thinking"; text: string }
+  | { type: "thinking"; text: string; durationMs?: number }
   | { type: "assistantText"; text: string }
   | {
       type: "tool";
@@ -143,7 +143,11 @@ function appendBlockStep(
     return;
   }
   if (block.type === "thinking" && block.thinking.trim()) {
-    steps.push({ type: "thinking", text: block.thinking });
+    steps.push({
+      type: "thinking",
+      text: block.thinking,
+      ...(block.durationMs !== undefined ? { durationMs: block.durationMs } : {}),
+    });
     return;
   }
   if (block.type === "tool_call") {
@@ -160,7 +164,13 @@ function replayAssistantLinear(
   steps: ReplayStep[]
 ): void {
   if (msg.reasoning_content?.trim()) {
-    steps.push({ type: "thinking", text: msg.reasoning_content });
+    steps.push({
+      type: "thinking",
+      text: msg.reasoning_content,
+      ...(msg.thinking_duration_ms !== undefined
+        ? { durationMs: msg.thinking_duration_ms }
+        : {}),
+    });
   }
   if (msg.content?.trim()) {
     steps.push({ type: "assistantText", text: msg.content });

--- a/src/cli/slash-autocomplete.ts
+++ b/src/cli/slash-autocomplete.ts
@@ -34,6 +34,12 @@ export function shouldShowSlashAutocomplete(
     return { show: false, matches: [] };
   }
 
+  // e.g. token /show → still list /show-think even though /show is an exact match
+  const extensions = matches.filter((c) => c.cmd.toLowerCase().length > token.length);
+  if (extensions.length > 0) {
+    return { show: true, matches: extensions };
+  }
+
   const hasExactMatch = matches.some((c) => c.cmd.toLowerCase() === token);
   if (hasExactMatch) {
     return { show: false, matches };
@@ -47,25 +53,103 @@ export function isSlashCommandInput(input: string): boolean {
   return input.trimStart().startsWith("/");
 }
 
+/** Cycle state for Tab through ambiguous slash commands (e.g. /show vs /show-think). */
+export type SlashCompleteCycle = { prefix: string; index: number };
+
+function replaceSlashToken(input: string, newToken: string): string {
+  const leading = input.match(/^\s*/)?.[0] ?? "";
+  const rest = input.slice(leading.length);
+  const token = rest.split(/\s+/)[0] ?? "";
+  const afterToken = rest.slice(token.length);
+  return `${leading}${newToken}${afterToken}`;
+}
+
+function prefixMatchesForToken(
+  commands: SlashCommandEntry[],
+  token: string
+): SlashCommandEntry[] {
+  return commands
+    .filter((c) => c.cmd.toLowerCase().startsWith(token))
+    .sort((a, b) => a.cmd.localeCompare(b.cmd));
+}
+
+function longestCommonPrefix(strings: string[]): string {
+  if (strings.length === 0) return "";
+  let prefix = strings[0]!.toLowerCase();
+  for (const s of strings.slice(1)) {
+    const lower = s.toLowerCase();
+    while (prefix.length > 0 && !lower.startsWith(prefix)) {
+      prefix = prefix.slice(0, -1);
+    }
+  }
+  const first = strings[0]!;
+  return first.slice(0, prefix.length);
+}
+
 /**
- * Complete the first slash token when exactly one command matches the prefix.
- * Returns null when there are zero or multiple matches, or the token is already complete.
+ * Tab-complete the slash token: unique match, shared prefix extension, or cycle ambiguities.
+ */
+export function completeSlashCommandTab(
+  input: string,
+  commands: SlashCommandEntry[],
+  cycle: SlashCompleteCycle | null
+): { text: string | null; nextCycle: SlashCompleteCycle | null } {
+  const token = slashCommandToken(input);
+  if (token === null) return { text: null, nextCycle: null };
+
+  const tokenLower = token.toLowerCase();
+
+  if (cycle && tokenLower.startsWith(cycle.prefix)) {
+    const cycleMatches = prefixMatchesForToken(commands, cycle.prefix);
+    if (cycleMatches.length > 1) {
+      const nextIndex = (cycle.index + 1) % cycleMatches.length;
+      const chosen = cycleMatches[nextIndex]!.cmd;
+      if (chosen.toLowerCase() !== tokenLower) {
+        return {
+          text: replaceSlashToken(input, chosen),
+          nextCycle: { prefix: cycle.prefix, index: nextIndex },
+        };
+      }
+    }
+  }
+
+  const matches = prefixMatchesForToken(commands, token);
+  if (matches.length === 0) return { text: null, nextCycle: null };
+
+  if (matches.length === 1) {
+    const full = matches[0]!.cmd;
+    if (full.toLowerCase() === token) return { text: null, nextCycle: null };
+    return { text: replaceSlashToken(input, full), nextCycle: null };
+  }
+
+  const lcp = longestCommonPrefix(matches.map((m) => m.cmd));
+  if (lcp.length > token.length) {
+    return { text: replaceSlashToken(input, lcp), nextCycle: null };
+  }
+
+  let nextIndex = 0;
+  const exactIndex = matches.findIndex((m) => m.cmd.toLowerCase() === tokenLower);
+  if (exactIndex >= 0) {
+    nextIndex = (exactIndex + 1) % matches.length;
+  }
+
+  const chosen = matches[nextIndex]!.cmd;
+  if (chosen.toLowerCase() === tokenLower) {
+    return { text: null, nextCycle: null };
+  }
+
+  return {
+    text: replaceSlashToken(input, chosen),
+    nextCycle: { prefix: tokenLower, index: nextIndex },
+  };
+}
+
+/**
+ * Complete when exactly one command matches (legacy helper).
  */
 export function completeSlashCommand(
   input: string,
   commands: SlashCommandEntry[]
 ): string | null {
-  const token = slashCommandToken(input);
-  if (token === null) return null;
-
-  const matches = commands.filter((c) => c.cmd.toLowerCase().startsWith(token));
-  if (matches.length !== 1) return null;
-
-  const full = matches[0]!.cmd;
-  if (full.toLowerCase() === token) return null;
-
-  const leading = input.match(/^\s*/)?.[0] ?? "";
-  const rest = input.slice(leading.length);
-  const afterToken = rest.slice(token.length);
-  return `${leading}${full}${afterToken}`;
+  return completeSlashCommandTab(input, commands, null).text;
 }

--- a/src/cli/slash-commands.ts
+++ b/src/cli/slash-commands.ts
@@ -103,6 +103,17 @@ export function buildSlashCommandDefs(
       helpDetail: "Restore the on-screen chat from session history",
     },
     {
+      cmd: "/show-think",
+      hint: "expand collapsed Thought for… blocks in chat",
+      helpDetail:
+        "Expand collapsed main-agent thinking blocks in the current chat (live and restored sessions)",
+    },
+    {
+      cmd: "/hide-think",
+      hint: "collapse thinking blocks to Thought for…",
+      helpDetail: "Collapse expanded thinking blocks back to one-line Thought for… summaries",
+    },
+    {
       cmd: "/side",
       hint: "side prompt during active turn; --history to review",
       helpDetail:

--- a/src/cli/subagent-progress-labels.ts
+++ b/src/cli/subagent-progress-labels.ts
@@ -1,2 +1,4 @@
 export const SUBAGENT_PROGRESS_THINKING = "thinking...";
+/** Placeholder when subagent reasoning runs but /settings hides detail lines. */
+export const SUBAGENT_PROGRESS_THINKING_PLACEHOLDER = "Thinking...";
 export const SUBAGENT_PROGRESS_WRAPPING_UP = "wrapping up...";

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -54,7 +54,7 @@ async function handleHelp() {
     `${"WORK".padEnd(12)}${"Cyan".padEnd(10)}Full execution mode with file editing and code generation`,
     `${"".padEnd(12)}${"".padEnd(10)}Tools: All tools available`,
     "",
-    `${"PLAN".padEnd(12)}${"Purple".padEnd(10)}Planning and documentation with restricted writes`,
+    `${"PLAN".padEnd(12)}${"Purple".padEnd(10)}Research + .impulse/plans revisions (latest wins)`,
     `${"".padEnd(12)}${"".padEnd(10)}Tools: Read-only + docs/ and PRD.md`,
     "",
     `${"DEBUG".padEnd(12)}${"Orange".padEnd(10)}Systematic 7-step debugging methodology`,

--- a/src/commands/utility.ts
+++ b/src/commands/utility.ts
@@ -276,7 +276,8 @@ async function handleThink() {
 async function handleThinkingBlocks() {
   return {
     success: true,
-    output: "Thinking block visibility is always shown in the CLI during active turns.",
+    output:
+      "In the CLI, thinking blocks auto-collapse to Thought for… when done. Use /show-think and /hide-think to expand or collapse.",
   };
 }
 

--- a/src/git/gh-cli.ts
+++ b/src/git/gh-cli.ts
@@ -1,0 +1,88 @@
+import { execSync } from "child_process";
+
+export interface GhCliStatus {
+  installed: boolean;
+  authenticated: boolean;
+  account?: string;
+}
+
+let cachedAt = 0;
+let cachedStatus: GhCliStatus | null = null;
+
+const CACHE_MS = 60_000;
+
+function runQuiet(command: string, timeoutMs = 3000): { ok: boolean; stdout: string } {
+  try {
+    const stdout = execSync(command, {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: timeoutMs,
+      encoding: "utf-8",
+    });
+    return { ok: true, stdout: stdout.toString().trim() };
+  } catch (err: unknown) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer };
+    const stdout = (e.stdout?.toString() ?? e.stderr?.toString() ?? "").trim();
+    return { ok: false, stdout };
+  }
+}
+
+/**
+ * Probe whether GitHub CLI is installed and authenticated.
+ */
+export function probeGhCli(force = false): GhCliStatus {
+  const now = Date.now();
+  if (!force && cachedStatus && now - cachedAt < CACHE_MS) {
+    return cachedStatus;
+  }
+
+  const version = runQuiet("gh --version", 2000);
+  if (!version.ok) {
+    cachedStatus = { installed: false, authenticated: false };
+    cachedAt = now;
+    return cachedStatus;
+  }
+
+  const auth = runQuiet("gh auth status -h github.com 2>&1", 4000);
+  if (!auth.ok) {
+    cachedStatus = { installed: true, authenticated: false };
+    cachedAt = now;
+    return cachedStatus;
+  }
+
+  const accountMatch = auth.stdout.match(/Logged in to github\.com account (\S+)/i);
+  cachedStatus = {
+    installed: true,
+    authenticated: true,
+    account: accountMatch?.[1],
+  };
+  cachedAt = now;
+  return cachedStatus;
+}
+
+export function clearGhCliCache(): void {
+  cachedAt = 0;
+  cachedStatus = null;
+}
+
+export function formatGhCliPromptBlock(status: GhCliStatus): string {
+  const lines = [
+    "## GitHub CLI",
+    "",
+    `installed: ${status.installed ? "yes" : "no"}`,
+    `authenticated: ${status.authenticated ? "yes" : "no"}`,
+  ];
+
+  if (status.installed && status.authenticated && status.account) {
+    lines.push(`account: ${status.account}`);
+    lines.push("");
+    lines.push("Use the `github_issue` tool to read issues from this repo (requires gh).");
+  } else if (status.installed && !status.authenticated) {
+    lines.push("");
+    lines.push("Run `gh auth login` to enable `github_issue`. Until then use `web_fetch` on the canonical issue URL from Repository (git).");
+  } else {
+    lines.push("");
+    lines.push("Install GitHub CLI (https://cli.github.com/) to enable `github_issue`. Until then use `web_fetch` on the canonical issue URL from Repository (git).");
+  }
+
+  return lines.join("\n");
+}

--- a/src/git/repo-context.ts
+++ b/src/git/repo-context.ts
@@ -1,0 +1,156 @@
+import { execSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
+export interface RepoContext {
+  owner: string;
+  repo: string;
+  fullName: string;
+  webUrl: string;
+  issueUrlTemplate: string;
+  source: "package.json" | "git-remote";
+}
+
+let cachedCwd: string | null = null;
+let cachedContext: RepoContext | null | undefined;
+
+/**
+ * Parse a GitHub remote or repository URL into owner/repo.
+ */
+export function parseGitHubOwnerRepo(raw: string): { owner: string; repo: string } | null {
+  const trimmed = raw.trim().replace(/\.git$/i, "");
+
+  const sshMatch = trimmed.match(/^(?:git@|ssh:\/\/git@)github\.com[:/]([^/]+)\/([^/]+)$/i);
+  if (sshMatch) {
+    return { owner: sshMatch[1]!, repo: sshMatch[2]! };
+  }
+
+  try {
+    const url = new URL(trimmed.startsWith("http") ? trimmed : `https://${trimmed}`);
+    if (url.hostname.replace(/^www\./, "") !== "github.com") {
+      return null;
+    }
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length >= 2) {
+      return { owner: parts[0]!, repo: parts[1]! };
+    }
+  } catch {
+    // not a URL
+  }
+
+  return null;
+}
+
+function readPackageRepositoryUrl(cwd: string): string | null {
+  const pkgPath = path.join(cwd, "package.json");
+  if (!existsSync(pkgPath)) return null;
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      repository?: string | { url?: string; type?: string };
+    };
+    const repo = pkg.repository;
+    if (typeof repo === "string") return repo;
+    if (repo && typeof repo.url === "string") return repo.url;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function readGitOriginUrl(cwd: string): string | null {
+  try {
+    execSync("git rev-parse --git-dir", { cwd, stdio: "pipe" });
+  } catch {
+    return null;
+  }
+
+  try {
+    return execSync("git remote get-url origin", { cwd, stdio: "pipe" })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+function buildContext(
+  owner: string,
+  repo: string,
+  source: RepoContext["source"]
+): RepoContext {
+  const fullName = `${owner}/${repo}`;
+  const webUrl = `https://github.com/${fullName}`;
+  return {
+    owner,
+    repo,
+    fullName,
+    webUrl,
+    issueUrlTemplate: `${webUrl}/issues/{number}`,
+    source,
+  };
+}
+
+export function issueUrlForNumber(ctx: RepoContext, issueNumber: number): string {
+  return `${ctx.webUrl}/issues/${issueNumber}`;
+}
+
+/**
+ * Resolve GitHub owner/repo for the workspace (package.json repository, then git origin).
+ */
+export function resolveRepoContext(cwd = process.cwd()): RepoContext | null {
+  if (cachedCwd === cwd && cachedContext !== undefined) {
+    return cachedContext;
+  }
+
+  cachedCwd = cwd;
+  cachedContext = null;
+
+  const fromPkg = readPackageRepositoryUrl(cwd);
+  if (fromPkg) {
+    const parsed = parseGitHubOwnerRepo(fromPkg);
+    if (parsed) {
+      cachedContext = buildContext(parsed.owner, parsed.repo, "package.json");
+      return cachedContext;
+    }
+  }
+
+  const fromGit = readGitOriginUrl(cwd);
+  if (fromGit) {
+    const parsed = parseGitHubOwnerRepo(fromGit);
+    if (parsed) {
+      cachedContext = buildContext(parsed.owner, parsed.repo, "git-remote");
+      return cachedContext;
+    }
+  }
+
+  return null;
+}
+
+/** Clear cache when cwd changes between sessions (tests). */
+export function clearRepoContextCache(): void {
+  cachedCwd = null;
+  cachedContext = undefined;
+}
+
+export function formatRepoContextPromptBlock(ctx: RepoContext | null): string {
+  if (!ctx) {
+    return `
+## Repository (git)
+
+No GitHub repository detected for this workspace (not a git repo or origin is not github.com).
+If the user mentions "issue #N" without a repo or URL, use the \`question\` tool to ask which repository — they can use **Type your own answer** for \`owner/repo\` or a full issue URL.
+`.trim();
+  }
+
+  return `
+## Repository (git)
+
+Detected GitHub repo: **${ctx.fullName}** (from ${ctx.source})
+Repo URL: ${ctx.webUrl}
+Issue URL pattern: ${ctx.issueUrlTemplate}
+
+When the user says "issue #N" or "#N" without naming another repo, they mean **this repository's** issue N.
+Do not web_search for generic "github issue N". Prefer \`github_issue\` when GitHub CLI is available, else \`web_fetch\` on the canonical issue URL.
+`.trim();
+}

--- a/src/plan/paths.ts
+++ b/src/plan/paths.ts
@@ -1,0 +1,40 @@
+import path from "path";
+
+export const PLAN_ROOT_DIR = ".impulse/plans";
+export const REVISIONS_SUBDIR = "revisions";
+
+export const SPEC_PLAN_FILES = ["design.md", "spec.md", "tasks.md"] as const;
+export const TDD_PLAN_FILES = ["PRD.md"] as const;
+
+export type PlanningStyle = "spec" | "tdd";
+
+export function getPlanSessionRoot(sessionId: string, cwd = process.cwd()): string {
+  return path.join(cwd, PLAN_ROOT_DIR, sessionId);
+}
+
+export function getRevisionsRoot(sessionId: string, cwd = process.cwd()): string {
+  return path.join(getPlanSessionRoot(sessionId, cwd), REVISIONS_SUBDIR);
+}
+
+export function getRevisionDir(
+  sessionId: string,
+  revisionId: string,
+  cwd = process.cwd()
+): string {
+  return path.join(getRevisionsRoot(sessionId, cwd), revisionId);
+}
+
+export function allowedPlanFilenames(style: PlanningStyle): readonly string[] {
+  return style === "tdd"
+    ? [...SPEC_PLAN_FILES, ...TDD_PLAN_FILES]
+    : SPEC_PLAN_FILES;
+}
+
+export function toRelativePlanPath(absolutePath: string, cwd = process.cwd()): string {
+  const normalized = absolutePath.replace(/\\/g, "/");
+  const base = cwd.replace(/\\/g, "/");
+  if (normalized.startsWith(base)) {
+    return normalized.slice(base.length).replace(/^\//, "");
+  }
+  return normalized;
+}

--- a/src/plan/revisions.ts
+++ b/src/plan/revisions.ts
@@ -1,0 +1,232 @@
+import fs from "fs";
+import path from "path";
+import {
+  allowedPlanFilenames,
+  getRevisionDir,
+  getRevisionsRoot,
+  toRelativePlanPath,
+  type PlanningStyle,
+} from "./paths.js";
+
+export type { PlanningStyle } from "./paths.js";
+
+export interface PlanRevisionMeta {
+  revisionId: string;
+  revises: string;
+  createdAt: string;
+  active: boolean;
+  planningStyle: PlanningStyle;
+}
+
+export interface PlanRevision {
+  meta: PlanRevisionMeta;
+  dir: string;
+  files: Record<string, string>;
+}
+
+export function formatRevisionId(date = new Date()): string {
+  return date.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+}
+
+function metaPath(revisionDir: string): string {
+  return path.join(revisionDir, "meta.json");
+}
+
+function readMeta(revisionDir: string): PlanRevisionMeta | null {
+  const file = metaPath(revisionDir);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8")) as PlanRevisionMeta;
+  } catch {
+    return null;
+  }
+}
+
+function writeMeta(revisionDir: string, meta: PlanRevisionMeta): void {
+  fs.writeFileSync(metaPath(revisionDir), JSON.stringify(meta, null, 2), { mode: 0o600 });
+}
+
+function buildFilePaths(revisionDir: string, style: PlanningStyle): Record<string, string> {
+  const files: Record<string, string> = {};
+  for (const name of allowedPlanFilenames(style)) {
+    files[name] = path.join(revisionDir, name);
+  }
+  return files;
+}
+
+export function listRevisionIds(sessionId: string, cwd = process.cwd()): string[] {
+  const root = getRevisionsRoot(sessionId, cwd);
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+function deactivateAllRevisions(sessionId: string, cwd: string): void {
+  for (const id of listRevisionIds(sessionId, cwd)) {
+    const dir = getRevisionDir(sessionId, id, cwd);
+    const meta = readMeta(dir);
+    if (meta?.active) {
+      writeMeta(dir, { ...meta, active: false });
+    }
+  }
+}
+
+/**
+ * Create a new plan revision and mark it active (latest wins).
+ */
+export function createPlanRevision(
+  sessionId: string,
+  options?: { revises?: string; planningStyle?: PlanningStyle; revisionId?: string },
+  cwd = process.cwd()
+): PlanRevision {
+  const revisionsRoot = getRevisionsRoot(sessionId, cwd);
+  fs.mkdirSync(revisionsRoot, { recursive: true });
+
+  const priorActive = getActivePlanRevision(sessionId, cwd);
+  const revises =
+    options?.revises ??
+    (priorActive ? priorActive.meta.revisionId : "initial");
+  const planningStyle = options?.planningStyle ?? priorActive?.meta.planningStyle ?? "spec";
+  const revisionId =
+    options?.revisionId ??
+    (revises === "initial" && !priorActive ? "initial" : formatRevisionId());
+
+  deactivateAllRevisions(sessionId, cwd);
+
+  const dir = getRevisionDir(sessionId, revisionId, cwd);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const meta: PlanRevisionMeta = {
+    revisionId,
+    revises,
+    createdAt: new Date().toISOString(),
+    active: true,
+    planningStyle,
+  };
+  writeMeta(dir, meta);
+
+  return { meta, dir, files: buildFilePaths(dir, planningStyle) };
+}
+
+/**
+ * Latest revision by createdAt; falls back to revisionId sort if needed.
+ */
+export function getActivePlanRevision(sessionId: string, cwd = process.cwd()): PlanRevision | null {
+  const root = getRevisionsRoot(sessionId, cwd);
+  if (!fs.existsSync(root)) return null;
+
+  let best: PlanRevision | null = null;
+  let bestTime = "";
+
+  for (const id of listRevisionIds(sessionId, cwd)) {
+    const dir = getRevisionDir(sessionId, id, cwd);
+    const meta = readMeta(dir);
+    if (!meta?.active) continue;
+    if (!best || meta.createdAt >= bestTime) {
+      bestTime = meta.createdAt;
+      best = {
+        meta,
+        dir,
+        files: buildFilePaths(dir, meta.planningStyle),
+      };
+    }
+  }
+
+  if (best) return best;
+
+  // Fallback: newest revision by createdAt even if active flag missing
+  for (const id of listRevisionIds(sessionId, cwd)) {
+    const dir = getRevisionDir(sessionId, id, cwd);
+    const meta = readMeta(dir);
+    if (!meta) continue;
+    if (!best || meta.createdAt >= bestTime) {
+      bestTime = meta.createdAt;
+      best = { meta, dir, files: buildFilePaths(dir, meta.planningStyle) };
+    }
+  }
+
+  return best;
+}
+
+export function ensureActivePlanRevision(sessionId: string, cwd = process.cwd()): PlanRevision {
+  return getActivePlanRevision(sessionId, cwd) ?? createPlanRevision(sessionId, undefined, cwd);
+}
+
+export function setPlanningStyleForActiveRevision(
+  sessionId: string,
+  style: PlanningStyle,
+  cwd = process.cwd()
+): PlanRevision | null {
+  const active = getActivePlanRevision(sessionId, cwd);
+  if (!active) return null;
+  const meta = { ...active.meta, planningStyle: style };
+  writeMeta(active.dir, meta);
+  return { meta, dir: active.dir, files: buildFilePaths(active.dir, style) };
+}
+
+/**
+ * PLAN-mode write path check. Only the active revision directory; allowed plan filenames only.
+ */
+export function validatePlanWritePath(
+  filePath: string,
+  sessionId: string,
+  cwd = process.cwd()
+): string | null {
+  const active = ensureActivePlanRevision(sessionId, cwd);
+  const resolved = path.resolve(cwd, filePath);
+  const activeDir = path.resolve(active.dir);
+
+  const rel = path.relative(activeDir, resolved);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    return (
+      `PLAN mode can only write plan files under the active revision: ${toRelativePlanPath(activeDir, cwd)}. ` +
+      `Requested: ${filePath}. Use plan_revision to start a new revision before writing elsewhere.`
+    );
+  }
+
+  const base = path.basename(resolved).toLowerCase();
+  const allowed = allowedPlanFilenames(active.meta.planningStyle).map((f) => f.toLowerCase());
+  if (!allowed.includes(base)) {
+    return (
+      `PLAN mode allows only: ${allowed.join(", ")} in the active revision. ` +
+      `For TDD artifacts (e.g. PRD.md), confirm TDD with the user via the question tool first.`
+    );
+  }
+
+  return null;
+}
+
+export function buildPlanModeContextBlock(sessionId: string, cwd = process.cwd()): string {
+  const active = getActivePlanRevision(sessionId, cwd);
+  if (!active) {
+    return `
+## Active plan (PLAN mode)
+
+No plan revision yet. On first plan write, revision \`initial\` will be created under \`.impulse/plans/${sessionId}/revisions/\`.
+Use \`plan_revision\` when the user asks to rework the plan (creates a new revision; latest revision is always current context).
+`.trim();
+  }
+
+  const fileList = Object.entries(active.files)
+    .map(([name, p]) => `- ${name}: ${toRelativePlanPath(p, cwd)}`)
+    .join("\n");
+
+  return `
+## Active plan (PLAN mode) — latest revision only
+
+Revision: \`${active.meta.revisionId}\` (revises: ${active.meta.revises})
+Style: ${active.meta.planningStyle}
+Directory: ${toRelativePlanPath(active.dir, cwd)}
+
+Write or edit ONLY these files in the active revision:
+${fileList}
+
+Rules:
+- Older revisions are historical; do not treat them as current unless the user asks to read them.
+- To rework the plan, call \`plan_revision\` first, then write new files (do not overwrite superseded revisions).
+- Default is spec-driven (design + spec + tasks). For TDD, confirm with the question tool before adding PRD.md.
+`.trim();
+}

--- a/src/plan/revisions.ts
+++ b/src/plan/revisions.ts
@@ -25,7 +25,7 @@ export interface PlanRevision {
 }
 
 export function formatRevisionId(date = new Date()): string {
-  return date.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  return date.toISOString().replace(/[:.]/g, "-").slice(0, 23);
 }
 
 function metaPath(revisionDir: string): string {
@@ -175,9 +175,11 @@ export function validatePlanWritePath(
   sessionId: string,
   cwd = process.cwd()
 ): string | null {
-  const active = ensureActivePlanRevision(sessionId, cwd);
+  const active = getActivePlanRevision(sessionId, cwd);
+  const revisionDir = active?.dir ?? getRevisionDir(sessionId, "initial", cwd);
+  const planningStyle = active?.meta.planningStyle ?? "spec";
   const resolved = path.resolve(cwd, filePath);
-  const activeDir = path.resolve(active.dir);
+  const activeDir = path.resolve(revisionDir);
 
   const rel = path.relative(activeDir, resolved);
   if (rel.startsWith("..") || path.isAbsolute(rel)) {
@@ -188,12 +190,16 @@ export function validatePlanWritePath(
   }
 
   const base = path.basename(resolved).toLowerCase();
-  const allowed = allowedPlanFilenames(active.meta.planningStyle).map((f) => f.toLowerCase());
+  const allowed = allowedPlanFilenames(planningStyle).map((f) => f.toLowerCase());
   if (!allowed.includes(base)) {
     return (
       `PLAN mode allows only: ${allowed.join(", ")} in the active revision. ` +
       `For TDD artifacts (e.g. PRD.md), confirm TDD with the user via the question tool first.`
     );
+  }
+
+  if (!active) {
+    createPlanRevision(sessionId, undefined, cwd);
   }
 
   return null;

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -72,6 +72,8 @@ export interface Message {
   /** Expanded provider content when display differs (paste tokens, images). */
   apiContent?: UserMessageApiContent
   reasoning_content?: string
+  /** Wall-clock ms for the reasoning phase on this assistant message (UI replay). */
+  thinking_duration_ms?: number
   content_blocks?: MessageContentBlock[]
   validation?: MessageValidation
   timestamp: string
@@ -82,7 +84,7 @@ export interface Message {
 
 export type MessageContentBlock =
   | { id: string; type: "text"; text: string }
-  | { id: string; type: "thinking"; thinking: string }
+  | { id: string; type: "thinking"; thinking: string; durationMs?: number }
   | { id: string; type: "tool_call"; tool_call_id: string };
 
 export interface MessageValidation {

--- a/src/tools/github-issue.ts
+++ b/src/tools/github-issue.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import { probeGhCli } from "../git/gh-cli.js";
+import {
+  issueUrlForNumber,
+  parseGitHubOwnerRepo,
+  resolveRepoContext,
+  type RepoContext,
+} from "../git/repo-context.js";
+
+const DESCRIPTION = `Read a GitHub issue via GitHub CLI (gh). Requires gh installed and authenticated.
+
+Does not use web_fetch. If gh is unavailable, the tool returns the canonical issue URL — use web_fetch on that URL instead.
+
+For "issue #N" in the current workspace, omit owner/repo (uses Repository context).`;
+
+const GithubIssueSchema = z.object({
+  number: z.number().int().positive().describe("Issue number"),
+  owner: z.string().optional().describe("Repository owner (defaults to workspace repo)"),
+  repo: z.string().optional().describe("Repository name (defaults to workspace repo)"),
+  url: z
+    .string()
+    .optional()
+    .describe("Full GitHub issue URL (overrides number/owner/repo when parseable)"),
+});
+
+type GithubIssueInput = z.infer<typeof GithubIssueSchema>;
+
+interface GhIssueJson {
+  title?: string;
+  body?: string;
+  state?: string;
+  url?: string;
+  labels?: Array<{ name?: string }>;
+  comments?: Array<{ author?: { login?: string }; body?: string }>;
+}
+
+function parseIssueUrl(url: string): { owner: string; repo: string; number: number } | null {
+  try {
+    const u = new URL(url);
+    if (u.hostname.replace(/^www\./, "") !== "github.com") return null;
+    const parts = u.pathname.split("/").filter(Boolean);
+    // owner/repo/issues/N
+    if (parts.length >= 4 && parts[2] === "issues") {
+      const num = parseInt(parts[3]!, 10);
+      if (!Number.isNaN(num) && num > 0) {
+        return { owner: parts[0]!, repo: parts[1]!, number: num };
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function resolveTarget(input: GithubIssueInput, ctx: RepoContext | null): {
+  owner: string;
+  repo: string;
+  number: number;
+} | { error: string } {
+  if (input.url) {
+    const fromUrl = parseIssueUrl(input.url);
+    if (fromUrl) return fromUrl;
+    const parsed = parseGitHubOwnerRepo(input.url);
+    if (parsed && input.number) {
+      return { ...parsed, number: input.number };
+    }
+    return { error: `Could not parse GitHub issue URL: ${input.url}` };
+  }
+
+  const number = input.number;
+  if (input.owner && input.repo) {
+    return { owner: input.owner, repo: input.repo, number };
+  }
+
+  if (ctx) {
+    return { owner: ctx.owner, repo: ctx.repo, number };
+  }
+
+  return {
+    error:
+      "No GitHub repository detected for this workspace. Provide owner/repo, a full issue URL, or use the question tool to ask which repository.",
+  };
+}
+
+function formatIssueOutput(
+  data: GhIssueJson,
+  fullName: string,
+  number: number
+): string {
+  const labels =
+    data.labels?.map((l) => l.name).filter(Boolean).join(", ") || "(none)";
+  const comments = data.comments ?? [];
+  const commentBlock =
+    comments.length === 0
+      ? "(no comments)"
+      : comments
+          .slice(0, 5)
+          .map(
+            (c, i) =>
+              `### Comment ${i + 1}${c.author?.login ? ` (@${c.author.login})` : ""}\n${(c.body ?? "").slice(0, 2000)}`
+          )
+          .join("\n\n") +
+        (comments.length > 5 ? `\n\n... and ${comments.length - 5} more comments` : "");
+
+  return [
+    `# ${fullName}#${number}: ${data.title ?? "(no title)"}`,
+    "",
+    `**State:** ${data.state ?? "unknown"}`,
+    `**URL:** ${data.url ?? ""}`,
+    `**Labels:** ${labels}`,
+    "",
+    "## Body",
+    data.body ?? "(empty)",
+    "",
+    "## Comments (preview)",
+    commentBlock,
+  ].join("\n");
+}
+
+export const githubIssueTool: Tool<GithubIssueInput> = Tool.define(
+  "github_issue",
+  DESCRIPTION,
+  GithubIssueSchema,
+  async (input: GithubIssueInput): Promise<ToolResult> => {
+    const gh = probeGhCli();
+    const ctx = resolveRepoContext();
+    const target = resolveTarget(input, ctx);
+
+    if ("error" in target) {
+      return { success: false, output: target.error };
+    }
+
+    const { owner, repo, number } = target;
+    const fullName = `${owner}/${repo}`;
+    const canonicalUrl = issueUrlForNumber(
+      ctx ?? {
+        owner,
+        repo,
+        fullName,
+        webUrl: `https://github.com/${fullName}`,
+        issueUrlTemplate: `https://github.com/${fullName}/issues/{number}`,
+        source: "git-remote",
+      },
+      number
+    );
+
+    if (!gh.installed) {
+      return {
+        success: false,
+        output: [
+          "GitHub CLI (gh) is not installed.",
+          `Canonical issue URL: ${canonicalUrl}`,
+          "Install gh (https://cli.github.com/) or use web_fetch on that URL.",
+        ].join("\n"),
+      };
+    }
+
+    if (!gh.authenticated) {
+      return {
+        success: false,
+        output: [
+          "GitHub CLI is not authenticated. Run: gh auth login",
+          `Canonical issue URL: ${canonicalUrl}`,
+          "Or use web_fetch on that URL.",
+        ].join("\n"),
+      };
+    }
+
+    const fields = "title,body,state,url,labels,comments";
+    const proc = Bun.spawn(
+      ["gh", "issue", "view", String(number), "-R", fullName, "--json", fields],
+      { stdout: "pipe", stderr: "pipe", cwd: process.cwd() }
+    );
+
+    const timedOut = await Promise.race([
+      proc.exited.then(() => false),
+      Bun.sleep(30_000).then(() => true),
+    ]);
+
+    if (timedOut) {
+      proc.kill();
+      return { success: false, output: `gh issue view timed out for ${fullName}#${number}` };
+    }
+
+    const exitCode = proc.exitCode ?? 1;
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+
+    if (exitCode !== 0) {
+      return {
+        success: false,
+        output: [
+          `gh issue view failed for ${fullName}#${number} (exit ${exitCode})`,
+          stderr || stdout,
+          `Canonical URL: ${canonicalUrl}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      };
+    }
+
+    try {
+      const data = JSON.parse(stdout) as GhIssueJson;
+      return {
+        success: true,
+        output: formatIssueOutput(data, fullName, number),
+        metadata: {
+          type: "github_issue",
+          owner,
+          repo,
+          number,
+          url: data.url ?? canonicalUrl,
+        },
+      };
+    } catch {
+      return {
+        success: false,
+        output: `Failed to parse gh JSON output for ${fullName}#${number}\n${stdout}`,
+      };
+    }
+  },
+  { timeout: 35_000 }
+);

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -40,5 +40,8 @@ import "./web-search";
 import "./plan-revision";
 import "./install-skill";
 
+// GitHub
+import "./github-issue";
+
 // Re-export registry for convenience
 export { Tool } from "./registry";

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -36,5 +36,9 @@ import "./tool-docs";
 import "./web-fetch";
 import "./web-search";
 
+// Plan mode
+import "./plan-revision";
+import "./install-skill";
+
 // Re-export registry for convenience
 export { Tool } from "./registry";

--- a/src/tools/install-skill-source.ts
+++ b/src/tools/install-skill-source.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
+/** owner/repo only — `skills add` with -y installs every skill in the repo. */
+const REPO_ONLY_PATTERN = /^[\w.-]+\/[\w.-]+$/;
+
+export type NormalizedSkillSource = {
+  source: string;
+  skillSlug: string;
+};
+
+export function normalizeSkillSource(raw: string): NormalizedSkillSource | { error: string } {
+  let source = raw.trim().replace(/\/+$/, "");
+
+  const treeMatch = source.match(
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/[^/]+\/(.+)$/i
+  );
+  if (treeMatch) {
+    source = `${treeMatch[1]}/${treeMatch[2]}/${treeMatch[3]}`;
+  } else {
+    const blobMatch = source.match(
+      /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/[^/]+\/(.+)$/i
+    );
+    if (blobMatch) {
+      source = `${blobMatch[1]}/${blobMatch[2]}/${blobMatch[3]}`;
+    }
+  }
+
+  source = source.replace(/\.git$/, "");
+
+  if (REPO_ONLY_PATTERN.test(source)) {
+    return {
+      error: [
+        `Source "${source}" names a repository, not one skill.`,
+        "With non-interactive install, that would install every skill in the repo.",
+        `Use the full skill path instead, e.g. ${source}/skills/engineering/grill-with-docs`,
+        "Or pass the GitHub tree URL to the skill folder.",
+      ].join("\n"),
+    };
+  }
+
+  const segments = source.split("/").filter(Boolean);
+  if (segments.length < 3) {
+    return {
+      error: `Source must include owner/repo and a skill path (at least 3 segments). Got: ${source}`,
+    };
+  }
+
+  const skillSlug = segments[segments.length - 1]!;
+  return { source, skillSlug };
+}
+
+export function skillInstructionsPath(cwd: string, skillSlug: string): string {
+  return join(cwd, ".agents", "skills", skillSlug, "SKILL.md");
+}
+
+export function isSkillInstalled(cwd: string, skillSlug: string): boolean {
+  return existsSync(skillInstructionsPath(cwd, skillSlug));
+}
+
+export function formatSkillReadyMessage(skillSlug: string, instructionsPath: string): string {
+  return [
+    `Skill "${skillSlug}" is ready.`,
+    `Instructions: ${instructionsPath}`,
+    "Read SKILL.md and follow it.",
+    "For interview/grill flows: use the question tool (one topic per call) — never ask in plain chat text.",
+  ].join("\n");
+}

--- a/src/tools/install-skill.ts
+++ b/src/tools/install-skill.ts
@@ -2,17 +2,29 @@ import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { ask as askPermission } from "../permission";
 import { SessionManager } from "../session/manager.js";
+import {
+  formatSkillReadyMessage,
+  isSkillInstalled,
+  normalizeSkillSource,
+  skillInstructionsPath,
+} from "./install-skill-source.js";
 
-const DESCRIPTION = `Install an agent skill package (e.g. from the skills registry).
+const DESCRIPTION = `Install a single agent skill via \`npx skills@latest add\` (non-interactive).
 
-Runs \`npx skills@latest add <source>\` in the project. Use in PLAN mode when planning needs a referenced skill.
-Does not grant general shell access.`;
+Use in PLAN when a referenced skill is missing. Always pass the **full skill path**, not the repo root:
+- Good: mattpocock/skills/skills/engineering/grill-with-docs
+- Bad: mattpocock/skills (installs all skills in the repo)
+
+GitHub tree URLs to a skill folder are accepted. After install, read \`.agents/skills/<name>/SKILL.md\`.
+Interview/grill skills require the question tool (one topic per call), not markdown questions in chat.`;
 
 const InstallSkillSchema = z.object({
   source: z
     .string()
     .min(1)
-    .describe("Skill source, e.g. mattpocock/skills or a package path from the skills CLI"),
+    .describe(
+      "Full skill path (owner/repo/.../skill-name) or GitHub tree URL — not repo root only"
+    ),
   global: z
     .boolean()
     .optional()
@@ -26,10 +38,26 @@ export const installSkillTool: Tool<InstallSkillInput> = Tool.define(
   DESCRIPTION,
   InstallSkillSchema,
   async (input: InstallSkillInput): Promise<ToolResult> => {
+    const normalized = normalizeSkillSource(input.source);
+    if ("error" in normalized) {
+      return { success: false, output: normalized.error };
+    }
+
+    const { source, skillSlug } = normalized;
+    const cwd = process.cwd();
+    const instructionsPath = skillInstructionsPath(cwd, skillSlug);
+
+    if (isSkillInstalled(cwd, skillSlug)) {
+      return {
+        success: true,
+        output: formatSkillReadyMessage(skillSlug, instructionsPath),
+      };
+    }
+
     const sessionId = SessionManager.getCurrentSessionID() ?? "unknown";
-    const args = ["skills@latest", "add", input.source];
+    const args = ["skills@latest", "add", source, "-y"];
     if (input.global) {
-      args.push("--global");
+      args.push("-g");
     }
     const command = `npx ${args.join(" ")}`;
 
@@ -37,14 +65,15 @@ export const installSkillTool: Tool<InstallSkillInput> = Tool.define(
       sessionID: sessionId,
       permission: "bash",
       patterns: [command],
-      message: `Install skill: ${input.source}`,
-      metadata: { command, tool: "install_skill" },
+      message: `Install skill: ${skillSlug}`,
+      metadata: { command, tool: "install_skill", skillSlug },
     });
 
     const proc = Bun.spawn(["npx", ...args], {
-      cwd: process.cwd(),
+      cwd,
       stdout: "pipe",
       stderr: "pipe",
+      stdin: "ignore",
       env: { ...process.env, CI: "1" },
     });
 
@@ -58,7 +87,10 @@ export const installSkillTool: Tool<InstallSkillInput> = Tool.define(
       proc.kill();
       return {
         success: false,
-        output: `Skill install timed out after ${timeoutMs / 1000}s`,
+        output: [
+          `Skill install timed out after ${timeoutMs / 1000}s.`,
+          "The skills CLI may be waiting for interactive input — use a full skill path, not the repo root.",
+        ].join("\n"),
       };
     }
 
@@ -73,9 +105,25 @@ export const installSkillTool: Tool<InstallSkillInput> = Tool.define(
       };
     }
 
+    if (!isSkillInstalled(cwd, skillSlug)) {
+      const cliOutput = [stdout, stderr].filter((s) => s.trim()).join("\n");
+      return {
+        success: false,
+        output: [
+          `Install finished but ${instructionsPath} was not found.`,
+          "Check the skill path — the last segment must match the installed folder name.",
+          cliOutput,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      };
+    }
+
+    const cliOutput = [stdout, stderr].filter((s) => s.trim()).join("\n");
+    const ready = formatSkillReadyMessage(skillSlug, instructionsPath);
     return {
       success: true,
-      output: [stdout, stderr].filter((s) => s.trim()).join("\n") || `Installed skill: ${input.source}`,
+      output: cliOutput ? `${cliOutput}\n\n${ready}` : ready,
     };
   },
   { timeout: 130_000 }

--- a/src/tools/install-skill.ts
+++ b/src/tools/install-skill.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import { ask as askPermission } from "../permission";
+import { SessionManager } from "../session/manager.js";
+
+const DESCRIPTION = `Install an agent skill package (e.g. from the skills registry).
+
+Runs \`npx skills@latest add <source>\` in the project. Use in PLAN mode when planning needs a referenced skill.
+Does not grant general shell access.`;
+
+const InstallSkillSchema = z.object({
+  source: z
+    .string()
+    .min(1)
+    .describe("Skill source, e.g. mattpocock/skills or a package path from the skills CLI"),
+  global: z
+    .boolean()
+    .optional()
+    .describe("Install globally when supported (default: project-local)"),
+});
+
+type InstallSkillInput = z.infer<typeof InstallSkillSchema>;
+
+export const installSkillTool: Tool<InstallSkillInput> = Tool.define(
+  "install_skill",
+  DESCRIPTION,
+  InstallSkillSchema,
+  async (input: InstallSkillInput): Promise<ToolResult> => {
+    const sessionId = SessionManager.getCurrentSessionID() ?? "unknown";
+    const args = ["skills@latest", "add", input.source];
+    if (input.global) {
+      args.push("--global");
+    }
+    const command = `npx ${args.join(" ")}`;
+
+    await askPermission({
+      sessionID: sessionId,
+      permission: "bash",
+      patterns: [command],
+      message: `Install skill: ${input.source}`,
+      metadata: { command, tool: "install_skill" },
+    });
+
+    const proc = Bun.spawn(["npx", ...args], {
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, CI: "1" },
+    });
+
+    const timeoutMs = 120_000;
+    const timedOut = await Promise.race([
+      proc.exited.then(() => false),
+      Bun.sleep(timeoutMs).then(() => true),
+    ]);
+
+    if (timedOut) {
+      proc.kill();
+      return {
+        success: false,
+        output: `Skill install timed out after ${timeoutMs / 1000}s`,
+      };
+    }
+
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = proc.exitCode ?? 1;
+
+    if (exitCode !== 0) {
+      return {
+        success: false,
+        output: [`Skill install failed (exit ${exitCode})`, stderr || stdout].filter(Boolean).join("\n"),
+      };
+    }
+
+    return {
+      success: true,
+      output: [stdout, stderr].filter((s) => s.trim()).join("\n") || `Installed skill: ${input.source}`,
+    };
+  },
+  { timeout: 130_000 }
+);

--- a/src/tools/mode-state.ts
+++ b/src/tools/mode-state.ts
@@ -9,6 +9,8 @@
  */
 
 import type { MODES } from "../constants";
+import { SessionManager } from "../session/manager.js";
+import { validatePlanWritePath } from "../plan/revisions.js";
 
 type Mode = typeof MODES[number];
 
@@ -81,26 +83,12 @@ export function validateWritePath(filePath: string): string | null {
     return "EXPLORE mode is read-only. Switch to WORK mode to write files.";
   }
   
-  // PLAN mode can only write planning artifacts (docs/ or PRD.md)
   if (mode === "PLAN") {
-    // Normalize path for comparison
-    const normalizedPath = filePath.replace(/\\/g, "/").toLowerCase();
-    const cwd = process.cwd().replace(/\\/g, "/").toLowerCase();
-    
-    // Check if path is in docs/ directory
-    const relativePath = normalizedPath.startsWith(cwd) 
-      ? normalizedPath.slice(cwd.length).replace(/^\//, "")
-      : normalizedPath;
-    
-    if (
-      relativePath.startsWith("docs/") ||
-      relativePath === "prd.md" ||
-      relativePath.endsWith("/prd.md")
-    ) {
-      return null;
+    const sessionId = SessionManager.getCurrentSessionID();
+    if (!sessionId) {
+      return "PLAN mode requires an active session to write plan files.";
     }
-    
-    return `PLAN mode can only write to docs/ or PRD.md. Requested path: ${filePath}. Switch to WORK mode to write elsewhere.`;
+    return validatePlanWritePath(filePath, sessionId);
   }
   
   return null; // Unknown mode, allow by default

--- a/src/tools/plan-revision.ts
+++ b/src/tools/plan-revision.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import {
+  buildPlanModeContextBlock,
+  createPlanRevision,
+  getActivePlanRevision,
+  type PlanningStyle,
+} from "../plan/revisions.js";
+import { toRelativePlanPath } from "../plan/paths.js";
+import { SessionManager } from "../session/manager.js";
+
+const DESCRIPTION = `Create a new plan revision in PLAN mode (latest revision becomes active context).
+
+Use when the user asks to revise or rework the plan — do not overwrite files in superseded revisions.
+First revision is created automatically on first plan write if none exists.`;
+
+const PlanRevisionSchema = z.object({
+  revises: z
+    .string()
+    .optional()
+    .describe("Prior revision id this revises; defaults to current active revision"),
+  planning_style: z
+    .enum(["spec", "tdd"])
+    .optional()
+    .describe("spec (default) or tdd after user confirmed via question tool"),
+});
+
+type PlanRevisionInput = z.infer<typeof PlanRevisionSchema>;
+
+export const planRevisionTool: Tool<PlanRevisionInput> = Tool.define(
+  "plan_revision",
+  DESCRIPTION,
+  PlanRevisionSchema,
+  async (input: PlanRevisionInput): Promise<ToolResult> => {
+    const sessionId = SessionManager.getCurrentSessionID();
+    if (!sessionId) {
+      return { success: false, output: "No active session. Start or resume a session first." };
+    }
+
+    const prior = getActivePlanRevision(sessionId);
+    const style: PlanningStyle = input.planning_style ?? prior?.meta.planningStyle ?? "spec";
+
+    const opts: { revises?: string; planningStyle: PlanningStyle } = {
+      planningStyle: style,
+    };
+    const revisesTarget = input.revises ?? prior?.meta.revisionId;
+    if (revisesTarget) {
+      opts.revises = revisesTarget;
+    }
+    const revision = createPlanRevision(sessionId, opts);
+
+    const session = SessionManager.getCurrentSession();
+    if (session) {
+      await SessionManager.update({
+        metadata: {
+          ...session.metadata,
+          activePlanRevisionId: revision.meta.revisionId,
+          planningStyle: revision.meta.planningStyle,
+        },
+      });
+    }
+
+    const paths = Object.entries(revision.files)
+      .map(([name, p]) => `${name}: ${toRelativePlanPath(p)}`)
+      .join("\n");
+
+    return {
+      success: true,
+      output: [
+        `Created plan revision: ${revision.meta.revisionId}`,
+        `Revises: ${revision.meta.revises}`,
+        `Planning style: ${revision.meta.planningStyle}`,
+        "",
+        "Active plan files:",
+        paths,
+        "",
+        buildPlanModeContextBlock(sessionId),
+      ].join("\n"),
+    };
+  }
+);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,7 @@ const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   tool_docs: "read_only",
   plan_revision: "utility",
   install_skill: "utility",
+  github_issue: "read_only",
   
   // Write tools (restricted in PLAN)
   file_write: "write",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -42,6 +42,8 @@ const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   web_fetch: "read_only",
   web_search: "read_only",
   tool_docs: "read_only",
+  plan_revision: "utility",
+  install_skill: "utility",
   
   // Write tools (restricted in PLAN)
   file_write: "write",
@@ -103,8 +105,12 @@ function isCategoryAllowedForMode(category: ToolCategory, mode: Mode, toolName: 
   }
 
   if (mode === "PLAN") {
-    // file_write and task are available with mode-specific restrictions in handlers.
-    if (toolName === "file_write" || toolName === "task" || toolName === "todo_write") {
+    if (
+      toolName === "file_write" ||
+      toolName === "file_edit" ||
+      toolName === "task" ||
+      toolName === "todo_write"
+    ) {
       return true;
     }
   }
@@ -195,8 +201,12 @@ export namespace Tool {
         
         // For PLAN, modify tool descriptions to note restrictions
         let description = tool.description;
-        if (tool.name === "file_write" && mode === "PLAN") {
-          const restriction = "RESTRICTED: PLAN mode can only write docs/ or PRD.md.";
+        if (
+          (tool.name === "file_write" || tool.name === "file_edit") &&
+          mode === "PLAN"
+        ) {
+          const restriction =
+            "RESTRICTED: PLAN mode can only write/edit files in the active plan revision under .impulse/plans/<sessionId>/revisions/.";
           description = `${restriction}\n\n${description}`;
         }
 

--- a/src/tools/tool-docs.ts
+++ b/src/tools/tool-docs.ts
@@ -32,6 +32,7 @@ const TOOL_DOCS_MAP: Record<string, string> = {
   web_search: "web-search.md",
   plan_revision: "plan-revision.md",
   install_skill: "install-skill.md",
+  github_issue: "github-issue.md",
   tool_docs: "tool-docs.md",
 };
 

--- a/src/tools/tool-docs.ts
+++ b/src/tools/tool-docs.ts
@@ -30,6 +30,8 @@ const TOOL_DOCS_MAP: Record<string, string> = {
   set_mode: "set-mode.md",
   web_fetch: "web-fetch.md",
   web_search: "web-search.md",
+  plan_revision: "plan-revision.md",
+  install_skill: "install-skill.md",
   tool_docs: "tool-docs.md",
 };
 

--- a/test/github-issue-tool.test.ts
+++ b/test/github-issue-tool.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { Tool, isToolAllowedForMode } from "../src/tools/registry.js";
+import "../src/tools/init.js";
+
+describe("github_issue tool", () => {
+  test("allowed in PLAN mode as read_only", () => {
+    expect(isToolAllowedForMode("github_issue", "PLAN")).toBe(true);
+  });
+
+  test("returns gh install message when gh missing", async () => {
+    const originalProbe = await import("../src/git/gh-cli.js");
+    // If gh is installed in CI, skip strict message test
+    const status = originalProbe.probeGhCli(true);
+    if (status.installed && status.authenticated) {
+      return;
+    }
+
+    const result = await Tool.execute("github_issue", { number: 50 });
+    expect(result.success).toBe(false);
+    if (!status.installed) {
+      expect(result.output).toContain("not installed");
+    } else {
+      expect(result.output).toContain("auth");
+    }
+    expect(result.output).toContain("github.com");
+    expect(result.output).toContain("/issues/50");
+  });
+});

--- a/test/github-repo-context.test.ts
+++ b/test/github-repo-context.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  clearRepoContextCache,
+  formatRepoContextPromptBlock,
+  issueUrlForNumber,
+  parseGitHubOwnerRepo,
+  type RepoContext,
+} from "../src/git/repo-context.js";
+
+function testContext(owner: string, repo: string): RepoContext {
+  const fullName = `${owner}/${repo}`;
+  const webUrl = `https://github.com/${fullName}`;
+  return {
+    owner,
+    repo,
+    fullName,
+    webUrl,
+    issueUrlTemplate: `${webUrl}/issues/{number}`,
+    source: "package.json",
+  };
+}
+
+describe("parseGitHubOwnerRepo", () => {
+  test("parses https github URL", () => {
+    expect(parseGitHubOwnerRepo("https://github.com/spenceriam/impulse")).toEqual({
+      owner: "spenceriam",
+      repo: "impulse",
+    });
+  });
+
+  test("parses https with .git suffix", () => {
+    expect(parseGitHubOwnerRepo("https://github.com/spenceriam/impulse.git")).toEqual({
+      owner: "spenceriam",
+      repo: "impulse",
+    });
+  });
+
+  test("parses git@github.com SSH URL", () => {
+    expect(parseGitHubOwnerRepo("git@github.com:spenceriam/impulse.git")).toEqual({
+      owner: "spenceriam",
+      repo: "impulse",
+    });
+  });
+
+  test("returns null for non-GitHub host", () => {
+    expect(parseGitHubOwnerRepo("https://gitlab.com/foo/bar")).toBeNull();
+  });
+});
+
+describe("formatRepoContextPromptBlock", () => {
+  test("includes owner/repo when context present", () => {
+    const block = formatRepoContextPromptBlock(testContext("spenceriam", "impulse"));
+    expect(block).toContain("spenceriam/impulse");
+    expect(block).toContain("issues/{number}");
+  });
+
+  test("mentions question tool when unknown", () => {
+    const block = formatRepoContextPromptBlock(null);
+    expect(block).toContain("question");
+    expect(block).toContain("Type your own answer");
+  });
+});
+
+describe("issueUrlForNumber", () => {
+  test("builds canonical URL", () => {
+    expect(issueUrlForNumber(testContext("spenceriam", "impulse"), 50)).toBe(
+      "https://github.com/spenceriam/impulse/issues/50"
+    );
+  });
+});
+
+describe("resolveRepoContext cache", () => {
+  beforeEach(() => {
+    clearRepoContextCache();
+  });
+
+  test("clearRepoContextCache does not throw", () => {
+    clearRepoContextCache();
+    expect(true).toBe(true);
+  });
+});

--- a/test/install-skill-source.test.ts
+++ b/test/install-skill-source.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeSkillSource,
+  skillInstructionsPath,
+} from "../src/tools/install-skill-source.js";
+
+describe("normalizeSkillSource", () => {
+  test("rejects repo-only source", () => {
+    const result = normalizeSkillSource("mattpocock/skills");
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toContain("repository");
+    }
+  });
+
+  test("accepts full skill path", () => {
+    const result = normalizeSkillSource(
+      "mattpocock/skills/skills/engineering/grill-with-docs"
+    );
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.source).toBe(
+        "mattpocock/skills/skills/engineering/grill-with-docs"
+      );
+      expect(result.skillSlug).toBe("grill-with-docs");
+    }
+  });
+
+  test("normalizes GitHub tree URL", () => {
+    const result = normalizeSkillSource(
+      "https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs"
+    );
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.source).toBe(
+        "mattpocock/skills/skills/engineering/grill-with-docs"
+      );
+      expect(result.skillSlug).toBe("grill-with-docs");
+    }
+  });
+
+  test("rejects too-short path", () => {
+    const result = normalizeSkillSource("owner/repo");
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("skillInstructionsPath", () => {
+  test("resolves under .agents/skills", () => {
+    expect(skillInstructionsPath("/proj", "grill-with-docs")).toBe(
+      "/proj/.agents/skills/grill-with-docs/SKILL.md"
+    );
+  });
+});

--- a/test/plan-revisions.test.ts
+++ b/test/plan-revisions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  createPlanRevision,
+  getActivePlanRevision,
+  validatePlanWritePath,
+} from "../src/plan/revisions.js";
+import { isToolAllowedForMode } from "../src/tools/registry.js";
+import { getSubagentTools } from "../src/agent/prompts.js";
+
+describe("plan revisions", () => {
+  let tmp: string;
+  const sessionId = "sess_test_123";
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-plan-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("first revision is initial and active", () => {
+    const r1 = createPlanRevision(sessionId, undefined, tmp);
+    expect(r1.meta.revisionId).toBe("initial");
+    expect(r1.meta.active).toBe(true);
+
+    const active = getActivePlanRevision(sessionId, tmp);
+    expect(active?.meta.revisionId).toBe("initial");
+  });
+
+  test("second revision becomes active (latest wins)", () => {
+    createPlanRevision(sessionId, undefined, tmp);
+    const r2 = createPlanRevision(sessionId, { revises: "initial" }, tmp);
+    expect(r2.meta.revises).toBe("initial");
+
+    const active = getActivePlanRevision(sessionId, tmp);
+    expect(active?.meta.revisionId).toBe(r2.meta.revisionId);
+    expect(active?.meta.revisionId).not.toBe("initial");
+  });
+
+  test("validatePlanWritePath allows trio in active revision only", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    const design = rev.files["design.md"]!;
+    expect(validatePlanWritePath(design, sessionId, tmp)).toBeNull();
+
+    const outside = path.join(tmp, "src", "foo.ts");
+    expect(validatePlanWritePath(outside, sessionId, tmp)).toContain("active revision");
+  });
+
+  test("superseded revision files are not writable", () => {
+    const r1 = createPlanRevision(sessionId, undefined, tmp);
+    createPlanRevision(sessionId, { revises: "initial" }, tmp);
+    expect(validatePlanWritePath(r1.files["design.md"]!, sessionId, tmp)).toContain(
+      "active revision"
+    );
+  });
+});
+
+describe("PLAN mode tool surface", () => {
+  test("allows file_edit and web tools for main agent", () => {
+    expect(isToolAllowedForMode("file_edit", "PLAN")).toBe(true);
+    expect(isToolAllowedForMode("web_search", "PLAN")).toBe(true);
+    expect(isToolAllowedForMode("bash", "PLAN")).toBe(false);
+    expect(isToolAllowedForMode("plan_revision", "PLAN")).toBe(true);
+    expect(isToolAllowedForMode("install_skill", "PLAN")).toBe(true);
+  });
+
+  test("explore subagent includes web tools", () => {
+    const tools = getSubagentTools("explore");
+    expect(tools).toContain("web_search");
+    expect(tools).toContain("web_fetch");
+  });
+});

--- a/test/plan-revisions.test.ts
+++ b/test/plan-revisions.test.ts
@@ -4,9 +4,12 @@ import path from "path";
 import os from "os";
 import {
   createPlanRevision,
+  formatRevisionId,
   getActivePlanRevision,
+  listRevisionIds,
   validatePlanWritePath,
 } from "../src/plan/revisions.js";
+import { getRevisionDir } from "../src/plan/paths.js";
 import { isToolAllowedForMode } from "../src/tools/registry.js";
 import { getSubagentTools } from "../src/agent/prompts.js";
 
@@ -56,6 +59,34 @@ describe("plan revisions", () => {
     expect(validatePlanWritePath(r1.files["design.md"]!, sessionId, tmp)).toContain(
       "active revision"
     );
+  });
+
+  test("validatePlanWritePath does not create revision for rejected paths", () => {
+    const outside = path.join(tmp, "src", "foo.ts");
+    expect(validatePlanWritePath(outside, sessionId, tmp)).toContain("active revision");
+    expect(listRevisionIds(sessionId, tmp)).toEqual([]);
+
+    const initialDir = getRevisionDir(sessionId, "initial", tmp);
+    const prd = path.join(initialDir, "PRD.md");
+    expect(validatePlanWritePath(prd, sessionId, tmp)).toContain("PLAN mode allows only");
+    expect(listRevisionIds(sessionId, tmp)).toEqual([]);
+  });
+
+  test("formatRevisionId includes millisecond precision", () => {
+    const id = formatRevisionId(new Date("2026-06-04T12:34:56.789Z"));
+    expect(id).toBe("2026-06-04T12-34-56-789");
+  });
+
+  test("createPlanRevision assigns distinct ids within the same second", () => {
+    const fixed = new Date("2026-06-04T12:34:56.100Z");
+    const r1 = createPlanRevision(sessionId, { revisionId: formatRevisionId(fixed) }, tmp);
+    const r2 = createPlanRevision(
+      sessionId,
+      { revisionId: formatRevisionId(new Date("2026-06-04T12:34:56.200Z")) },
+      tmp
+    );
+    expect(r1.meta.revisionId).not.toBe(r2.meta.revisionId);
+    expect(listRevisionIds(sessionId, tmp)).toEqual([r1.meta.revisionId, r2.meta.revisionId]);
   });
 });
 

--- a/test/session-replay-thinking.test.ts
+++ b/test/session-replay-thinking.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { buildReplaySteps } from "../src/cli/session-replay.js";
+import type { Message } from "../src/session/store.js";
+
+describe("buildReplaySteps thinking duration", () => {
+  test("includes durationMs from thinking_duration_ms", () => {
+    const messages: Message[] = [
+      { role: "user", content: "hi", timestamp: "2026-01-01T00:00:00Z" },
+      {
+        role: "assistant",
+        content: "ok",
+        reasoning_content: "reasoning here",
+        thinking_duration_ms: 4200,
+        timestamp: "2026-01-01T00:00:01Z",
+      },
+    ];
+
+    const steps = buildReplaySteps(messages);
+    const thinking = steps.find((s) => s.type === "thinking");
+    expect(thinking).toBeDefined();
+    if (thinking?.type === "thinking") {
+      expect(thinking.durationMs).toBe(4200);
+      expect(thinking.text).toBe("reasoning here");
+    }
+  });
+});

--- a/test/settings-overlay.test.ts
+++ b/test/settings-overlay.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { settingsValuesEqual } from "../src/cli/components/settings-overlay.js";
+
+describe("settingsValuesEqual", () => {
+  const base = {
+    showMainThinking: true,
+    showSubagentThinking: false,
+    useSubagentModel: false,
+    subagentModel: "ollama/foo",
+  };
+
+  test("detects identical values", () => {
+    expect(settingsValuesEqual(base, { ...base })).toBe(true);
+  });
+
+  test("detects toggle change", () => {
+    expect(
+      settingsValuesEqual(base, { ...base, showMainThinking: false })
+    ).toBe(false);
+  });
+
+  test("treats whitespace-only model id differences as equal", () => {
+    expect(
+      settingsValuesEqual(
+        { ...base, subagentModel: "ollama/foo" },
+        { ...base, subagentModel: " ollama/foo " }
+      )
+    ).toBe(true);
+  });
+
+  test("detects subagent model change", () => {
+    expect(
+      settingsValuesEqual(base, { ...base, subagentModel: "ollama/bar" })
+    ).toBe(false);
+  });
+});

--- a/test/slash-autocomplete.test.ts
+++ b/test/slash-autocomplete.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  completeSlashCommandTab,
+  shouldShowSlashAutocomplete,
+} from "../src/cli/slash-autocomplete.js";
+
+const COMMANDS = [
+  { cmd: "/show", hint: "restore chat" },
+  { cmd: "/show-think", hint: "expand thinking" },
+  { cmd: "/hide-think", hint: "collapse thinking" },
+  { cmd: "/settings", hint: "settings" },
+];
+
+describe("shouldShowSlashAutocomplete", () => {
+  test("lists extension commands when token is an exact shorter match", () => {
+    const result = shouldShowSlashAutocomplete("/show", COMMANDS);
+    expect(result.show).toBe(true);
+    expect(result.matches.map((m) => m.cmd)).toEqual(["/show-think"]);
+  });
+
+  test("lists all prefix matches when token is partial", () => {
+    const result = shouldShowSlashAutocomplete("/sh", COMMANDS);
+    expect(result.show).toBe(true);
+    expect(result.matches.map((m) => m.cmd).sort()).toEqual(["/show", "/show-think"]);
+  });
+
+  test("hides when token is exact and no longer extensions exist", () => {
+    const result = shouldShowSlashAutocomplete("/settings", COMMANDS);
+    expect(result.show).toBe(false);
+  });
+});
+
+describe("completeSlashCommandTab", () => {
+  test("completes unique prefix to full command", () => {
+    const { text } = completeSlashCommandTab("/show-th", COMMANDS, null);
+    expect(text).toBe("/show-think");
+  });
+
+  test("completes /hide to /hide-think", () => {
+    const { text } = completeSlashCommandTab("/hide", COMMANDS, null);
+    expect(text).toBe("/hide-think");
+  });
+
+  test("cycles /show to /show-think on Tab", () => {
+    const first = completeSlashCommandTab("/show", COMMANDS, null);
+    expect(first.text).toBe("/show-think");
+    expect(first.nextCycle?.index).toBe(1);
+
+    const second = completeSlashCommandTab("/show-think", COMMANDS, first.nextCycle);
+    expect(second.text).toBe("/show");
+    expect(second.nextCycle?.index).toBe(0);
+  });
+
+  test("extends partial /sh to /show when shared prefix", () => {
+    const { text } = completeSlashCommandTab("/sh", COMMANDS, null);
+    expect(text).toBe("/show");
+  });
+});

--- a/test/subagent-iterations.test.ts
+++ b/test/subagent-iterations.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { SUBAGENT_MAX_ITERATIONS } from "../src/agent/task-runner.js";
+
+describe("subagent iteration cap", () => {
+  test("SUBAGENT_MAX_ITERATIONS is 150", () => {
+    expect(SUBAGENT_MAX_ITERATIONS).toBe(150);
+  });
+});

--- a/test/task-runner-progress.test.ts
+++ b/test/task-runner-progress.test.ts
@@ -4,38 +4,52 @@ import {
   resolvePreCompleteProgress,
   shouldPublishFinalWrappingUp,
 } from "../src/agent/task-runner.js";
-import { SUBAGENT_PROGRESS_THINKING } from "../src/cli/subagent-progress-labels.js";
+import {
+  SUBAGENT_PROGRESS_THINKING,
+  SUBAGENT_PROGRESS_THINKING_PLACEHOLDER,
+} from "../src/cli/subagent-progress-labels.js";
 
 describe("resolvePreCompleteProgress", () => {
-  test("publishes thinking when no prior tool results and thinking enabled", () => {
+  test("publishes thinking when reasoning capable and detail on", () => {
     const messages: ChatMessage[] = [
       { role: "system", content: "sys" },
       { role: "user", content: "go" },
     ];
-    expect(resolvePreCompleteProgress(messages, true)).toEqual({
+    expect(resolvePreCompleteProgress(messages, true, true)).toEqual({
       type: "thinking",
       content: SUBAGENT_PROGRESS_THINKING,
     });
   });
 
-  test("skips thinking when thinking disabled", () => {
+  test("publishes placeholder when reasoning capable but detail off", () => {
     const messages: ChatMessage[] = [
       { role: "system", content: "sys" },
       { role: "user", content: "go" },
     ];
-    expect(resolvePreCompleteProgress(messages, false)).toBeNull();
+    expect(resolvePreCompleteProgress(messages, true, false)).toEqual({
+      type: "thinking",
+      content: SUBAGENT_PROGRESS_THINKING_PLACEHOLDER,
+    });
   });
 
-  test("after tool results publishes thinking or nothing, not wrapping up", () => {
+  test("skips when reasoning not capable", () => {
+    const messages: ChatMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "go" },
+    ];
+    expect(resolvePreCompleteProgress(messages, false, true)).toBeNull();
+    expect(resolvePreCompleteProgress(messages, false, false)).toBeNull();
+  });
+
+  test("after tool results publishes thinking when capable", () => {
     const messages: ChatMessage[] = [
       { role: "user", content: "go" },
       { role: "assistant", content: "", tool_calls: [] },
       { role: "tool", content: "ok", tool_call_id: "t1" },
     ];
-    expect(resolvePreCompleteProgress(messages, false)).toBeNull();
-    expect(resolvePreCompleteProgress(messages, true)).toEqual({
+    expect(resolvePreCompleteProgress(messages, true, false)).toEqual({
       type: "thinking",
-      content: SUBAGENT_PROGRESS_THINKING,
+      content: SUBAGENT_PROGRESS_THINKING_PLACEHOLDER,
     });
   });
 });

--- a/test/thinking-block.test.ts
+++ b/test/thinking-block.test.ts
@@ -22,7 +22,7 @@ describe("ThinkingBlock", () => {
     expect(block.render(80)[0]).toContain("Thinking...");
     block.finalize(500);
     expect(block.render(80)[0]).toContain("Thought for");
-    expect(block.render(80)[0]).toContain("▶");
+    expect(block.render(80)[0]).not.toContain("▶");
   });
 
   test("placeholder accumulates content for expand after finalize", () => {
@@ -40,7 +40,7 @@ describe("ThinkingBlock", () => {
     const block = new ThinkingBlock();
     block.setText("line one");
     block.finalize(2000);
-    expect(block.render(80)[0]).toContain("▶");
+    expect(block.render(80)[0]).not.toContain("▶");
     block.setExpanded(true);
     const lines = block.render(80);
     expect(lines.some((l) => l.includes("line one"))).toBe(true);

--- a/test/thinking-block.test.ts
+++ b/test/thinking-block.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ThinkingBlock,
+  formatThoughtSummary,
+  isThinkingBlock,
+} from "../src/cli/components/thinking-block.js";
+
+describe("formatThoughtSummary", () => {
+  test("includes duration when provided", () => {
+    expect(formatThoughtSummary(1250)).toBe("Thought for 1.3s");
+  });
+
+  test("falls back without duration", () => {
+    expect(formatThoughtSummary()).toBe("Thought");
+  });
+});
+
+describe("ThinkingBlock", () => {
+  test("placeholder then finalize collapses", () => {
+    const block = new ThinkingBlock();
+    block.setPlaceholder();
+    expect(block.render(80)[0]).toContain("Thinking...");
+    block.finalize(500);
+    expect(block.render(80)[0]).toContain("Thought for");
+    expect(block.render(80)[0]).toContain("▶");
+  });
+
+  test("placeholder accumulates content for expand after finalize", () => {
+    const block = new ThinkingBlock();
+    block.setPlaceholder();
+    block.appendContent("hidden reasoning");
+    expect(block.render(80)[0]).toContain("Thinking...");
+    block.finalize(800);
+    block.setExpanded(true);
+    const lines = block.render(80);
+    expect(lines.some((l) => l.includes("hidden reasoning"))).toBe(true);
+  });
+
+  test("expanded shows body after finalize", () => {
+    const block = new ThinkingBlock();
+    block.setText("line one");
+    block.finalize(2000);
+    expect(block.render(80)[0]).toContain("▶");
+    block.setExpanded(true);
+    const lines = block.render(80);
+    expect(lines.some((l) => l.includes("line one"))).toBe(true);
+    expect(lines[0]).toContain("▼");
+  });
+
+  test("isThinkingBlock type guard", () => {
+    const block = new ThinkingBlock();
+    expect(isThinkingBlock(block)).toBe(true);
+    expect(isThinkingBlock({ invalidate: () => {}, render: () => [] })).toBe(false);
+  });
+});

--- a/test/thinking-block.test.ts
+++ b/test/thinking-block.test.ts
@@ -44,7 +44,8 @@ describe("ThinkingBlock", () => {
     block.setExpanded(true);
     const lines = block.render(80);
     expect(lines.some((l) => l.includes("line one"))).toBe(true);
-    expect(lines[0]).toContain("▼");
+    expect(lines[0]).toContain("Thinking:");
+    expect(lines[0]).not.toContain("▼");
   });
 
   test("isThinkingBlock type guard", () => {


### PR DESCRIPTION
## Summary

Fixes #55

PLAN mode can research the codebase and the web, write spec-driven artifacts under revision-based plan paths, and install single skills non-interactively. Follow-up polish: thinking block collapse, `/show-think` / `/hide-think`, hardened `install_skill`, and higher subagent iteration limits.

## Changes

- **Plan revisions** — `.impulse/plans/<sessionId>/revisions/`; `plan_revision` tool; active revision injected each turn
- **PLAN research** — `web_search` / `web_fetch` on main agent and explore subagents; `file_edit` for plan files in active revision
- **`install_skill`** — `npx skills@latest add -y`; reject repo-only sources; skip when `.agents/skills/<name>/SKILL.md` exists (utility tool, all modes)
- **GitHub** — repository context in system prompt; `github_issue` tool (gh-only)
- **Thinking UI (1.4.1)** — auto-collapse to **Thought for (duration)**; `/show-think` / `/hide-think`; `thinking_duration_ms` on replay
- **Subagents** — max **150** iterations; progress respects reasoning capability + settings
- **Slash / settings** — Tab cycles `/show` vs `/show-think`; **Settings unchanged** when Enter with no edits
- Bump version to **1.4.1** + CHANGELOG + AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PLAN write paths and tool surface changed materially (new revision enforcement, shell-backed `install_skill`/`github_issue`); thinking and subagent behavior affect all modes but are mostly UI/limits with tests.
> 
> **Overview**
> **v1.4.0** reshapes **PLAN** around revision-based artifacts under `.impulse/plans/<sessionId>/revisions/` (latest revision is active context), with new **`plan_revision`**, **`install_skill`**, and **`github_issue`** tools plus **repo/gh prompt blocks** and stricter PLAN writes (`file_edit` allowed only in the active revision). Main and **explore** subagents gain **web research** in PLAN; explore tool lists and prompts are updated accordingly.
> 
> **v1.4.1** polishes **thinking UI**: reasoning phases get **`thinking_duration_ms`**, blocks **auto-collapse** to *Thought for…*, and **`/show-think`** / **`/hide-think`** toggle session-local expand. Subagent caps rise to **150** iterations with progress that respects reasoning capability vs settings detail. **`install_skill`** is hardened (non-interactive `-y`, reject repo-only sources, skip existing `.agents/skills/…`). **`/settings`** reports *Settings unchanged* when nothing toggled; slash **Tab** cycles ambiguous commands (e.g. `/show` ↔ `/show-think`).
> 
> Docs, changelog, version bump to **1.4.1**, and `.gitignore` for `.agents/` / `skills-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fda303bed67827f3dbc3242ec93dcfa443afe9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->