### PR TITLE
feat: shell bang ghost text hint (#59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,18 @@
 ### Identity
 
 - **Name:** impulse
-- **Version:** v1.4.1
+- **Version:** v1.4.2
 - **Tagline:** Provider-flexible terminal AI co-partner agent
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
 
 ## Current State
 
-**Status:** v1.4.1 (2026-06-04) — PLAN research (#55), plan revisions, thinking UI polish, hardened `install_skill`
+**Status:** v1.4.2 (2026-06-04) — Shell bang ghost text hint (#59), PLAN research (#55), plan revisions, thinking UI polish, hardened `install_skill`
+
+### v1.4.2 (2026-06-04)
+
+- [x] Ghost text hint for lone `!` — typing `!` alone shows "type any terminal command" in dim gray (color 238), vanishes on any further input
 
 ### v1.4.1 (2026-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-06-04
+
+  **Type:** patch
+  **Title:** Shell bang ghost text hint
+
+  ### Added
+  - **Ghost text hint for `!`** — typing `!` alone in the prompt shows "type any terminal command" in dim gray, vanishing on any further input
+
 ## [1.4.1] - 2026-06-04
 
   **Type:** patch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/cli/prompt-input.ts
+++ b/src/cli/prompt-input.ts
@@ -769,8 +769,14 @@ export class PromptInput implements Component, Focusable {
       return [truncateGutterLine(ARROW + masked, width)];
     }
 
+    // Ghost text hint for lone ! (shell bang mode indicator)
+    let displayContent = content;
+    if (content === "!") {
+      displayContent += "\x1b[38;5;238m type any terminal command\x1b[0m";
+    }
+
     return [
-      truncateGutterLine(ARROW + content, width),
+      truncateGutterLine(ARROW + displayContent, width),
       ...innerLines.slice(1).map((line) => gutterContent(line, width)),
     ];
   }

--- a/src/cli/prompt-input.ts
+++ b/src/cli/prompt-input.ts
@@ -770,13 +770,16 @@ export class PromptInput implements Component, Focusable {
     }
 
     // Ghost text hint for lone ! (shell bang mode indicator)
-    let displayContent = content;
-    if (content === "!") {
-      displayContent += "\x1b[38;5;238m type any terminal command\x1b[0m";
+    if (this.editor.getText().trim() === "!") {
+      const ghostLine = ARROW + this.editor.getText() + "\x1b[38;5;238m type any terminal command\x1b[0m";
+      return [
+        truncateGutterLine(ghostLine, width),
+        ...innerLines.slice(1).map((line) => gutterContent(line, width)),
+      ];
     }
 
     return [
-      truncateGutterLine(ARROW + displayContent, width),
+      truncateGutterLine(ARROW + content, width),
       ...innerLines.slice(1).map((line) => gutterContent(line, width)),
     ];
   }

--- a/src/cli/prompt-input.ts
+++ b/src/cli/prompt-input.ts
@@ -770,7 +770,7 @@ export class PromptInput implements Component, Focusable {
     }
 
     // Ghost text hint for lone ! (shell bang mode indicator)
-    if (this.editor.getText().trim() === "!") {
+    if (this.editor.getText() === "!") {
       const ghostLine = ARROW + this.editor.getText() + "\x1b[38;5;238m type any terminal command\x1b[0m";
       return [
         truncateGutterLine(ghostLine, width),


### PR DESCRIPTION
## Summary

Fixes #59

When a user types `!` alone in the prompt input, inline ghost text appears: `! type any terminal command` in dim gray (ANSI color 238). The ghost text vanishes the instant the user types any additional character, including a space. Uses raw editor text (`getText()`) to avoid ANSI truncation artifacts from the pi-tui render output.

## Changes

- **Ghost text hint** — `PromptInput.render()` detects lone `!` via `this.editor.getText().trim()` and appends ` type any terminal command` in dim gray inline on the same rendered line
- **ANSI-safe rendering** — builds the ghost line from raw editor text rather than the ANSI-laden render output to prevent `truncateToWidth` from producing `...` ellipsis artifacts
- Bump version to **1.4.2** + CHANGELOG + AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt rendering-only change with no auth, tooling, or execution path impact.
> 
> **Overview**
> Adds an inline **ghost text** hint when the prompt contains only `!`: the first line shows dim gray “type any terminal command” (ANSI 238), built from raw `editor.getText()` so width truncation does not corrupt escape sequences.
> 
> The hint is gated on an exact lone `!` and drops as soon as the user types anything else. Release metadata is bumped to **v1.4.2** (`package.json`, lockfile, `CHANGELOG.md`, `AGENTS.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821328a3e1a131e2b17cecf161edddb451e704d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->