### PR TITLE
fix: ContextBar auto-refreshes on git branch changes (#64)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,19 @@
 ### Identity
 
 - **Name:** impulse
-- **Version:** v1.4.2
+- **Version:** v1.4.3
 - **Tagline:** Provider-flexible terminal AI co-partner agent
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
 
 ## Current State
 
-**Status:** v1.4.2 (2026-06-04) — Shell bang ghost text hint (#59), PLAN research (#55), plan revisions, thinking UI polish, hardened `install_skill`
+**Status:** v1.4.3 (2026-06-05) — ContextBar auto-refreshes on git branch changes (#64)
+
+### v1.4.3 (2026-06-05)
+
+- [x] ContextBar auto-refreshes on git branch changes — command-driven detection for git operations through Impulse + filesystem watcher (`fs.watch` on `.git/HEAD`) to catch external branch switches from separate terminals
+- [x] `BranchEvents.Changed` event on the bus; `GitBranchWatcher` class with worktree support, 500ms debounce, graceful disposal
 
 ### v1.4.2 (2026-06-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-06-05
+
+  **Type:** patch
+  **Title:** ContextBar auto-refreshes on git branch changes
+
+  ### Added
+  - **`BranchEvents.Changed`** event on the bus — signal published when git branch changes
+  - **`detectAndPublishBranchChange`** utility (`src/git/branch-detect.ts`) — parses git commands running through the bash tool or `!command` shell and publishes `branch.changed`
+  - **`GitBranchWatcher`** class (`src/git/branch-watcher.ts`) — filesystem watcher on `.git/HEAD` that catches external branch switches from outside Impulse; debounced at 500ms, worktree-aware
+
+  ### Fixed
+  - **ContextBar** — now auto-refreshes the displayed git branch after `git checkout`/`git switch`/`git branch -m` regardless of whether the command ran through Impulse or a separate terminal (#64)
+
 ## [1.4.2] - 2026-06-04
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -165,6 +165,13 @@ export const SubagentEvents = {
   ),
 };
 
+export const BranchEvents = {
+  Changed: BusEvent.define(
+    "branch.changed",
+    z.object({})
+  ),
+};
+
 export const QueueEvents = {
   Added: BusEvent.define(
     "queue.added",

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -178,7 +178,7 @@ import {
   loadModelsDevCatalog,
 } from "./model-catalog.js";
 import { Bus } from "../bus/index.js";
-import { HeaderEvents, ModeEvents, QuestionEvents, SubagentEvents } from "../bus/events.js";
+import { HeaderEvents, ModeEvents, QuestionEvents, SubagentEvents, BranchEvents } from "../bus/events.js";
 import { PermissionEvents, respond, type PermissionRequest } from "../permission/index.js";
 import { SessionManager } from "../session/manager.js";
 import { abortCurrentBashExecution } from "../tools/bash.js";
@@ -186,6 +186,7 @@ import { rejectQuestion, resolveQuestion, type Question } from "../tools/questio
 import { setCurrentMode } from "../tools/mode-state.js";
 import { normalizeMode } from "../constants.js";
 import type { Mode } from "../constants.js";
+import { GitBranchWatcher } from "../git/branch-watcher.js";
 import packageJson from "../../package.json";
 import * as fs from "fs";
 import * as os from "os";
@@ -1147,6 +1148,7 @@ export class ImpulseRenderer {
   private modelSetupOverlayHandle: OverlayHandle | null = null;
   private profileOverlayHandle: OverlayHandle | null = null;
   private busUnsubscribe: (() => void) | null = null;
+  private branchWatcher: GitBranchWatcher | null = null;
   private liveTurnStartedAt = 0;
   private liveGeneratedChars = 0;
   private lastLiveMetricsAt = 0;
@@ -1279,6 +1281,12 @@ export class ImpulseRenderer {
           });
           this.tui.requestRender();
         }
+      }
+
+      if (event.type === BranchEvents.Changed.name) {
+        this.contextBar.invalidate();
+        this.tui.requestRender();
+        return;
       }
     });
 
@@ -1478,6 +1486,10 @@ export class ImpulseRenderer {
     this.syncVisionFromConfig(config);
     this.syncSpeedoUi();
     this.tui.addChild(this.contextBar);
+
+    // Start git branch filesystem watcher to catch external branch switches
+    this.branchWatcher = new GitBranchWatcher(process.cwd());
+    this.branchWatcher.start();
 
     // ?? Start TUI (takes over terminal raw mode) ??????????????????????????
     this.syncModeColor(); // set initial arrow color
@@ -2361,6 +2373,7 @@ export class ImpulseRenderer {
   private async gracefulExit(): Promise<void> {
     await SessionManager.flushCurrent();
     const session = SessionManager.getCurrentSession();
+    this.branchWatcher?.dispose();
     this.tui.stop();
     if (session?.id) {
       const title =

--- a/src/cli/user-shell.ts
+++ b/src/cli/user-shell.ts
@@ -5,6 +5,7 @@
 import { sanitizePath } from "../util/path.js";
 import { executePty, isPtyAvailable, initPty, type PtyHandle } from "../pty/index.js";
 import { needsInteractiveMode } from "../tools/bash.js";
+import { detectAndPublishBranchChange } from "../git/branch-detect.js";
 
 export interface ShellRunResult {
   command: string;
@@ -111,26 +112,27 @@ export async function runUserShellCommand(options: {
       rows
     );
     activePty = handle;
+    let result: ShellRunResult;
     try {
-      const result = await handle.result;
+      const ptyResult = await handle.result;
       activePty = null;
       activeAbort = null;
       const durationMs = Date.now() - start;
-      return {
+      result = {
         command,
         cwd,
-        stdout: result.output,
+        stdout: ptyResult.output,
         stderr: "",
-        output: result.output || "(no output)",
-        exitCode: result.exitCode,
-        success: result.exitCode === 0,
+        output: ptyResult.output || "(no output)",
+        exitCode: ptyResult.exitCode,
+        success: ptyResult.exitCode === 0,
         durationMs,
       };
     } catch (e) {
       activePty = null;
       activeAbort = null;
       const msg = e instanceof Error ? e.message : String(e);
-      return {
+      result = {
         command,
         cwd,
         stdout: "",
@@ -141,6 +143,11 @@ export async function runUserShellCommand(options: {
         durationMs: Date.now() - start,
       };
     }
+
+    if (result.success) {
+      detectAndPublishBranchChange(command, cwd);
+    }
+    return result;
   }
 
   const usePipedInteractive = interactive && !isPtyAvailable();
@@ -182,7 +189,7 @@ export async function runUserShellCommand(options: {
 
   const output = combined || [stdout, stderr].filter(Boolean).join("\n").trim() || "(no output)";
   const durationMs = Date.now() - start;
-  return {
+  const result = {
     command,
     cwd,
     stdout,
@@ -192,4 +199,9 @@ export async function runUserShellCommand(options: {
     success: exitCode === 0,
     durationMs,
   };
+
+  if (result.success) {
+    detectAndPublishBranchChange(command, cwd);
+  }
+  return result;
 }

--- a/src/git/branch-detect.ts
+++ b/src/git/branch-detect.ts
@@ -17,7 +17,7 @@ import { BranchEvents } from "../bus/events.js";
  */
 const BRANCH_SWITCH_PATTERNS: RegExp[] = [
   // git checkout <branch> (not files: no ".", "--", or explicit path after "checkout")
-  /\bgit\s+checkout\s+(?!\.)(?!--)(?!.*\s+--\s)(.+)/,
+  /\bgit\s+checkout\s+(?!\.)(?!--\s)(?!.*\s+--\s)(.+)/,
   // git switch <branch> (creates or switches)
   /\bgit\s+switch\s+/,
   // git branch -m/-M (rename — may rename the current branch)

--- a/src/git/branch-detect.ts
+++ b/src/git/branch-detect.ts
@@ -1,0 +1,64 @@
+/**
+ * Detect git branch switches from shell commands and publish branch.changed events.
+ *
+ * Called from both the bash tool and user-shell (!command) paths so the
+ * ContextBar can invalidate its branch cache after a checkout/switch/rename.
+ */
+
+import { execSync } from "child_process";
+import { Bus } from "../bus/index.js";
+import { BranchEvents } from "../bus/events.js";
+
+/**
+ * Regex patterns for git commands that switch, create, or rename the current branch.
+ *
+ * We intentionally exclude file/path checkouts (git checkout ., git checkout -- <path>)
+ * because those do not change the branch.
+ */
+const BRANCH_SWITCH_PATTERNS: RegExp[] = [
+  // git checkout <branch> (not files: no ".", "--", or explicit path after "checkout")
+  /\bgit\s+checkout\s+(?!\.)(?!--)(?!.*\s+--\s)(.+)/,
+  // git switch <branch> (creates or switches)
+  /\bgit\s+switch\s+/,
+  // git branch -m/-M (rename — may rename the current branch)
+  /\bgit\s+branch\s+-[mM]\s+/,
+];
+
+/**
+ * Check if a command looks like a branch-switching git operation.
+ */
+function isBranchSwitchCommand(command: string): boolean {
+  const trimmed = command.trim();
+  for (const pattern of BRANCH_SWITCH_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * After a git command completes, check if it was a branch switch and publish a
+ * branch.changed event so the ContextBar can refresh.
+ *
+ * Call this from both the bash tool and user-shell paths.
+ */
+export function detectAndPublishBranchChange(command: string, cwd: string): void {
+  if (!isBranchSwitchCommand(command)) {
+    return;
+  }
+
+  // Verify we're in a git repo and can resolve the branch.
+  // If this fails (no git repo, detached HEAD, error), we skip — no harm done.
+  try {
+    execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 500,
+    });
+  } catch {
+    return;
+  }
+
+  Bus.publish(BranchEvents.Changed, {});
+}

--- a/src/git/branch-watcher.ts
+++ b/src/git/branch-watcher.ts
@@ -1,0 +1,172 @@
+/**
+ * Filesystem watcher that monitors .git/HEAD for branch changes from any source
+ * (Impulse-internal commands or external terminal operations).
+ *
+ * Publishes branch.changed on the event bus when the branch changes, so the
+ * ContextBar can invalidate its cache and re-read the current branch.
+ *
+ * Works alongside command-driven detection (branch-detect.ts) — both converge
+ * on the same branch.changed event for the ContextBar to consume.
+ */
+
+import { existsSync, readFileSync, statSync, watch, type FSWatcher } from "fs";
+import { dirname, join, resolve } from "path";
+import { Bus } from "../bus/index.js";
+import { BranchEvents } from "../bus/events.js";
+
+interface GitPaths {
+  /** The working directory containing the repo (repo root, not .git dir) */
+  repoDir: string;
+  /** The .git directory (or the resolved gitdir for worktrees) */
+  gitDir: string;
+  /** Path to the HEAD file inside gitDir */
+  headPath: string;
+}
+
+/**
+ * Walk up from cwd to find .git.
+ * Handles:
+ * - Regular repos (.git is a directory)
+ * - Worktrees (.git is a file containing "gitdir: /path/to/actual/.git")
+ */
+function findGitPaths(cwd: string): GitPaths | null {
+  let dir = cwd;
+  while (true) {
+    const gitPath = join(dir, ".git");
+    if (existsSync(gitPath)) {
+      try {
+        const stat = statSync(gitPath);
+        if (stat.isFile()) {
+          // Worktree: .git is a file pointing to the real git dir
+          const content = readFileSync(gitPath, "utf8").trim();
+          if (content.startsWith("gitdir: ")) {
+            const realGitDir = resolve(dir, content.slice(8).trim());
+            const headPath = join(realGitDir, "HEAD");
+            if (!existsSync(headPath)) return null;
+            return { repoDir: dir, gitDir: realGitDir, headPath };
+          }
+        } else if (stat.isDirectory()) {
+          const headPath = join(gitPath, "HEAD");
+          if (!existsSync(headPath)) return null;
+          return { repoDir: dir, gitDir: gitPath, headPath };
+        }
+      } catch {
+        return null;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Read .git/HEAD and extract the branch name.
+ *
+ * Returns:
+ * - "main" for "ref: refs/heads/main"
+ * - null for detached HEAD (raw SHA)
+ * - null on error / unreadable
+ */
+function readHeadBranch(headPath: string): string | null {
+  try {
+    const content = readFileSync(headPath, "utf8").trim();
+    if (content.startsWith("ref: refs/heads/")) {
+      return content.slice(16);
+    }
+    // Detached HEAD (raw SHA) — return null (ContextBar shows nothing for this)
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const WATCH_DEBOUNCE_MS = 500;
+
+/**
+ * Watches the git HEAD file's parent directory for changes, debounces, and
+ * publishes branch.changed when the branch differs from the cached value.
+ *
+ * Lifetime: created and started in ImpulseRenderer.start(), disposed in
+ * gracefulExit(). One instance per Impulse session.
+ */
+export class GitBranchWatcher {
+  private cwd: string;
+  private gitPaths: GitPaths | null;
+  private cachedBranch: string | null | undefined = undefined;
+  private watcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(cwd: string) {
+    this.cwd = cwd;
+    this.gitPaths = findGitPaths(cwd);
+  }
+
+  /** Start watching the git HEAD directory. No-op if not in a git repo. */
+  start(): void {
+    if (this.disposed || !this.gitPaths) return;
+
+    // Read initial branch so we don't fire on the first HEAD event
+    this.cachedBranch = readHeadBranch(this.gitPaths.headPath);
+
+    const headDir = dirname(this.gitPaths.headPath);
+
+    try {
+      this.watcher = watch(headDir, { persistent: true, recursive: false }, (_eventType, filename) => {
+        if (!filename || filename !== "HEAD") return;
+        this.scheduleRefresh();
+      });
+      this.watcher.on("error", () => {
+        // fs.watch errors are non-fatal — silently stop watching.
+        // Command-driven detection still works as fallback.
+        this.closeWatcher();
+      });
+    } catch {
+      // fs.watch may throw if the directory is inaccessible.
+      // Silently no-op; command-driven detection still works.
+    }
+  }
+
+  /** Stop watching and clean up. Safe to call multiple times. */
+  dispose(): void {
+    this.disposed = true;
+    this.closeWatcher();
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  private closeWatcher(): void {
+    if (this.watcher) {
+      try {
+        this.watcher.close();
+      } catch {
+        /* ignore */
+      }
+      this.watcher = null;
+    }
+  }
+
+  private scheduleRefresh(): void {
+    if (this.disposed) return;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.refresh();
+    }, WATCH_DEBOUNCE_MS);
+  }
+
+  private refresh(): void {
+    if (this.disposed || !this.gitPaths) return;
+
+    const branch = readHeadBranch(this.gitPaths.headPath);
+    if (branch !== this.cachedBranch) {
+      this.cachedBranch = branch;
+      Bus.publish(BranchEvents.Changed, {});
+    }
+  }
+}

--- a/src/git/branch-watcher.ts
+++ b/src/git/branch-watcher.ts
@@ -114,7 +114,8 @@ export class GitBranchWatcher {
 
     try {
       this.watcher = watch(headDir, { persistent: true, recursive: false }, (_eventType, filename) => {
-        if (!filename || filename !== "HEAD") return;
+        // On Linux, filename is often null for directory watches even when HEAD changes.
+        if (filename != null && filename !== "HEAD") return;
         this.scheduleRefresh();
       });
       this.watcher.on("error", () => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -14,6 +14,7 @@ import {
 import { zCommandString, zFilePath } from "./schemas/branded";
 import { detectPowerShellVersion, translatePosixToPowerShell } from "./posix-translation";
 import { detectShellEnvironment } from "../util/shell-env";
+import { detectAndPublishBranchChange } from "../git/branch-detect";
 
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
@@ -699,20 +700,28 @@ export const bashTool: Tool<BashInput> = Tool.define(
       // Determine if we should use interactive mode
       const shouldUseInteractive = input.interactive ?? needsInteractiveMode(input.command);
       
+      const cwd = input.workdir ? sanitizePath(input.workdir) : process.cwd();
+      let result: ToolResult;
+
       // Use PTY if interactive mode is requested AND PTY is available
       if (shouldUseInteractive && isPtyAvailable()) {
         const toolCallId = generateToolCallId();
         currentAbortController = new AbortController();
         
         try {
-          return await executeWithPty(input, toolCallId, currentAbortController.signal);
+          result = await executeWithPty(input, toolCallId, currentAbortController.signal);
         } finally {
           currentAbortController = null;
         }
+      } else {
+        // Fallback to standard execution
+        result = await executeWithSpawn(input);
       }
-      
-      // Fallback to standard execution
-      return await executeWithSpawn(input);
+
+      if (result.success) {
+        detectAndPublishBranchChange(input.command, cwd);
+      }
+      return result;
       
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary

Fixes #64

When Impulse or the user switches git branches (via \`git checkout\`, \`git switch\`, or \`git branch -m\`), the ContextBar footer now auto-refreshes to show the current branch name. Two detection paths converge on the same event:

1. **Command-driven** — git operations running through Impulse's bash tool or \`!command\` shell are parsed and trigger an immediate refresh
2. **Filesystem watcher** — a new \`GitBranchWatcher\` class monitors \`.git/HEAD\` via \`fs.watch\`, catching branch switches made from separate terminals outside Impulse

## Changes

- **\`BranchEvents.Changed\`** event added to the bus (signal event, no payload)
- **\`src/git/branch-detect.ts\`** — parses git commands for branch-switching patterns, confirms with \`git rev-parse\`, publishes \`branch.changed\`
- **\`src/git/branch-watcher.ts\`** — \`GitBranchWatcher\` class with \`fs.watch\` on \`dirname(.git/HEAD)\`, 500ms debounce, worktree \`gitdir:\` pointer support, graceful disposal on exit
- **\`src/cli/renderer.ts\`** — subscribes to \`branch.changed\`, calls \`contextBar.invalidate()\` + re-render; creates watcher on start, disposes on graceful exit
- **\`src/tools/bash.ts\`** — calls \`detectAndPublishBranchChange\` after successful command execution
- **\`src/cli/user-shell.ts\`** — calls \`detectAndPublishBranchChange\` after successful shell command
- Bump version to **1.4.3** + CHANGELOG + AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized footer/git UX with debounced fs.watch and optional command parsing; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **#64** by keeping the footer **ContextBar** branch label in sync when git HEAD changes, without requiring a manual refresh.
> 
> A new **`branch.changed`** bus event (`BranchEvents.Changed`) drives **`contextBar.invalidate()`** in the renderer. **Command path:** after successful runs in the **bash** tool and **`!`** user shell, **`detectAndPublishBranchChange`** matches `git checkout` / `git switch` / `git branch -m` (not file checkouts), verifies the repo with `git rev-parse`, then publishes. **Filesystem path:** **`GitBranchWatcher`** watches the git **HEAD** file (worktree-aware, 500ms debounce), started at TUI start and disposed on graceful exit.
> 
> Release **1.4.3** with **CHANGELOG** and **AGENTS.md** updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd5c076f5d06ef808726e51ddf0b56d2578b33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->