### PR TITLE
fix: grep EACCES on bundled binary (#63), empty single-file results (#66), and nonexistent path errors (#71)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,19 @@
 ### Identity
 
 - **Name:** impulse
-- **Version:** v1.4.3
+- **Version:** v1.4.4
 - **Tagline:** Provider-flexible terminal AI co-partner agent
 - **Design:** Brutally minimal
 - **License:** AGPL-3.0
 
 ## Current State
 
-**Status:** v1.4.3 (2026-06-05) — ContextBar auto-refreshes on git branch changes (#64)
+**Status:** v1.4.4 (2026-06-05) — grep bug fixes (#63 EACCES, #66 single-file results)
+
+### v1.4.4 (2026-06-05)
+
+- [x] Grep tool #63 — lazy `statSync`/`chmodSync` permission repair on bundled ripgrep binary to fix EACCES
+- [x] Grep tool #66 — added `--with-filename` to ripgrep args so single-file searches return results
 
 ### v1.4.3 (2026-06-05)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,13 @@
 
 ## Current State
 
-**Status:** v1.4.4 (2026-06-05) — grep bug fixes (#63 EACCES, #66 single-file results)
+**Status:** v1.4.4 (2026-06-05) — grep bug fixes (#63 EACCES, #66 single-file results, #71 nonexistent path errors)
 
 ### v1.4.4 (2026-06-05)
 
 - [x] Grep tool #63 — lazy `statSync`/`chmodSync` permission repair on bundled ripgrep binary to fix EACCES
 - [x] Grep tool #66 — added `--with-filename` to ripgrep args so single-file searches return results
+- [x] Grep tool #71 — surface ripgrep stderr when exit code is 2 (nonexistent path, bad regex, IO error); discovered during #66 testing
 
 ### v1.4.3 (2026-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to impulse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.4] - 2026-06-05
+
+  **Type:** patch
+  **Title:** Fix grep tool bugs — EACCES on bundled binary and empty results on single-file search
+
+  ### Fixed
+  - **#63** — EACCES permission denied on bundled ripgrep binary; added lazy permission check and repair (`statSync`/`chmodSync`) before spawn
+  - **#66** — grep returned empty results when searching a single file (vs directory); added `--with-filename` to ripgrep args for consistent `file:line:content` output
+
 ## [1.4.3] - 2026-06-05
 
   **Type:** patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.4.4] - 2026-06-05
 
   **Type:** patch
-  **Title:** Fix grep tool bugs — EACCES on bundled binary and empty results on single-file search
+  **Title:** Fix grep tool bugs — EACCES on bundled binary, empty single-file results, and nonexistent path error handling
 
   ### Fixed
   - **#63** — EACCES permission denied on bundled ripgrep binary; added lazy permission check and repair (`statSync`/`chmodSync`) before spawn
   - **#66** — grep returned empty results when searching a single file (vs directory); added `--with-filename` to ripgrep args for consistent `file:line:content` output
+  - **#71** — grep silently returned success on nonexistent paths (exit code 2 / stderr discarded); now surfaces ripgrep's stderr error as a failure, discovered during #66 testing
 
 ## [1.4.3] - 2026-06-05
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -106,6 +106,16 @@ export const grepTool: Tool<GrepInput> = Tool.define(
         env: process.env,
       });
 
+      // Surface exit-code-2 errors (nonexistent path, bad regex, IO error) that
+      // ripgrep writes to stderr. Exit code 1 (no matches) is not an error.
+      if (result.exitCode === 2) {
+        const stderr = (result.stderr?.toString("utf-8") ?? "").trim();
+        return {
+          success: false,
+          output: stderr || "ripgrep exited with code 2 (unknown error)",
+        };
+      }
+
       const stdout = (result.stdout?.toString("utf-8") ?? "") as string;
       const outputLines = stdout.split("\n").filter((line) => line.trim() !== "");
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { existsSync } from "fs";
+import { chmodSync, existsSync, statSync } from "fs";
 import { dirname } from "path";
 import { Tool, ToolResult } from "./registry";
 import { sanitizePath } from "../util/path";
@@ -71,11 +71,22 @@ export const grepTool: Tool<GrepInput> = Tool.define(
 
       const searchPath = sanitizePath(input.path ?? ".");
 
+      // Ensure binary has execute permissions (fixes EACCES on bundled binaries)
+      try {
+        const stats = statSync(rgPath);
+        if ((stats.mode & 0o111) === 0) {
+          chmodSync(rgPath, stats.mode | 0o111);
+        }
+      } catch {
+        // Can't check or repair — let spawn try and fail with a clear error
+      }
+
       // Build command args properly as array elements
       const cmd = [
         rgPath,
         "--line-number", // Ensure line numbers in output
         "--no-heading", // One result per line (file:line:content)
+        "--with-filename", // Always include filename, even for single-file searches
         "--max-count",
         "10", // Max 10 matches per file to avoid spam
         "-m",


### PR DESCRIPTION
## Summary

Fixes #63, fixes #66, fixes #71

Three grep tool bugs resolved:

1. **#63** — the bundled platform-specific ripgrep binary (`@spenceriam/impulse-darwin-arm64/bin/rg`) may be unpacked without execute permissions, causing `EACCES: permission denied` on every grep call. Added a lazy `statSync`/`chmodSync` check before `Bun.spawnSync` to repair missing `+x` bits.

2. **#66** — grep returned empty results when `path` pointed to a single file (works correctly for directories). Root cause: ripgrep outputs `file:line:content` for directories but only `line:content` for single files. The handler regex expected three colon-separated segments, so single-file output was silently discarded. Added `--with-filename` to always produce consistent `file:line:content` output.

3. **#71** — discovered during #66 testing: grep returned `success: true, matchCount: 0` for nonexistent paths because the handler only read stdout and ignored stderr + exit code. ripgrep exits with code 2 and writes errors to stderr. Now checks `result.exitCode === 2` and surfaces the stderr message as `success: false`.

## Changes

- **`src/tools/grep.ts`**
  - Import `statSync` and `chmodSync` from `fs`
  - Add permission check/repair before `Bun.spawnSync` (#63)
  - Add `--with-filename` to ripgrep args (#66)
  - Check `result.exitCode === 2` and surface stderr as error (#71)
- **`package.json`** — bump version to 1.4.4
- **`CHANGELOG.md`** — v1.4.4 entry with all three fixes
- **`AGENTS.md`** — v1.4.4 status and version listing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized grep spawn/parse changes with no auth or data-path impact; chmod on the bundled binary is a minor packaging side effect.
> 
> **Overview**
> **v1.4.4** patch release that hardens the agent **`grep`** tool around bundled ripgrep.
> 
> Before spawn, the tool lazily checks the resolved `rg` binary and **`chmod`s execute bits** when missing, addressing **EACCES** on packaged installs (#63). Ripgrep args now include **`--with-filename`** so single-file searches emit the same `file:line:content` shape the parser expects, fixing empty results (#66). When ripgrep exits with **code 2**, the handler returns **`success: false`** with **stderr** instead of treating it as zero matches (#71).
> 
> Version and release notes are bumped in **`package.json`**, **`CHANGELOG.md`**, and **`AGENTS.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd0f30081e81339252c793737ab4a1f9f6e90cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->