### PR TITLE
fix: restore source modules omitted from PR #75 merge

### DIFF
--- a/src/agent/build-chat-messages.ts
+++ b/src/agent/build-chat-messages.ts
@@ -1,12 +1,33 @@
 import type { ChatMessage } from "../api/types.js";
 import type { Message } from "../session/store.js";
 
+/** Prefix written by compaction — must reach the provider (not a generic system skip). */
+export const COMPACT_SUMMARY_PREFIX = "Previous conversation summary:";
+
+function isCompactSummaryMessage(m: Message): boolean {
+  return (
+    m.role === "system" &&
+    typeof m.content === "string" &&
+    m.content.startsWith(COMPACT_SUMMARY_PREFIX)
+  );
+}
+
 /** Build provider chat messages from session history (includes preserved reasoning). */
 export function buildChatMessages(
   sessionMessages: Message[],
   systemPrompt: string
 ): ChatMessage[] {
-  const result: ChatMessage[] = [{ role: "system", content: systemPrompt }];
+  const compactSummaries = sessionMessages
+    .filter(isCompactSummaryMessage)
+    .map((m) => m.content.trim())
+    .filter((c) => c.length > 0);
+
+  let mergedSystem = systemPrompt;
+  if (compactSummaries.length > 0) {
+    mergedSystem = `${systemPrompt}\n\n${compactSummaries.join("\n\n")}`;
+  }
+
+  const result: ChatMessage[] = [{ role: "system", content: mergedSystem }];
   for (const m of sessionMessages) {
     if (m.role === "system") continue;
     if (m.role === "user" || m.role === "assistant") {
@@ -26,16 +47,11 @@ export function buildChatMessages(
         }));
       }
       result.push(msg);
-    } else if (m.role === "tool" as string) {
-      const toolMsg = m as unknown as {
-        role: "tool";
-        content: string;
-        tool_call_id: string;
-      };
+    } else if (m.role === "tool" && m.tool_call_id) {
       result.push({
         role: "tool",
-        content: toolMsg.content,
-        tool_call_id: toolMsg.tool_call_id,
+        content: m.content,
+        tool_call_id: m.tool_call_id,
       });
     }
   }

--- a/src/agent/debug-nudge.ts
+++ b/src/agent/debug-nudge.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+
+const DEBUG_MARKER = "[IMPULSE_DEBUG]";
+
+/**
+ * After a DEBUG-mode turn, nudge if edited files still contain debug instrumentation.
+ */
+export function buildDebugInstrumentationNudge(
+  editedFilePaths: string[],
+  cwd = process.cwd()
+): string | undefined {
+  const hits: string[] = [];
+  for (const rel of editedFilePaths) {
+    const full = path.isAbsolute(rel) ? rel : path.join(cwd, rel);
+    try {
+      const content = fs.readFileSync(full, "utf-8");
+      if (content.includes(DEBUG_MARKER)) {
+        hits.push(rel);
+      }
+    } catch {
+      // ignore missing/unreadable paths
+    }
+  }
+  if (hits.length === 0) return undefined;
+  const list = hits.slice(0, 8).join(", ");
+  const more = hits.length > 8 ? ` (+${hits.length - 8} more)` : "";
+  return `Remove ${DEBUG_MARKER} instrumentation before closing this debug pass: ${list}${more}`;
+}

--- a/src/agent/loop-guard.ts
+++ b/src/agent/loop-guard.ts
@@ -1,0 +1,82 @@
+/**
+ * Main-loop iteration guard — detect no-op spirals, check in with user, hard stop at ceiling.
+ */
+
+export const LOOP_GUARD_MAX_ITERATIONS = 120;
+export const LOOP_CHECKIN_MIN_ITERATIONS = 60;
+export const LOOP_CHECKIN_SNOOZE_ITERATIONS = 30;
+export const TODO_ONLY_FORCE_FINAL_THRESHOLD = 4;
+export const PLANNING_FORCE_FINAL_THRESHOLD = 6;
+export const SAME_PATH_WRITE_FORCE_FINAL_THRESHOLD = 4;
+
+export type LoopCheckinDecision = "continue" | "finalize" | "stop";
+
+export interface LoopGuardCounters {
+  loopIteration: number;
+  consecutiveTodoOnlyRounds: number;
+  planningIterations: number;
+  consecutiveSamePathWrites: number;
+  /** Do not prompt again until this iteration count. */
+  checkinSnoozedUntilIteration: number;
+}
+
+export function createLoopGuardCounters(): LoopGuardCounters {
+  return {
+    loopIteration: 0,
+    consecutiveTodoOnlyRounds: 0,
+    planningIterations: 0,
+    consecutiveSamePathWrites: 0,
+    checkinSnoozedUntilIteration: 0,
+  };
+}
+
+export function isHeuristicTripped(counters: LoopGuardCounters): boolean {
+  return (
+    counters.consecutiveTodoOnlyRounds >= TODO_ONLY_FORCE_FINAL_THRESHOLD ||
+    counters.planningIterations >= PLANNING_FORCE_FINAL_THRESHOLD ||
+    counters.consecutiveSamePathWrites >= SAME_PATH_WRITE_FORCE_FINAL_THRESHOLD
+  );
+}
+
+export function heuristicTrippedReason(counters: LoopGuardCounters): string | undefined {
+  if (counters.consecutiveTodoOnlyRounds >= TODO_ONLY_FORCE_FINAL_THRESHOLD) {
+    return `${counters.consecutiveTodoOnlyRounds} consecutive todo-only rounds`;
+  }
+  if (counters.planningIterations >= PLANNING_FORCE_FINAL_THRESHOLD) {
+    return `${counters.planningIterations} non-substantive planning rounds`;
+  }
+  if (counters.consecutiveSamePathWrites >= SAME_PATH_WRITE_FORCE_FINAL_THRESHOLD) {
+    return `${counters.consecutiveSamePathWrites} repeated writes to the same path`;
+  }
+  return undefined;
+}
+
+/** True only at the absolute iteration backstop. */
+export function shouldForceFinal(counters: LoopGuardCounters): boolean {
+  return counters.loopIteration >= LOOP_GUARD_MAX_ITERATIONS;
+}
+
+export function shouldLoopCheckin(counters: LoopGuardCounters): boolean {
+  if (!isHeuristicTripped(counters)) return false;
+  if (counters.loopIteration < LOOP_CHECKIN_MIN_ITERATIONS) return false;
+  if (counters.loopIteration < counters.checkinSnoozedUntilIteration) return false;
+  return true;
+}
+
+export function resetHeuristicCounters(counters: LoopGuardCounters): void {
+  counters.consecutiveTodoOnlyRounds = 0;
+  counters.planningIterations = 0;
+  counters.consecutiveSamePathWrites = 0;
+}
+
+export function snoozeLoopCheckin(counters: LoopGuardCounters): void {
+  counters.checkinSnoozedUntilIteration =
+    counters.loopIteration + LOOP_CHECKIN_SNOOZE_ITERATIONS;
+  resetHeuristicCounters(counters);
+}
+
+export function forceFinalReason(counters: LoopGuardCounters): string {
+  const heuristic = heuristicTrippedReason(counters);
+  if (heuristic) return heuristic;
+  return `${counters.loopIteration} loop iterations`;
+}

--- a/src/agent/tool-call-accumulator.ts
+++ b/src/agent/tool-call-accumulator.ts
@@ -1,0 +1,105 @@
+/**
+ * Accumulate streaming tool_call deltas into complete invocations.
+ * Tool name handling: assign on first chunk, never append unrelated names.
+ */
+
+export interface PartialToolCall {
+  index: number;
+  id: string;
+  name: string;
+  argumentsJson: string;
+}
+
+export interface ToolCallDelta {
+  index?: number | undefined;
+  id?: string | undefined;
+  function?: {
+    name?: string | undefined;
+    arguments?: string | undefined;
+  } | undefined;
+}
+
+function nextFreeIndex(
+  partials: Map<number, PartialToolCall>,
+  requestedIndex: number
+): number {
+  let max = requestedIndex;
+  for (const k of partials.keys()) max = Math.max(max, k);
+  return max + 1;
+}
+
+function isParsableJsonObject(s: string): boolean {
+  const trimmed = s.trim();
+  if (!trimmed.startsWith("{")) return false;
+  try {
+    JSON.parse(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** When a provider reuses the same index for parallel tools, allocate a fresh slot. */
+export function resolveToolCallIndex(
+  partials: Map<number, PartialToolCall>,
+  requestedIndex: number,
+  incomingName: string,
+  incomingArgs: string,
+  incomingId?: string
+): number {
+  const existing = partials.get(requestedIndex);
+  if (!existing) return requestedIndex;
+
+  if (incomingId && existing.id && incomingId !== existing.id) {
+    return nextFreeIndex(partials, requestedIndex);
+  }
+
+  if (!incomingName || !existing.name) return requestedIndex;
+
+  if (incomingName !== existing.name && !incomingName.startsWith(existing.name)) {
+    return nextFreeIndex(partials, requestedIndex);
+  }
+
+  // Same tool name on reused index — parallel call if both send complete JSON objects.
+  if (
+    incomingName === existing.name &&
+    incomingArgs.trimStart().startsWith("{") &&
+    isParsableJsonObject(existing.argumentsJson)
+  ) {
+    return nextFreeIndex(partials, requestedIndex);
+  }
+
+  return requestedIndex;
+}
+
+export function accumulateToolCallDelta(
+  partials: Map<number, PartialToolCall>,
+  tc: ToolCallDelta,
+  callIdFallback: (idx: number) => string
+): void {
+  const requestedIndex = tc.index ?? 0;
+  const incomingName = tc.function?.name ?? "";
+  const incomingArgs = tc.function?.arguments ?? "";
+  const idx = resolveToolCallIndex(
+    partials,
+    requestedIndex,
+    incomingName,
+    incomingArgs,
+    tc.id
+  );
+
+  if (!partials.has(idx)) {
+    partials.set(idx, {
+      index: idx,
+      id: tc.id ?? callIdFallback(idx),
+      name: incomingName,
+      argumentsJson: incomingArgs,
+    });
+    return;
+  }
+
+  const partial = partials.get(idx)!;
+  if (tc.id) partial.id = tc.id;
+  if (incomingName) partial.name = incomingName;
+  if (incomingArgs) partial.argumentsJson += incomingArgs;
+}

--- a/src/cli/components/loop-checkin-overlay.ts
+++ b/src/cli/components/loop-checkin-overlay.ts
@@ -1,0 +1,117 @@
+import { visibleWidth, wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
+import { overlayBoxWidth } from "../layout.js";
+import {
+  intrinsicFramedBoxWidth,
+  measureOverlayTopChromeWidth,
+  overlayBottomBorder,
+  overlayRenderBoxWidth,
+  overlaySideLine,
+  overlayTitleLine,
+  overlayAnsi,
+} from "./overlay-theme.js";
+
+export type LoopCheckinChoice = "continue" | "finalize" | "stop";
+
+const OPTIONS: Array<{ value: LoopCheckinChoice; label: string }> = [
+  { value: "continue", label: "Keep going" },
+  { value: "finalize", label: "Wrap up now" },
+  { value: "stop", label: "Stop turn" },
+];
+
+const A = overlayAnsi;
+
+export class LoopCheckinOverlay implements Component {
+  private reason: string;
+  private iteration: number;
+  private selectedIndex = 0;
+  private measureTerminalWidth: number | null = null;
+
+  onDecision?: (choice: LoopCheckinChoice) => void;
+
+  constructor(input: { reason: string; iteration: number }) {
+    this.reason = input.reason;
+    this.iteration = input.iteration;
+  }
+
+  setMeasureTerminalWidth(cols: number): void {
+    this.measureTerminalWidth = cols;
+  }
+
+  preferredBoxWidth(terminalWidth: number): number {
+    const terminal = this.measureTerminalWidth ?? terminalWidth;
+    const cap = overlayBoxWidth(terminal);
+    const innerWidth = Math.max(8, cap - 4);
+    const plainWidths: number[] = [
+      measureOverlayTopChromeWidth("Loop check-in", 33),
+      visibleWidth(`Impulse appears to be looping (iteration ${this.iteration})`),
+      visibleWidth(`Reason: ${this.reason}`),
+    ];
+    const optionLine = OPTIONS.map((o) => `[ ${o.label} ]`).join("   ");
+    for (const line of wrapTextWithAnsi(optionLine, innerWidth)) {
+      plainWidths.push(visibleWidth(line));
+    }
+    plainWidths.push(visibleWidth("←/→ choose   Enter confirm   Esc stop turn"));
+    return Math.min(cap, intrinsicFramedBoxWidth(terminal, "Loop check-in", plainWidths));
+  }
+
+  invalidate(): void {}
+
+  handleInput(data: string): void {
+    if (data === "\x1b" || data === "\x03") {
+      this.onDecision?.("stop");
+      return;
+    }
+
+    if (data === "\x1b[D") {
+      this.selectedIndex = (this.selectedIndex - 1 + OPTIONS.length) % OPTIONS.length;
+      return;
+    }
+
+    if (data === "\x1b[C" || data === "\t") {
+      this.selectedIndex = (this.selectedIndex + 1) % OPTIONS.length;
+      return;
+    }
+
+    if (data === "\r") {
+      const choice = OPTIONS[this.selectedIndex]!.value;
+      this.onDecision?.(choice);
+    }
+  }
+
+  render(width: number): string[] {
+    const boxWidth = overlayRenderBoxWidth(width);
+    const innerWidth = Math.max(8, boxWidth - 4);
+
+    const lines: string[] = [];
+    lines.push(overlayTitleLine("Loop check-in", boxWidth, 33));
+
+    const pushBoxLine = (content = "") => {
+      lines.push(overlaySideLine(content, innerWidth, boxWidth));
+    };
+
+    pushBoxLine(`${A.bold}Impulse appears to be looping (iteration ${this.iteration})${A.reset}`);
+    for (const line of wrapTextWithAnsi(`Reason: ${this.reason}`, innerWidth)) {
+      pushBoxLine(line);
+    }
+
+    pushBoxLine("");
+
+    const optionLine = OPTIONS.map((option, index) => {
+      const isSelected = index === this.selectedIndex;
+      if (isSelected) {
+        return `${A.bg(39, A.fg(16, ` ${option.label} `))}`;
+      }
+      return `${A.fg(250, `[ ${option.label} ]`)}`;
+    }).join("   ");
+
+    for (const line of wrapTextWithAnsi(optionLine, innerWidth)) {
+      pushBoxLine(line);
+    }
+
+    pushBoxLine("");
+    pushBoxLine(`${A.dim}←/→ choose   Enter confirm   Esc stop turn${A.reset}`);
+    lines.push(overlayBottomBorder(boxWidth));
+
+    return lines;
+  }
+}

--- a/src/cli/components/overlay-scroll-region.ts
+++ b/src/cli/components/overlay-scroll-region.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared vertical viewport slicing for modal overlays.
+ */
+
+export const OVERLAY_SCROLL_FOOTER = "↑↓ scroll · PgUp/PgDn · Home/End";
+
+export interface OverlayScrollSlice {
+  visibleLines: string[];
+  needsScroll: boolean;
+  maxScrollTop: number;
+}
+
+export function sliceOverlayBody(
+  bodyLines: string[],
+  viewportLines: number,
+  scrollTop: number
+): OverlayScrollSlice {
+  const viewport = Math.max(1, viewportLines);
+  const needsScroll = bodyLines.length > viewport;
+  const maxScrollTop = Math.max(0, bodyLines.length - viewport);
+  const top = Math.min(Math.max(0, scrollTop), maxScrollTop);
+  return {
+    visibleLines: bodyLines.slice(top, top + viewport),
+    needsScroll,
+    maxScrollTop,
+  };
+}
+
+export function overlayScrollPageStep(viewportLines: number): number {
+  return Math.max(1, viewportLines - 1);
+}
+
+export function handleOverlayScrollInput(
+  data: string,
+  scrollTop: number,
+  maxScrollTop: number,
+  pageStep: number
+): number | null {
+  if (maxScrollTop === 0) return null;
+
+  if (data === "\x1b[A" || data === "k") {
+    return Math.max(0, scrollTop - 1);
+  }
+  if (data === "\x1b[B" || data === "j") {
+    return Math.min(maxScrollTop, scrollTop + 1);
+  }
+  if (data === "\x1b[5~" || data === "\x1b[b") {
+    return Math.max(0, scrollTop - pageStep);
+  }
+  if (data === "\x1b[6~" || data === "\x1b[f") {
+    return Math.min(maxScrollTop, scrollTop + pageStep);
+  }
+  if (data === "\x1b[H" || data === "\x1bOH" || data === "g") {
+    return 0;
+  }
+  if (data === "\x1b[F" || data === "\x1bOF" || data === "G") {
+    return maxScrollTop;
+  }
+  return null;
+}

--- a/src/cli/components/permission-overlay.ts
+++ b/src/cli/components/permission-overlay.ts
@@ -1,5 +1,6 @@
 import { visibleWidth, wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
 import {
+  getPermissionLabel,
   type PermissionRequest,
   type PermissionResponse,
 } from "../../permission/index.js";
@@ -26,12 +27,18 @@ const A = {
   bg: (code: number, s: string) => `\x1b[48;5;${code}m${s}\x1b[0m`,
 };
 
-const OPTIONS: Array<{ value: PermissionResponse; label: string }> = [
+const BASE_OPTIONS: Array<{ value: PermissionResponse; label: string }> = [
   { value: "reject", label: "Deny" },
   { value: "once", label: "Allow once" },
   { value: "session", label: "Allow session" },
   { value: "always", label: "Always" },
 ];
+
+function sessionOptionLabel(request: PermissionRequest, wildcard: boolean): string {
+  const kind = getPermissionLabel(request.permission).toLowerCase();
+  if (!wildcard) return "Allow session (this only)";
+  return `Allow session (all ${kind})`;
+}
 
 function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
@@ -40,9 +47,14 @@ function stripAnsi(s: string): string {
 export class PermissionOverlay implements Component {
   private request: PermissionRequest;
   private selectedIndex = 1;
+  private sessionWildcard = false;
+  private confirmAlways = false;
   private measureTerminalWidth: number | null = null;
 
-  onDecision?: (response: PermissionResponse) => void;
+  onDecision?: (
+    response: PermissionResponse,
+    opts?: { wildcard?: boolean }
+  ) => void;
 
   constructor(request: PermissionRequest) {
     this.request = request;
@@ -51,6 +63,16 @@ export class PermissionOverlay implements Component {
   setRequest(request: PermissionRequest): void {
     this.request = request;
     this.selectedIndex = 1;
+    this.sessionWildcard = false;
+    this.confirmAlways = false;
+  }
+
+  private options(): Array<{ value: PermissionResponse; label: string }> {
+    return BASE_OPTIONS.map((option) =>
+      option.value === "session"
+        ? { ...option, label: sessionOptionLabel(this.request, this.sessionWildcard) }
+        : option
+    );
   }
 
   setMeasureTerminalWidth(cols: number): void {
@@ -71,7 +93,9 @@ export class PermissionOverlay implements Component {
       plainWidths.push(visibleWidth(`Why: ${why}`));
     }
 
-    const optionLine = OPTIONS.map((o) => `[ ${o.label} ]`).join("   ");
+    const optionLine = this.options()
+      .map((o) => `[ ${o.label} ]`)
+      .join("   ");
     for (const line of wrapTextWithAnsi(optionLine, innerWidth)) {
       plainWidths.push(visibleWidth(line));
     }
@@ -88,35 +112,55 @@ export class PermissionOverlay implements Component {
       return;
     }
 
-    if (data === "\x1b[D" || data === "\x1b[Z") {
-      this.selectedIndex = (this.selectedIndex - 1 + OPTIONS.length) % OPTIONS.length;
+    if (data === "\x1b[Z") {
+      const options = this.options();
+      if (options[this.selectedIndex]?.value === "session") {
+        this.sessionWildcard = !this.sessionWildcard;
+        return;
+      }
+    }
+
+    const optionCount = this.confirmAlways ? 2 : this.options().length;
+
+    if (data === "\x1b[D") {
+      this.selectedIndex = (this.selectedIndex - 1 + optionCount) % optionCount;
       return;
     }
 
     if (data === "\x1b[C" || data === "\t") {
-      this.selectedIndex = (this.selectedIndex + 1) % OPTIONS.length;
+      this.selectedIndex = (this.selectedIndex + 1) % optionCount;
       return;
     }
 
     if (data === "\r") {
-      this.onDecision?.(OPTIONS[this.selectedIndex]!.value);
+      if (this.confirmAlways) {
+        if (this.selectedIndex === 0) {
+          this.onDecision?.("always");
+        } else {
+          this.confirmAlways = false;
+          this.selectedIndex = 1;
+        }
+        return;
+      }
+      const options = this.options();
+      const choice = options[this.selectedIndex]!.value;
+      if (choice === "always") {
+        this.confirmAlways = true;
+        this.selectedIndex = 0;
+        return;
+      }
+      if (choice === "session" && this.sessionWildcard) {
+        this.onDecision?.(choice, { wildcard: true });
+      } else {
+        this.onDecision?.(choice);
+      }
       return;
     }
-
-    const key = data.toLowerCase().trim();
-    if (key === "1") this.selectedIndex = 0;
-    else if (key === "2") this.selectedIndex = 1;
-    else if (key === "3") this.selectedIndex = 2;
-    else if (key === "4") this.selectedIndex = 3;
   }
 
   render(width: number): string[] {
     const boxWidth = overlayRenderBoxWidth(width);
     const innerWidth = Math.max(8, boxWidth - 4);
-
-    const action = formatPermissionAction(this.request);
-    const reason = formatPermissionReason(this.request);
-    const { why } = formatPermissionWhyPolicy(this.request);
 
     const lines: string[] = [];
     lines.push(overlayTitleLine("Permission required", boxWidth, 33));
@@ -124,6 +168,34 @@ export class PermissionOverlay implements Component {
     const pushBoxLine = (content = "") => {
       lines.push(overlaySideLine(content, innerWidth, boxWidth));
     };
+
+    if (this.confirmAlways) {
+      const kind = getPermissionLabel(this.request.permission).toLowerCase();
+      pushBoxLine(`${A.bold}Confirm: always allow ${kind}?${A.reset}`);
+      pushBoxLine("");
+      const confirmOptions = [
+        { label: "Yes", selected: this.selectedIndex === 0 },
+        { label: "Back", selected: this.selectedIndex === 1 },
+      ];
+      const optionLine = confirmOptions
+        .map((option) =>
+          option.selected
+            ? `${A.bg(39, A.fg(16, ` ${option.label} `))}`
+            : `${A.fg(250, `[ ${option.label} ]`)}`
+        )
+        .join("   ");
+      for (const line of wrapTextWithAnsi(optionLine, innerWidth)) {
+        pushBoxLine(line);
+      }
+      pushBoxLine("");
+      pushBoxLine(`${A.dim}←/→ choose   Enter confirm   Esc deny${A.reset}`);
+      lines.push(overlayBottomBorder(boxWidth));
+      return lines;
+    }
+
+    const action = formatPermissionAction(this.request);
+    const reason = formatPermissionReason(this.request);
+    const { why } = formatPermissionWhyPolicy(this.request);
 
     pushBoxLine(`${A.bold}${action}${A.reset}`);
 
@@ -140,7 +212,8 @@ export class PermissionOverlay implements Component {
 
     pushBoxLine("");
 
-    const optionLine = OPTIONS.map((option, index) => {
+    const options = this.options();
+    const optionLine = options.map((option, index) => {
       const isSelected = index === this.selectedIndex;
       if (isSelected) {
         return `${A.bg(39, A.fg(16, ` ${option.label} `))}`;
@@ -153,7 +226,11 @@ export class PermissionOverlay implements Component {
     }
 
     pushBoxLine("");
-    pushBoxLine(`${A.dim}←/→ choose   Enter confirm   Esc deny${A.reset}`);
+    const sessionSelected = options[this.selectedIndex]?.value === "session";
+    const footer = sessionSelected
+      ? "←/→ choose   Shift+Tab: this only ↔ all   Enter confirm   Esc deny"
+      : "←/→ choose   Enter confirm   Esc deny";
+    pushBoxLine(`${A.dim}${footer}${A.reset}`);
     lines.push(overlayBottomBorder(boxWidth));
 
     return lines;

--- a/src/cli/format-helpers.ts
+++ b/src/cli/format-helpers.ts
@@ -18,6 +18,11 @@ export function dimRuleIndented(terminalWidth: number, indent = 2): string {
   return `${DIM}${" ".repeat(indent)}${"─".repeat(inner)}${RESET}`;
 }
 
+/** Bracketed duration for tool summary rows — distinct from tool output. */
+export function formatDurationBracketed(durationMs: number): string {
+  return `[${formatDurationMs(durationMs)}]`;
+}
+
 /** Format elapsed duration for tool rows, speedometer, etc. */
 export function formatDurationMs(durationMs: number): string {
   if (durationMs < 100) {

--- a/src/cli/markdown-table.ts
+++ b/src/cli/markdown-table.ts
@@ -59,10 +59,16 @@ export function slashCommandsToTable(defs: SlashCommandDef[]): MarkdownTable {
   };
 }
 
+function unescapeTableCell(cell: string): string {
+  return cell.replace(/\\\|/g, "|");
+}
+
 function splitTableRow(line: string): string[] {
   const trimmed = line.trim();
   const withoutOuter = trimmed.replace(/^\|/, "").replace(/\|$/, "");
-  return withoutOuter.split("|").map((cell) => cell.trim());
+  return withoutOuter
+    .split(/(?<!\\)\|/)
+    .map((cell) => unescapeTableCell(cell.trim()));
 }
 
 function isTableCandidate(line: string): boolean {
@@ -128,9 +134,11 @@ export function tableTotalWidth(widths: number[]): number {
   return widths.reduce((sum, width) => sum + width, 0) + widths.length * 3 + 1;
 }
 
+const TABLE_MIN_COLUMN_WIDTH = 8;
+
 export function tableColumnWidths(table: MarkdownTable, maxWidth?: number): number[] {
   const formatted = formatTable(table);
-  return formatted.header.map((header, column) => {
+  const widths = formatted.header.map((header, column) => {
     const rowMax = formatted.rows.reduce(
       (max, row) => Math.max(max, visibleWidth(row[column] ?? "")),
       0
@@ -139,6 +147,24 @@ export function tableColumnWidths(table: MarkdownTable, maxWidth?: number): numb
     const maxColWidth = maxWidth ? Math.floor(maxWidth * 0.8) : 120;
     return Math.max(3, Math.min(maxColWidth, naturalWidth));
   });
+
+  if (!maxWidth) return widths;
+
+  while (tableTotalWidth(widths) > maxWidth) {
+    let widest = TABLE_MIN_COLUMN_WIDTH;
+    let widestIndex = -1;
+    for (let index = 0; index < widths.length; index += 1) {
+      const width = widths[index]!;
+      if (width > TABLE_MIN_COLUMN_WIDTH && width > widest) {
+        widest = width;
+        widestIndex = index;
+      }
+    }
+    if (widestIndex < 0) break;
+    widths[widestIndex] = widths[widestIndex]! - 1;
+  }
+
+  return widths;
 }
 
 function renderBorder(left: string, middle: string, right: string, widths: number[]): string {

--- a/src/cli/model-catalog.ts
+++ b/src/cli/model-catalog.ts
@@ -87,6 +87,20 @@ let catalogCache: { loadedAt: number; data: CatalogData } | null = null;
 let globalIndex: Map<string, { bucket: string; record: ModelsDevRecord }> | null =
   null;
 
+/** Per-model-family fallback when catalog/discovery cannot resolve context window. */
+export function defaultContextWindowForModel(modelId: string): number {
+  const bare = (
+    modelId.includes("/") ? modelId.split("/").slice(1).join("/") : modelId
+  ).toLowerCase();
+
+  if (/gemini.*2\.|gemini-2|1[\s._-]?m|million/.test(bare)) return 1_000_000;
+  if (/claude.*opus|200k|sonnet-4|opus-4/.test(bare)) return 200_000;
+  if (/32k|gpt-3\.5|gpt-35/.test(bare)) return 32_768;
+  if (/8k|gpt-4-0314/.test(bare)) return 8_192;
+  // Most current flagship / coding models (128k-class)
+  return 128_000;
+}
+
 export function formatContextK(tokens: number): string {
   if (tokens >= 1_000_000) {
     const m = tokens / 1_000_000;

--- a/src/cli/model-setup.ts
+++ b/src/cli/model-setup.ts
@@ -84,6 +84,17 @@ export function providerConfig(config: Config, providerKey: string): StoredProvi
   return providers[providerKey] ?? {};
 }
 
+/** Whether stored config is sufficient to use a built-in provider. */
+export function isStoredProviderConfigured(
+  providerKey: string,
+  stored: StoredProviderConfig
+): boolean {
+  if (providerKey === "ollama") {
+    return !!(stored.apiKey || stored.baseUrl);
+  }
+  return !!stored.apiKey;
+}
+
 /** Configured custom provider keys (excludes built-in provider keys). */
 export function listConfiguredCustomProviderKeys(config: Config): string[] {
   const providers = (config.providers as Record<string, StoredProviderConfig | undefined>) ?? {};
@@ -436,14 +447,67 @@ export function modelUsesProvider(model: string | undefined, providerKey: string
   return model === providerKey || model.startsWith(prefix);
 }
 
+const BUILTIN_PROVIDER_LABELS: Record<string, string> = {
+  "z.ai": "Z.ai",
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  groq: "Groq",
+  gemini: "Google Gemini",
+  nous: "Nous Research",
+};
+
+export function builtinProviderLabel(key: string): string {
+  return (
+    MODEL_PROVIDERS.find((p) => p.key === key)?.label ??
+    BUILTIN_PROVIDER_LABELS[key] ??
+    key
+  );
+}
+
+/** Configured providers for /model picker (custom + env/file builtins). */
+export function listConfiguredProviderKeysForPicker(
+  config: Config
+): Array<{ providerKey: string; provider: ModelProviderOption }> {
+  const entries: Array<{ providerKey: string; provider: ModelProviderOption }> = [];
+  const seen = new Set<string>();
+
+  for (const key of listConfiguredCustomProviderKeys(config)) {
+    const stored = providerConfig(config, key);
+    if (!isStoredProviderConfigured(key, stored)) continue;
+    seen.add(key);
+    entries.push({ providerKey: key, provider: resolveCustomProviderOption(key, config) });
+  }
+
+  for (const key of KNOWN_PROVIDER_KEYS) {
+    if (seen.has(key)) continue;
+    const stored = providerConfig(config, key);
+    if (!isStoredProviderConfigured(key, stored)) continue;
+    const template = MODEL_PROVIDERS.find((p) => !p.isCustom && p.key === key);
+    entries.push({
+      providerKey: key,
+      provider:
+        template ??
+        ({
+          key,
+          label: builtinProviderLabel(key),
+          envVar: "",
+          defaultModel: "",
+          modelBaseUrl: "",
+        } satisfies ModelProviderOption),
+    });
+  }
+
+  return entries;
+}
+
 export function countConfiguredProviders(config: Config): number {
   let n = 0;
   for (const key of listConfiguredCustomProviderKeys(config)) {
-    if (providerConfig(config, key).apiKey) n++;
+    if (isStoredProviderConfigured(key, providerConfig(config, key))) n++;
   }
   for (const mp of MODEL_PROVIDERS) {
     if (mp.isCustom) continue;
-    if (providerConfig(config, mp.key).apiKey) n++;
+    if (isStoredProviderConfigured(mp.key, providerConfig(config, mp.key))) n++;
   }
   return n;
 }

--- a/src/cli/overlay-height.ts
+++ b/src/cli/overlay-height.ts
@@ -17,3 +17,17 @@ export function overlayMaxHeightForContent(
   const desired = Math.max(minHeight, contentLineCount);
   return Math.min(desired, available);
 }
+
+/** Max overlay height from terminal viewport only (no content pre-measure). */
+export function overlayViewportMaxHeight(
+  terminalRows: number,
+  reservedBottom: number = PERMISSION_OVERLAY_RESERVED_BOTTOM,
+  opts?: { min?: number; topMargin?: number }
+): number {
+  return overlayMaxHeightForContent(
+    terminalRows,
+    Number.MAX_SAFE_INTEGER,
+    reservedBottom,
+    opts
+  );
+}

--- a/src/cli/prompt-input.ts
+++ b/src/cli/prompt-input.ts
@@ -166,10 +166,16 @@ export function buildSubmitPayload(editorText: string, groups: PasteGroup[]): Pr
   };
 }
 
+/** Normalize line endings from bracketed paste / speech-to-text input. */
+export function normalizePasteContent(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
 /** Chat transcript / history text: expand collapsed paste tokens to full apiText. */
 export function userTranscriptText(payload: PromptSubmitPayload): string {
   const hasTextPaste = payload.segments.some((s) => s.kind === "paste");
-  return hasTextPaste ? payload.apiText : payload.displayMessage;
+  const text = hasTextPaste ? payload.apiText : payload.displayMessage;
+  return text.includes("\r") ? normalizePasteContent(text) : text;
 }
 
 export class PromptInput implements Component, Focusable {
@@ -677,7 +683,7 @@ export class PromptInput implements Component, Focusable {
 
   private _finalizePaste(): void {
     this._isPasting = false;
-    const content = this._pasteBuffer;
+    const content = normalizePasteContent(this._pasteBuffer);
     this._pasteBuffer = "";
 
     const lines = content.split("\n").filter((l) => l.length > 0);

--- a/src/cli/startup-flags.ts
+++ b/src/cli/startup-flags.ts
@@ -1,0 +1,25 @@
+/**
+ * CLI startup flags parsed before TUI init.
+ */
+
+export interface StartupFlags {
+  allowAllOnStartup: boolean;
+}
+
+export function parseStartupFlags(argv: string[]): { flags: StartupFlags; argv: string[] } {
+  let allowAllOnStartup =
+    argv.includes("--aa") ||
+    argv.includes("--allow-all") ||
+    process.env["IMPULSE_ALLOW_ALL"] === "1";
+
+  const argvOut: string[] = [];
+  for (const arg of argv) {
+    if (arg === "--aa" || arg === "--allow-all") continue;
+    argvOut.push(arg);
+  }
+
+  return {
+    flags: { allowAllOnStartup },
+    argv: argvOut,
+  };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,23 @@ export function normalizeMode(mode?: string): Mode {
   return LEGACY_MODE_MAP[mode.toUpperCase()] ?? "AGENT";
 }
 
+/** User-facing mode label. WORK is a legacy alias mapped to AGENT in normalizeMode. */
+export function displayModeLabel(mode: Mode | string): string {
+  return normalizeMode(mode);
+}
+
+/** Default execution mode — omitted from context bar (implicit). */
+export function isDefaultMode(mode: Mode | string): boolean {
+  return normalizeMode(mode) === "AGENT";
+}
+
+/** Modes shown in /mode help and Tab cycling. */
+export const MODE_CYCLE: Mode[] = ["AGENT", "EXPLORE", "PLAN", "DEBUG"];
+
+export function displayModeOptions(): string {
+  return MODE_CYCLE.map(displayModeLabel).join(" | ");
+}
+
 /** Friendly display names for known provider models. */
 export const MODEL_DISPLAY_NAMES: Record<string, string> = {
   "z.ai/glm-4.7": "Z.ai GLM 4.7",

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -33,7 +33,19 @@ class SessionManagerImpl {
       const payload = event.properties as { sessionID?: unknown; session?: unknown };
       if (payload.sessionID !== this.currentSession?.id) return;
 
-      this.currentSession = payload.session as Session;
+      const incoming = payload.session as Session;
+      const current = this.currentSession;
+      if (!current) {
+        this.currentSession = incoming;
+        return;
+      }
+
+      if (incoming.messages.length < current.messages.length) {
+        this.currentSession = { ...incoming, messages: current.messages };
+        return;
+      }
+
+      this.currentSession = incoming;
     });
   }
 
@@ -166,17 +178,27 @@ class SessionManagerImpl {
     // consolidated per-turn so the session on disk always reflects a
     // complete conversation state rather than mid-turn snapshots.
     SessionStoreInstance.autoSave(this.currentSession.id, { messages });
+    CompactManager.invalidateCache(this.currentSession.id);
 
-    const messageIndex = messages.length - 1;
-    const summary = message.role === "user" ? message.content.slice(0, 100) : undefined;
+    await CompactManager.maybeCompact(this.currentSession.id);
+  }
 
-    await CheckpointManager.createCheckpoint(
+  /** Git checkpoint at current message index (explicit /checkpoint or experimental undo). */
+  async createCheckpoint(summary?: string): Promise<boolean> {
+    if (!this.currentSession) {
+      return false;
+    }
+
+    const messageIndex = this.currentSession.messages.length - 1;
+    if (messageIndex < 0) {
+      return false;
+    }
+
+    return await CheckpointManager.createCheckpoint(
       this.currentSession.id,
       messageIndex,
       summary
     );
-
-    await CompactManager.maybeCompact(this.currentSession.id);
   }
 
   async flushCurrent(): Promise<void> {

--- a/src/session/token-estimate.ts
+++ b/src/session/token-estimate.ts
@@ -1,0 +1,56 @@
+/**
+ * Unified token estimation for context %, auto-compact, and loop gates.
+ */
+
+import type { ChatMessage, ToolDefinition } from "../api/types.js";
+import type { Message } from "./store.js";
+export const CHARS_PER_TOKEN = 3.5;
+
+/** System prompt + tool-definition overhead when full request shape is unavailable. */
+export const SESSION_BASE_OVERHEAD_TOKENS = 5000;
+
+export function estimateTokensFromSerialized(value: unknown): number {
+  return Math.ceil(JSON.stringify(value).length / CHARS_PER_TOKEN);
+}
+
+export function estimateRequestTokens(
+  messages: ChatMessage[],
+  tools: ToolDefinition[] = []
+): number {
+  return estimateTokensFromSerialized({
+    messages,
+    ...(tools.length > 0 ? { tools } : {}),
+  });
+}
+
+/** Session messages only (no system prompt / tool defs) — footer fallback before first API turn. */
+export function estimateSessionMessagesTokens(messages: Message[]): number {
+  return estimateTokensFromSerialized(messages);
+}
+
+export function estimateSessionContextTokens(
+  messages: Message[],
+  overheadTokens = SESSION_BASE_OVERHEAD_TOKENS
+): number {
+  return overheadTokens + estimateSessionMessagesTokens(messages);
+}
+
+export function computeContextPct(tokens: number, contextWindow: number): number {
+  if (contextWindow <= 0) return 0;
+  return Math.max(0, Math.min(1, tokens / contextWindow));
+}
+
+export function applySafetyMargin(tokens: number, margin: number): number {
+  return Math.ceil(tokens * margin);
+}
+
+/** Prefer provider prompt_tokens for footer context fill. */
+export function resolveFooterContextTokens(opts: {
+  promptTokens: number | undefined;
+  estimatedTokens: number;
+}): number {
+  if (opts.promptTokens !== undefined && opts.promptTokens > 0) {
+    return opts.promptTokens;
+  }
+  return opts.estimatedTokens;
+}

--- a/src/session/turn-active.ts
+++ b/src/session/turn-active.ts
@@ -1,0 +1,11 @@
+/** True while the agent loop is executing a user turn (skip mid-turn auto-compact). */
+
+let turnActive = false;
+
+export function setAgentTurnActive(active: boolean): void {
+  turnActive = active;
+}
+
+export function isAgentTurnActive(): boolean {
+  return turnActive;
+}

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { resolve, relative, isAbsolute } from "path";
-import { sanitizePath } from "../util/path";
+import { resolveToolPath } from "./resolve-tool-path.js";
 import { ask as askPermission } from "../permission";
 import { Bus } from "../bus";
 import { 
@@ -15,6 +15,10 @@ import { zCommandString, zFilePath } from "./schemas/branded";
 import { detectPowerShellVersion, translatePosixToPowerShell } from "./posix-translation";
 import { detectShellEnvironment } from "../util/shell-env";
 import { detectAndPublishBranchChange } from "../git/branch-detect";
+import { SessionManager } from "../session/manager";
+
+/** Default bash/PTY timeout per docs/tools/bash.md */
+const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
@@ -354,11 +358,11 @@ function encodePowerShellCommand(command: string): string {
 
 async function getSpawnOptions(
   input: BashInput,
+  cwd: string,
   options: { interactive?: boolean } = {}
 ): Promise<SpawnOptions> {
-  const cwd = input.workdir ? sanitizePath(input.workdir) : undefined;
   const common: SpawnOptions = {
-    ...(cwd ? { cwd } : {}),
+    cwd,
     env: process.env,
     cmd: [],
   };
@@ -410,6 +414,10 @@ export function needsPermission(command: string, workdir?: string): { needed: bo
     return { needed: true, reason: "High-risk command" };
   }
 
+  if (classification === "unknown") {
+    return { needed: true, reason: "Unrecognized command — approval required" };
+  }
+
   for (const path of extractPaths(command)) {
     if (!isWithinCwd(path, cwd)) {
       return { needed: true, reason: `Path outside working directory: ${path}` };
@@ -437,9 +445,9 @@ export function getActivePtyHandle(toolCallId: string): PtyHandle | undefined {
 async function executeWithPty(
   input: BashInput,
   toolCallId: string,
-  abortSignal: AbortSignal
+  abortSignal: AbortSignal,
+  cwd: string
 ): Promise<ToolResult> {
-  const cwd = input.workdir ? sanitizePath(input.workdir) : process.cwd();
   const startTime = Date.now();
   
   let lastOutput = "";
@@ -474,7 +482,7 @@ async function executeWithPty(
   };
   
   try {
-    const spawnOptions = process.platform === "win32" ? await getSpawnOptions(input, { interactive: true }) : undefined;
+    const spawnOptions = process.platform === "win32" ? await getSpawnOptions(input, cwd, { interactive: true }) : undefined;
     const ptyOptions = spawnOptions
       ? (() => {
           const [shell, ...args] = spawnOptions.cmd;
@@ -502,8 +510,28 @@ async function executeWithPty(
     activePtyHandles.set(toolCallId, handle);
     Bus.emit(PtyEvents.Started, { toolCallId, pid: handle.pid });
     
-    // Wait for result
-    const result = await handle.result;
+    const timeoutMs = input.timeout ?? DEFAULT_BASH_TIMEOUT_MS;
+    let timedOut = false;
+    const result = await new Promise<{ output: string; exitCode: number; pid?: number }>((resolve) => {
+      const timer = setTimeout(() => {
+        timedOut = true;
+        try {
+          handle.kill();
+        } catch {
+          /* ignore */
+        }
+        resolve({
+          output: lastOutput,
+          exitCode: -1,
+          pid: handle.pid,
+        });
+      }, timeoutMs);
+
+      void handle.result.then((ptyResult) => {
+        clearTimeout(timer);
+        if (!timedOut) resolve(ptyResult);
+      });
+    });
     
     // Clean up handle
     activePtyHandles.delete(toolCallId);
@@ -518,6 +546,10 @@ async function executeWithPty(
       output += `\n[Output truncated to ${maxLines} lines]`;
     }
     
+    if (timedOut) {
+      output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
+    }
+
     return {
       success: result.exitCode === 0,
       output: output || "Command completed successfully.",
@@ -557,10 +589,10 @@ async function executeWithPty(
 /**
  * Execute command with standard Bun.spawn (non-interactive, host-shell aware)
  */
-async function executeWithSpawn(input: BashInput): Promise<ToolResult> {
+async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResult> {
   const startTime = Date.now();
   const maxLines = 2000;
-  const spawnOptions = await getSpawnOptions(input);
+  const spawnOptions = await getSpawnOptions(input, cwd);
 
   const proc = Bun.spawn({
     cmd: spawnOptions.cmd,
@@ -684,7 +716,7 @@ export const bashTool: Tool<BashInput> = Tool.define(
       
       if (permCheck.needed) {
         await askPermission({
-          sessionID: "current",
+          sessionID: SessionManager.getCurrentSessionID() ?? "unknown",
           permission: "bash",
           patterns: [input.command],
           message: input.description || `Execute: ${input.command.slice(0, 50)}...`,
@@ -703,7 +735,9 @@ export const bashTool: Tool<BashInput> = Tool.define(
       // Determine if we should use interactive mode
       const shouldUseInteractive = input.interactive ?? needsInteractiveMode(input.command);
       
-      const cwd = input.workdir ? sanitizePath(input.workdir) : process.cwd();
+      const cwd = input.workdir
+        ? await resolveToolPath(input.workdir, "bash")
+        : process.cwd();
       let result: ToolResult;
 
       // Use PTY if interactive mode is requested AND PTY is available
@@ -712,13 +746,13 @@ export const bashTool: Tool<BashInput> = Tool.define(
         currentAbortController = new AbortController();
         
         try {
-          result = await executeWithPty(input, toolCallId, currentAbortController.signal);
+          result = await executeWithPty(input, toolCallId, currentAbortController.signal, cwd);
         } finally {
           currentAbortController = null;
         }
       } else {
         // Fallback to standard execution
-        result = await executeWithSpawn(input);
+        result = await executeWithSpawn(input, cwd);
       }
 
       if (result.success) {

--- a/src/tools/parse-tool-args.ts
+++ b/src/tools/parse-tool-args.ts
@@ -1,0 +1,50 @@
+/**
+ * Parse tool call argument JSON from providers. Some models emit keys like
+ * `"context: "value"` instead of `"context": "value"`.
+ */
+export function repairToolArgumentsJson(json: string): string {
+  let repaired = json.trim();
+  if (!repaired) return repaired;
+
+  // `"context: "` → `"context": "` (and similar bare keys)
+  repaired = repaired.replace(/"([a-zA-Z_][a-zA-Z0-9_]*):\s/g, '"$1": ');
+
+  return repaired;
+}
+
+export function parseToolCallArguments(json: string): {
+  args: Record<string, unknown>;
+  repaired: boolean;
+  parseError?: string;
+} {
+  const trimmed = json.trim();
+  if (!trimmed) {
+    return { args: {}, repaired: false };
+  }
+
+  try {
+    return {
+      args: JSON.parse(trimmed) as Record<string, unknown>,
+      repaired: false,
+    };
+  } catch (firstError) {
+    const repairedJson = repairToolArgumentsJson(trimmed);
+    if (repairedJson !== trimmed) {
+      try {
+        return {
+          args: JSON.parse(repairedJson) as Record<string, unknown>,
+          repaired: true,
+        };
+      } catch {
+        // fall through
+      }
+    }
+
+    return {
+      args: { raw: trimmed },
+      repaired: repairedJson !== trimmed,
+      parseError:
+        firstError instanceof Error ? firstError.message : String(firstError),
+    };
+  }
+}

--- a/src/tools/question-dedup.ts
+++ b/src/tools/question-dedup.ts
@@ -1,0 +1,94 @@
+import type { Message } from "../session/store.js";
+
+export function normalizeQuestionTopic(topic: string): string {
+  return topic.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+/** Dedup key: same tab label can host a different question later in the session. */
+export function questionAnswerKey(topic: string, question: string): string {
+  return `${normalizeQuestionTopic(topic)}\0${normalizeQuestionTopic(question)}`;
+}
+
+function parseAnswerLines(content: string): Map<string, string[]> {
+  const answers = new Map<string, string[]>();
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("Note:") || trimmed.startsWith("Context:")) continue;
+    const colon = trimmed.indexOf(":");
+    if (colon <= 0) continue;
+    const topic = trimmed.slice(0, colon).trim();
+    const answer = trimmed.slice(colon + 1).trim();
+    if (!topic || !answer || answer === "(no selection)") continue;
+    answers.set(normalizeQuestionTopic(topic), answer.split(",").map((s) => s.trim()));
+  }
+  return answers;
+}
+
+/** Link assistant question tool_calls to tool results (topic + question text → answers). */
+export function priorAnsweredQuestionsFromSession(messages: Message[]): {
+  byAnswerKey: Map<string, string[]>;
+} {
+  const byAnswerKey = new Map<string, string[]>();
+
+  const resultByCallId = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role === "tool" && message.tool_call_id) {
+      resultByCallId.set(message.tool_call_id, message.content ?? "");
+    }
+  }
+
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.tool_calls) continue;
+    for (const call of message.tool_calls) {
+      if (call.tool !== "question" || !call.id) continue;
+      const result = resultByCallId.get(call.id);
+      if (!result) continue;
+      if (!result.includes("User responded:") && !result.includes("User already answered")) {
+        continue;
+      }
+
+      const answerLines = parseAnswerLines(result);
+      const args = call.arguments;
+      const questions = args["questions"];
+      if (!Array.isArray(questions)) continue;
+
+      for (const entry of questions) {
+        if (typeof entry !== "object" || entry === null) continue;
+        const topic = typeof entry.topic === "string" ? entry.topic : "";
+        const questionText = typeof entry.question === "string" ? entry.question : "";
+        if (!topic || !questionText) continue;
+        const answers = answerLines.get(normalizeQuestionTopic(topic)) ?? [];
+        if (answers.length === 0) continue;
+        byAnswerKey.set(questionAnswerKey(topic, questionText), answers);
+      }
+    }
+  }
+
+  return { byAnswerKey };
+}
+
+export function lookupPriorAnswer(
+  question: { topic: string; question: string },
+  prior: { byAnswerKey: Map<string, string[]> }
+): string[] | undefined {
+  return prior.byAnswerKey.get(questionAnswerKey(question.topic, question.question));
+}
+
+export function partitionQuestionsByPriorAnswers<T extends { topic: string; question: string }>(
+  questions: T[],
+  prior: { byAnswerKey: Map<string, string[]> }
+): { unanswered: T[]; cachedAnswers: string[][] } {
+  const unanswered: T[] = [];
+  const cachedAnswers: string[][] = [];
+
+  for (const question of questions) {
+    const existing = lookupPriorAnswer(question, prior);
+    if (existing && existing.length > 0) {
+      cachedAnswers.push(existing);
+    } else {
+      unanswered.push(question);
+    }
+  }
+
+  return { unanswered, cachedAnswers };
+}

--- a/src/tools/resolve-tool-path.ts
+++ b/src/tools/resolve-tool-path.ts
@@ -1,0 +1,70 @@
+import path from "path";
+import { sanitizePath, SecurityError } from "../util/path.js";
+import { isAllowAllBypass, ask as askPermission } from "../permission/index.js";
+import { SessionManager } from "../session/manager.js";
+
+export class OutsideCwdError extends Error {
+  constructor(
+    readonly filePath: string,
+    readonly cwd: string
+  ) {
+    super(`Blocked: ${filePath} is outside the working directory (${cwd})`);
+    this.name = "OutsideCwdError";
+  }
+}
+
+function isOutsideCwd(targetPath: string, cwd: string): boolean {
+  const absoluteTarget = path.resolve(targetPath);
+  const absoluteCwd = path.resolve(cwd);
+  const relativePath = path.relative(absoluteCwd, absoluteTarget);
+  return relativePath.startsWith("..") || path.isAbsolute(relativePath);
+}
+
+/**
+ * Resolve a tool path with cwd policy: --aa allows outside cwd; otherwise prompt once per directory.
+ */
+export async function resolveToolPath(
+  filePath: string,
+  toolName: string,
+  baseDir: string = process.cwd()
+): Promise<string> {
+  const resolved = path.isAbsolute(filePath)
+    ? path.resolve(filePath)
+    : path.resolve(baseDir, filePath);
+
+  if (!isOutsideCwd(resolved, baseDir)) {
+    try {
+      return sanitizePath(filePath, { baseDir });
+    } catch (err) {
+      if (err instanceof SecurityError) {
+        throw err;
+      }
+      throw err;
+    }
+  }
+
+  if (isAllowAllBypass()) {
+    return sanitizePath(filePath, { baseDir, allowOutsideCwd: true });
+  }
+
+  const sessionID = SessionManager.getCurrentSessionID() ?? "unknown";
+  const grantPattern = path.dirname(resolved);
+
+  try {
+    await askPermission({
+      sessionID,
+      permission: "path_outside_cwd",
+      patterns: [grantPattern],
+      message: `Access path outside working directory: ${resolved}?`,
+      metadata: {
+        path: resolved,
+        cwd: baseDir,
+        tool: toolName,
+        reason: `Access files outside ${baseDir}`,
+      },
+    });
+    return sanitizePath(filePath, { baseDir, allowOutsideCwd: true });
+  } catch {
+    throw new OutsideCwdError(filePath, baseDir);
+  }
+}

--- a/src/tools/set-header.ts
+++ b/src/tools/set-header.ts
@@ -51,6 +51,18 @@ export const setHeader: Tool<SetHeaderInput> = Tool.define(
         };
       }
 
+      const currentTitle = SessionManager.getCurrentSession()?.headerTitle;
+      if (currentTitle === title) {
+        return {
+          success: true,
+          output: "Header unchanged.",
+          metadata: {
+            title,
+            unchanged: true,
+          },
+        };
+      }
+
       await SessionManager.setHeaderTitle(title);
       Bus.publish(HeaderEvents.Updated, { title });
 

--- a/src/tools/silent-tools.ts
+++ b/src/tools/silent-tools.ts
@@ -1,0 +1,6 @@
+/** Tools that should not render output in the chat transcript (renderer + replay). */
+export const SILENT_TOOLS = new Set(["set_header", "todo_read"]);
+
+export function isSilentTool(name: string): boolean {
+  return SILENT_TOOLS.has(name);
+}

--- a/src/tools/todo-write.ts
+++ b/src/tools/todo-write.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
+import { batchCompletionNote, countPendingToCompleted } from "../agent/repeat-notes";
 import { Tool, ToolResult } from "./registry";
 import { Todo } from "../session/todo";
 
-const DESCRIPTION = `Create or update the session todo list.
+const DESCRIPTION = `The session todo list is live progress UI shown to the user — keep statuses truthful in real time.
 
 Required: todos array with id, content, status, priority.
-See docs/tools/todo-write.md for usage rules.`;
+
+Rules:
+- Mark a todo in_progress BEFORE starting work on it (exactly ONE in_progress at a time)
+- Mark completed IMMEDIATELY after finishing each item — never batch completions at end of turn
+- Only mark completed when actually done (verified); if blocked, keep in_progress and add a follow-up todo
+- Before ending your turn: every item must be completed or cancelled — never leave stale in_progress/pending for work you already finished`;
 
 const TodoWriteSchema = z.object({
   todos: z.array(z.object({
@@ -18,21 +24,56 @@ const TodoWriteSchema = z.object({
 
 type TodoWriteInput = z.infer<typeof TodoWriteSchema>;
 
+function todoSemanticKey(todo: { content: string; status: string }): string {
+  return `${todo.content}\0${todo.status}`;
+}
+
+function todosSemanticallyEqual(
+  current: Array<{ content: string; status: string }>,
+  incoming: Array<{ content: string; status: string }>
+): boolean {
+  if (current.length !== incoming.length) return false;
+  const a = current.map(todoSemanticKey).sort();
+  const b = incoming.map(todoSemanticKey).sort();
+  return a.every((key, index) => key === b[index]);
+}
+
 export const todoWrite: Tool<TodoWriteInput> = Tool.define(
   "todo_write",
   DESCRIPTION,
   TodoWriteSchema,
   async (input: TodoWriteInput): Promise<ToolResult> => {
     try {
+      const current = await Todo.get();
+      if (todosSemanticallyEqual(current, input.todos)) {
+        return {
+          success: true,
+          output: "Todos unchanged.",
+          metadata: {
+            type: "todo",
+            source: "write",
+            unchanged: true,
+            todos: input.todos,
+            total: input.todos.length,
+            remaining: input.todos.filter(
+              (t) => t.status !== "completed" && t.status !== "cancelled"
+            ).length,
+          },
+        };
+      }
+
       await Todo.update(input.todos as Todo[]);
 
       const incompleteCount = input.todos.filter(
         (t) => t.status !== "completed" && t.status !== "cancelled"
       ).length;
 
+      const batchNote =
+        batchCompletionNote(countPendingToCompleted(current, input.todos)) ?? "";
+
       return {
         success: true,
-        output: `Todo list updated. ${incompleteCount} tasks remaining.`,
+        output: `Todo list updated. ${incompleteCount} tasks remaining.${batchNote}`,
         metadata: {
           type: "todo",
           source: "write",

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -108,6 +108,8 @@ export interface TaskMetadata {
 export interface TodoMetadata {
   type: "todo";
   source: "read" | "write";
+  /** True when todo_write received an identical list — no write performed. */
+  unchanged?: boolean;
   todos: Array<{
     id: string;
     content: string;

--- a/src/util/debug-log.ts
+++ b/src/util/debug-log.ts
@@ -38,6 +38,14 @@ export async function enableDebugLog(): Promise<string> {
 }
 
 /**
+ * Disable debug logging and clear the active session log path.
+ */
+export function disableDebugLog(): void {
+  debugEnabled = false;
+  sessionLogPath = null;
+}
+
+/**
  * Check if debug logging is enabled
  */
 export function isDebugEnabled(): boolean {
@@ -134,9 +142,21 @@ export async function logToolExecution(
 /**
  * Log an API request
  */
+function contentLengthForLog(content: unknown): number {
+  if (typeof content === "string") return content.length;
+  if (Array.isArray(content)) return JSON.stringify(content).length;
+  return 0;
+}
+
+function contentPreviewForLog(content: unknown): string | null {
+  if (typeof content === "string") return content.slice(0, 200);
+  if (Array.isArray(content)) return JSON.stringify(content).slice(0, 200);
+  return null;
+}
+
 export async function logAPIRequest(
   model: string,
-  messages: Array<{ role: string; content?: string | null }>,
+  messages: Array<{ role: string; content?: unknown }>,
   tools?: unknown[]
 ): Promise<void> {
   await appendLog({
@@ -144,10 +164,10 @@ export async function logAPIRequest(
     timestamp: new Date().toISOString(),
     model,
     messageCount: messages.length,
-    messages: messages.map(m => ({
+    messages: messages.map((m) => ({
       role: m.role,
-      contentLength: typeof m.content === "string" ? m.content.length : 0,
-      contentPreview: typeof m.content === "string" ? m.content.slice(0, 200) : null,
+      contentLength: contentLengthForLog(m.content),
+      contentPreview: contentPreviewForLog(m.content),
     })),
     toolCount: tools?.length || 0,
   });
@@ -198,7 +218,12 @@ export async function logError(
  * Log raw API messages being sent
  */
 export async function logRawAPIMessages(
-  messages: Array<{ role: string; content?: string | null; reasoning_content?: string; tool_calls?: unknown[] }>
+  messages: Array<{
+    role: string;
+    content?: unknown;
+    reasoning_content?: string | undefined;
+    tool_calls?: unknown[] | undefined;
+  }>
 ): Promise<void> {
   await appendLog({
     type: "raw_api_messages",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -91,5 +91,11 @@ export async function error(message: string): Promise<void> {
   console.error(message);
 }
 
+/** Write error to log file only (no stderr — safe during TUI sessions). */
+export async function fileError(message: string): Promise<void> {
+  const entry = formatLogEntry("error", message);
+  await writeToLogFile(entry);
+}
+
 export type { LogLevel };
 

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -49,7 +49,23 @@ function advisorPlansDir(): string {
   return path.join(os.homedir(), ".impulse", "advisor-plans");
 }
 
-function sanitizePath(filePath: string, baseDir: string = process.cwd()): string {
+export type SanitizePathOptions = {
+  baseDir?: string;
+  /** Skip cwd containment (explicit permission or --aa); symlink checks still apply when inside cwd. */
+  allowOutsideCwd?: boolean;
+};
+
+function sanitizePath(
+  filePath: string,
+  baseDirOrOptions: string | SanitizePathOptions = process.cwd()
+): string {
+  const options: SanitizePathOptions =
+    typeof baseDirOrOptions === "string"
+      ? { baseDir: baseDirOrOptions }
+      : baseDirOrOptions;
+  const baseDir = options.baseDir ?? process.cwd();
+  const allowOutsideCwd = options.allowOutsideCwd === true;
+
   const resolved = path.isAbsolute(filePath)
     ? path.resolve(filePath)
     : path.resolve(baseDir, filePath);
@@ -63,6 +79,10 @@ function sanitizePath(filePath: string, baseDir: string = process.cwd()): string
     }
   } catch {
     // plans dir may not exist yet
+  }
+
+  if (allowOutsideCwd) {
+    return resolveWithExistingAncestors(resolved);
   }
 
   const normalizedBaseDir = path.resolve(baseDir);
@@ -81,4 +101,4 @@ function sanitizePath(filePath: string, baseDir: string = process.cwd()): string
   return realPath;
 }
 
-export { sanitizePath, SecurityError };
+export { sanitizePath, SecurityError, isWithinBase };

--- a/test/abort-interruption.test.ts
+++ b/test/abort-interruption.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { SessionManager } from "../src/session/manager.js";
+import {
+  INTERRUPTION_MARKER,
+  TOOL_CANCELLED_BY_USER,
+  answeredToolCallIds,
+  finalizeAbortedTurn,
+  lastAssistantWithToolCalls,
+} from "../src/agent/abort-interruption.js";
+
+const assistantWithToolCalls = {
+  role: "assistant" as const,
+  content: "Running tools",
+  tool_calls: [
+    {
+      id: "call_done",
+      tool: "bash",
+      arguments: { command: "echo done" },
+      timestamp: new Date().toISOString(),
+    },
+    {
+      id: "call_pending",
+      tool: "bash",
+      arguments: { command: "echo pending" },
+      timestamp: new Date().toISOString(),
+    },
+  ],
+  timestamp: new Date().toISOString(),
+};
+
+describe("abort interruption", () => {
+  beforeEach(async () => {
+    await SessionManager.createNew("abort-interruption-test");
+  });
+
+  afterEach(async () => {
+    await SessionManager.exitCurrent();
+  });
+
+  test("answeredToolCallIds collects tool result ids", () => {
+    const ids = answeredToolCallIds([
+      { role: "tool", content: "ok", tool_call_id: "a", timestamp: "" },
+      { role: "user", content: "hi", timestamp: "" },
+    ]);
+    expect(ids.has("a")).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("finalizeAbortedTurn persists partial text and interruption marker", async () => {
+    await finalizeAbortedTurn({
+      iterationText: "Partial reply before cancel",
+      iterationAssistantPersisted: false,
+    });
+
+    const messages = SessionManager.getCurrentSession()?.messages ?? [];
+    expect(messages.some((m) => m.role === "assistant" && m.content.includes("Partial reply"))).toBe(
+      true
+    );
+    expect(messages.some((m) => m.role === "user" && m.content === INTERRUPTION_MARKER)).toBe(true);
+  });
+
+  test("finalizeAbortedTurn fills synthetic results for dangling tool_calls", async () => {
+    await SessionManager.addMessage(assistantWithToolCalls);
+    await SessionManager.addMessage({
+      role: "tool",
+      content: "done",
+      tool_call_id: "call_done",
+      timestamp: new Date().toISOString(),
+    });
+
+    await finalizeAbortedTurn({
+      iterationText: "",
+      iterationAssistantPersisted: true,
+    });
+
+    const messages = SessionManager.getCurrentSession()?.messages ?? [];
+    const pendingResult = messages.find(
+      (m) => m.role === "tool" && m.tool_call_id === "call_pending"
+    );
+    expect(pendingResult?.content).toBe(TOOL_CANCELLED_BY_USER);
+    expect(messages.some((m) => m.role === "user" && m.content === INTERRUPTION_MARKER)).toBe(true);
+  });
+
+  test("lastAssistantWithToolCalls finds the latest assistant with tools", async () => {
+    await SessionManager.addMessage({ role: "user", content: "go", timestamp: "" });
+    await SessionManager.addMessage(assistantWithToolCalls);
+    const messages = SessionManager.getCurrentSession()?.messages ?? [];
+    expect(lastAssistantWithToolCalls(messages)?.tool_calls).toHaveLength(2);
+  });
+});

--- a/test/agent/build-chat-messages.test.ts
+++ b/test/agent/build-chat-messages.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChatMessages,
+  COMPACT_SUMMARY_PREFIX,
+} from "../../src/agent/build-chat-messages.js";
+import type { Message } from "../../src/session/store.js";
+
+describe("buildChatMessages", () => {
+  test("forwards reasoning_content on assistant messages", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        role: "assistant",
+        content: "hi",
+        reasoning_content: "internal plan: check tests first",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "system");
+    expect(chat).toHaveLength(3);
+    expect(chat[0]?.role).toBe("system");
+    expect(chat[2]?.role).toBe("assistant");
+    expect(chat[2]?.reasoning_content).toBe("internal plan: check tests first");
+  });
+
+  test("omits empty reasoning_content", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "ok",
+        reasoning_content: "   ",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "sys");
+    const assistant = chat.find((m) => m.role === "assistant");
+    expect(assistant?.reasoning_content).toBeUndefined();
+  });
+
+  test("forwards tool result messages with tool_call_id", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            tool: "file_read",
+            arguments: { path: "a.ts" },
+            timestamp: new Date().toISOString(),
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      },
+      {
+        role: "tool",
+        content: "file contents",
+        tool_call_id: "call_1",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "sys");
+    const toolMsg = chat.find((m) => m.role === "tool");
+    expect(toolMsg).toEqual({
+      role: "tool",
+      content: "file contents",
+      tool_call_id: "call_1",
+    });
+  });
+
+  test("merges compact summary system messages into the system prompt", () => {
+    const messages: Message[] = [
+      {
+        role: "system",
+        content: `${COMPACT_SUMMARY_PREFIX}\n\nUser wanted API client tests.`,
+        timestamp: new Date().toISOString(),
+      },
+      {
+        role: "user",
+        content: "continue",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const chat = buildChatMessages(messages, "You are impulse.");
+    expect(chat).toHaveLength(2);
+    expect(chat[0]?.role).toBe("system");
+    expect(chat[0]?.content).toContain("You are impulse.");
+    expect(chat[0]?.content).toContain(COMPACT_SUMMARY_PREFIX);
+    expect(chat[0]?.content).toContain("API client tests");
+  });
+});

--- a/test/agent/token-estimate.test.ts
+++ b/test/agent/token-estimate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applySafetyMargin,
+  computeContextPct,
+  estimateRequestTokens,
+  resolveFooterContextTokens,
+  SESSION_BASE_OVERHEAD_TOKENS,
+} from "../../src/session/token-estimate.js";
+import { SAFETY_MARGIN, CONTEXT_WRAPUP_THRESHOLD } from "../../src/session/compact.js";
+
+describe("token-estimate", () => {
+  test("computeContextPct clamps to 0-1", () => {
+    expect(computeContextPct(50_000, 100_000)).toBe(0.5);
+    expect(computeContextPct(150_000, 100_000)).toBe(1);
+  });
+
+  test("applySafetyMargin uses SAFETY_MARGIN constant", () => {
+    expect(applySafetyMargin(100_000, SAFETY_MARGIN)).toBe(
+      Math.ceil(100_000 * SAFETY_MARGIN)
+    );
+  });
+
+  test("resolveFooterContextTokens prefers prompt_tokens only", () => {
+    expect(
+      resolveFooterContextTokens({ promptTokens: 42_000, estimatedTokens: 50_000 })
+    ).toBe(42_000);
+    expect(
+      resolveFooterContextTokens({ estimatedTokens: 50_000 })
+    ).toBe(50_000);
+  });
+
+  test("hard cutoff gate: safety-adjusted estimate at or above window triggers", () => {
+    const contextWindow = 100_000;
+    const finalEstimate = 87_000;
+    const finalSafety = applySafetyMargin(finalEstimate, SAFETY_MARGIN);
+    expect(finalSafety).toBeGreaterThanOrEqual(contextWindow);
+    expect(finalEstimate).toBeLessThan(contextWindow);
+  });
+
+  test("wrap-up threshold constant", () => {
+    expect(CONTEXT_WRAPUP_THRESHOLD).toBe(0.8);
+  });
+
+  test("estimateRequestTokens includes tools in payload", () => {
+    const without = estimateRequestTokens([{ role: "user", content: "hi" }], []);
+    const withTools = estimateRequestTokens(
+      [{ role: "user", content: "hi" }],
+      [{ type: "function", function: { name: "bash", description: "run", parameters: {} } }]
+    );
+    expect(withTools).toBeGreaterThan(without);
+  });
+
+  test("SESSION_BASE_OVERHEAD_TOKENS is positive", () => {
+    expect(SESSION_BASE_OVERHEAD_TOKENS).toBeGreaterThan(0);
+  });
+});

--- a/test/agent/tool-call-accumulator.test.ts
+++ b/test/agent/tool-call-accumulator.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  accumulateToolCallDelta,
+  type PartialToolCall,
+} from "../../src/agent/tool-call-accumulator.js";
+
+function freshMap(): Map<number, PartialToolCall> {
+  return new Map();
+}
+
+const idFor = (idx: number) => `call_${idx}`;
+
+describe("accumulateToolCallDelta", () => {
+  test("single tool call on index 0", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(
+      map,
+      { index: 0, id: "a", function: { name: "set_header", arguments: '{"title":"x"}' } },
+      idFor,
+    );
+    expect(map.size).toBe(1);
+    expect(map.get(0)?.name).toBe("set_header");
+  });
+
+  test("parallel tools with duplicate index 0 split into separate slots", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(
+      map,
+      { index: 0, function: { name: "todo_write", arguments: '{"todos":[]}' } },
+      idFor,
+    );
+    accumulateToolCallDelta(
+      map,
+      { index: 0, function: { name: "bash", arguments: '{"command":"ls"}' } },
+      idFor,
+    );
+    accumulateToolCallDelta(
+      map,
+      { index: 0, function: { name: "set_header", arguments: '{"title":"t"}' } },
+      idFor,
+    );
+    expect(map.size).toBe(3);
+    expect(map.get(0)?.name).toBe("todo_write");
+    expect(map.get(1)?.name).toBe("bash");
+    expect(map.get(2)?.name).toBe("set_header");
+  });
+
+  test("does not merge set_header and question into set_headerquestion", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(
+      map,
+      { index: 0, function: { name: "set_header", arguments: '{"title":"t"}' } },
+      idFor,
+    );
+    accumulateToolCallDelta(
+      map,
+      { index: 0, function: { name: "question", arguments: '{"questions":[]}' } },
+      idFor,
+    );
+    expect(map.get(0)?.name).toBe("set_header");
+    expect(map.get(1)?.name).toBe("question");
+  });
+
+  test("streams name prefix on same index", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(map, { index: 0, function: { name: "set_" } }, idFor);
+    accumulateToolCallDelta(map, { index: 0, function: { name: "set_header" } }, idFor);
+    expect(map.size).toBe(1);
+    expect(map.get(0)?.name).toBe("set_header");
+  });
+
+  test("appends argument fragments on same index", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(map, { index: 0, function: { name: "bash", arguments: '{"cmd":' } }, idFor);
+    accumulateToolCallDelta(map, { index: 0, function: { arguments: '"ls"}' } }, idFor);
+    expect(map.get(0)?.argumentsJson).toBe('{"cmd":"ls"}');
+  });
+
+  test("parallel file_read on duplicate index 0 does not merge args", () => {
+    const map = freshMap();
+    accumulateToolCallDelta(
+      map,
+      {
+        index: 0,
+        id: "call_a",
+        function: { name: "file_read", arguments: '{"filePath":"a.md"}' },
+      },
+      idFor
+    );
+    accumulateToolCallDelta(
+      map,
+      {
+        index: 0,
+        id: "call_b",
+        function: { name: "file_read", arguments: '{"filePath":"b.md"}' },
+      },
+      idFor
+    );
+    expect(map.size).toBe(2);
+    expect(map.get(0)?.argumentsJson).toBe('{"filePath":"a.md"}');
+    expect(map.get(1)?.argumentsJson).toBe('{"filePath":"b.md"}');
+  });
+});

--- a/test/allow-all-nudge.test.ts
+++ b/test/allow-all-nudge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import {
+  ALLOW_ALL_TODO_NUDGE_MESSAGE,
+  isTodoOnlyToolBatch,
+  shouldInjectAllowAllTodoNudge,
+} from "../src/agent/allow-all-nudge.js";
+import { isTodoWriteRealUpdate } from "../src/agent/todo-progress.js";
+import { resetAllowAllBypass, setAllowAllBypass } from "../src/permission/index.js";
+
+describe("allow-all todo nudge", () => {
+  afterEach(() => {
+    resetAllowAllBypass();
+  });
+  test("isTodoOnlyToolBatch recognizes todo_write and todo_read only", () => {
+    expect(isTodoOnlyToolBatch(["todo_write"])).toBe(true);
+    expect(isTodoOnlyToolBatch(["todo_read", "todo_write"])).toBe(true);
+    expect(isTodoOnlyToolBatch(["todo_write", "bash"])).toBe(false);
+  });
+
+  test("isTodoWriteRealUpdate distinguishes changed vs unchanged output", () => {
+    expect(isTodoWriteRealUpdate("todo_write", "Todo list updated. 3 tasks remaining.")).toBe(true);
+    expect(isTodoWriteRealUpdate("todo_write", "Todos unchanged.")).toBe(false);
+    expect(isTodoWriteRealUpdate("bash", "Todo list updated.")).toBe(false);
+  });
+
+  test("message defers to the user on conflict", () => {
+    expect(ALLOW_ALL_TODO_NUDGE_MESSAGE).toContain("follow the user's message");
+  });
+
+  test("shouldInjectAllowAllTodoNudge requires bypass and two consecutive todo-only rounds", () => {
+    expect(
+      shouldInjectAllowAllTodoNudge({
+        consecutiveTodoOnlyRounds: 2,
+        nudgeUsed: false,
+      })
+    ).toBe(false);
+
+    setAllowAllBypass(true);
+    expect(
+      shouldInjectAllowAllTodoNudge({
+        consecutiveTodoOnlyRounds: 1,
+        nudgeUsed: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldInjectAllowAllTodoNudge({
+        consecutiveTodoOnlyRounds: 2,
+        nudgeUsed: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/test/bash-permission.test.ts
+++ b/test/bash-permission.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCommand, needsPermission } from "../src/tools/bash.js";
+
+describe("bash permission policy", () => {
+  test("unknown commands require approval", () => {
+    expect(classifyCommand("mystery-cli --foo")).toBe("unknown");
+    expect(needsPermission("mystery-cli --foo").needed).toBe(true);
+  });
+
+  test("safe read-only commands within cwd do not require approval", () => {
+    expect(needsPermission("ls -la").needed).toBe(false);
+  });
+});

--- a/test/debug-log.test.ts
+++ b/test/debug-log.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import {
+  disableDebugLog,
+  enableDebugLog,
+  getDebugLogPath,
+  isDebugEnabled,
+  logAPIRequest,
+} from "../src/util/debug-log.js";
+
+describe("debug log JSONL", () => {
+  test("enableDebugLog writes api_request entries", async () => {
+    disableDebugLog();
+    const path = await enableDebugLog();
+    expect(isDebugEnabled()).toBe(true);
+    expect(path).toContain("session-");
+    expect(path.endsWith(".jsonl")).toBe(true);
+
+    await logAPIRequest("test-model", [{ role: "user", content: "hello" }], []);
+
+    const jsonl = await fs.readFile(path, "utf-8");
+    expect(jsonl).toContain('"type":"api_request"');
+    expect(jsonl).toContain('"messageCount":1');
+
+    disableDebugLog();
+    expect(isDebugEnabled()).toBe(false);
+    expect(getDebugLogPath()).toBeNull();
+
+    await fs.unlink(path);
+  });
+});

--- a/test/debug-nudge.test.ts
+++ b/test/debug-nudge.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { buildDebugInstrumentationNudge } from "../src/agent/debug-nudge.js";
+
+describe("debug instrumentation nudge", () => {
+  test("returns undefined when no markers remain", () => {
+    const dir = mkdtempSync(join(tmpdir(), "impulse-debug-"));
+    const file = join(dir, "clean.ts");
+    writeFileSync(file, "export const x = 1;\n");
+    expect(buildDebugInstrumentationNudge([file], dir)).toBeUndefined();
+  });
+
+  test("flags files that still contain IMPULSE_DEBUG", () => {
+    const dir = mkdtempSync(join(tmpdir(), "impulse-debug-"));
+    const file = join(dir, "dirty.ts");
+    writeFileSync(file, 'console.error("[IMPULSE_DEBUG] probe");\n');
+    const nudge = buildDebugInstrumentationNudge(["dirty.ts"], dir);
+    expect(nudge).toContain("[IMPULSE_DEBUG]");
+    expect(nudge).toContain("dirty.ts");
+  });
+});

--- a/test/github-issue-tool.test.ts
+++ b/test/github-issue-tool.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import { Tool, isToolAllowedForMode } from "../src/tools/registry.js";
+import { probeGhCli } from "../src/git/gh-cli.js";
 import "../src/tools/init.js";
+
+const ghReady = probeGhCli(true);
 
 describe("github_issue tool", () => {
   test("allowed in PLAN mode as read_only", () => {
     expect(isToolAllowedForMode("github_issue", "PLAN")).toBe(true);
   });
 
-  test("returns gh install message when gh missing", async () => {
-    const originalProbe = await import("../src/git/gh-cli.js");
-    // If gh is installed in CI, skip strict message test
-    const status = originalProbe.probeGhCli(true);
-    if (status.installed && status.authenticated) {
-      return;
-    }
-
+  test.skipIf(ghReady.installed && ghReady.authenticated)(
+    "returns gh install message when gh missing",
+    async () => {
+    const status = probeGhCli(true);
     const result = await Tool.execute("github_issue", { number: 50 });
     expect(result.success).toBe(false);
     if (!status.installed) {
@@ -24,5 +23,6 @@ describe("github_issue tool", () => {
     }
     expect(result.output).toContain("github.com");
     expect(result.output).toContain("/issues/50");
-  });
+    }
+  );
 });

--- a/test/loop-guard.test.ts
+++ b/test/loop-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createLoopGuardCounters,
+  LOOP_CHECKIN_MIN_ITERATIONS,
+  LOOP_GUARD_MAX_ITERATIONS,
+  PLANNING_FORCE_FINAL_THRESHOLD,
+  SAME_PATH_WRITE_FORCE_FINAL_THRESHOLD,
+  shouldForceFinal,
+  shouldLoopCheckin,
+  TODO_ONLY_FORCE_FINAL_THRESHOLD,
+} from "../src/agent/loop-guard.js";
+
+describe("loop-guard", () => {
+  test("shouldForceFinal is false at defaults", () => {
+    expect(shouldForceFinal(createLoopGuardCounters())).toBe(false);
+  });
+
+  test("shouldForceFinal only triggers at absolute iteration backstop", () => {
+    expect(
+      shouldForceFinal({
+        ...createLoopGuardCounters(),
+        consecutiveTodoOnlyRounds: TODO_ONLY_FORCE_FINAL_THRESHOLD,
+        planningIterations: PLANNING_FORCE_FINAL_THRESHOLD,
+        consecutiveSamePathWrites: SAME_PATH_WRITE_FORCE_FINAL_THRESHOLD,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldForceFinal({
+        ...createLoopGuardCounters(),
+        loopIteration: LOOP_GUARD_MAX_ITERATIONS,
+      })
+    ).toBe(true);
+  });
+
+  test("shouldLoopCheckin requires iteration 60+ and a heuristic", () => {
+    expect(
+      shouldLoopCheckin({
+        ...createLoopGuardCounters(),
+        planningIterations: PLANNING_FORCE_FINAL_THRESHOLD,
+        loopIteration: LOOP_CHECKIN_MIN_ITERATIONS - 1,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldLoopCheckin({
+        ...createLoopGuardCounters(),
+        planningIterations: PLANNING_FORCE_FINAL_THRESHOLD,
+        loopIteration: LOOP_CHECKIN_MIN_ITERATIONS,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldLoopCheckin({
+        ...createLoopGuardCounters(),
+        planningIterations: PLANNING_FORCE_FINAL_THRESHOLD,
+        loopIteration: 80,
+        checkinSnoozedUntilIteration: 90,
+      })
+    ).toBe(false);
+  });
+});

--- a/test/markdown-table.test.ts
+++ b/test/markdown-table.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import {
+  parseTable,
+  renderTable,
+  resolveTableLayoutMode,
+  tableTotalWidth,
+  tableColumnWidths,
+  type MarkdownTable,
+} from "../src/cli/markdown-table.js";
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+const findingsTable: MarkdownTable = {
+  header: ["Phase", "Check", "Result", "Evidence"],
+  rows: [
+    ["0", "Folder wipe + recreate", "PASS", "x".repeat(120)],
+    ["1", "file_write / file_read / file_edit", "PASS", "greeter.ts created"],
+    ["6", "set_header", "PASS", "Header updated to `[impulse] \\| Cap smoke test`"],
+  ],
+};
+
+describe("markdown table layout", () => {
+  test("fits wide tables at 173 cols by shrinking columns instead of stacking", () => {
+    const width = 173;
+    expect(resolveTableLayoutMode(findingsTable, width)).toBe("wide");
+
+    const widths = tableColumnWidths(findingsTable, width);
+    expect(tableTotalWidth(widths)).toBeLessThanOrEqual(width);
+
+    const lines = renderTable(findingsTable, width, "wide");
+    for (const line of lines) {
+      expect(visibleWidth(stripAnsi(line))).toBeLessThanOrEqual(width);
+    }
+  });
+
+  test("falls back to stacked layout when columns cannot fit at minimum width", () => {
+    // Four columns at TABLE_MIN_COLUMN_WIDTH (8) need 45 cols including borders.
+    expect(resolveTableLayoutMode(findingsTable, 30)).toBe("stacked");
+  });
+
+  test("preserves escaped pipe inside a table cell", () => {
+    const markdown = [
+      "| Phase | Check | Result | Evidence |",
+      "| --- | --- | --- | --- |",
+      "| 6 | set_header | PASS | Header updated to `[impulse] \\| Cap smoke test` |",
+    ];
+    const parsed = parseTable(markdown, 0);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.table.rows).toHaveLength(1);
+    expect(parsed!.table.rows[0]).toHaveLength(4);
+    expect(parsed!.table.rows[0]![3]).toBe(
+      "Header updated to `[impulse] | Cap smoke test`"
+    );
+  });
+});

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { enrichModelId } from "../src/cli/model-catalog.js";
+import { defaultContextWindowForModel, enrichModelId } from "../src/cli/model-catalog.js";
+
+describe("defaultContextWindowForModel", () => {
+  test("uses 128k for typical flagship models", () => {
+    expect(defaultContextWindowForModel("openai/gpt-4o")).toBe(128_000);
+    expect(defaultContextWindowForModel("anthropic/claude-3-5-haiku")).toBe(128_000);
+  });
+
+  test("uses 200k for extended-context claude families", () => {
+    expect(defaultContextWindowForModel("anthropic/claude-sonnet-4")).toBe(200_000);
+  });
+
+  test("uses family-specific defaults", () => {
+    expect(defaultContextWindowForModel("google/gemini-2.0-flash")).toBe(1_000_000);
+    expect(defaultContextWindowForModel("openai/gpt-3.5-turbo")).toBe(32_768);
+  });
+});
 
 describe("model catalog context resolution", () => {
   test("prefers provider API context_length over models.dev context", () => {

--- a/test/parse-tool-args.test.ts
+++ b/test/parse-tool-args.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { parseToolCallArguments, repairToolArgumentsJson } from "../src/tools/parse-tool-args.js";
+
+describe("parseToolCallArguments", () => {
+  test("parses valid JSON unchanged", () => {
+    const { args, repaired } = parseToolCallArguments('{"context":"hi","questions":[]}');
+    expect(repaired).toBe(false);
+    expect(args["context"]).toBe("hi");
+  });
+
+  test("repairs missing quote before colon on keys", () => {
+    const broken = '{"context: "Foundational decisions", "questions": []}';
+    const { args, repaired } = parseToolCallArguments(broken);
+    expect(repaired).toBe(true);
+    expect(args["context"]).toBe("Foundational decisions");
+  });
+
+  test("repairToolArgumentsJson fixes context key", () => {
+    expect(repairToolArgumentsJson('{"context: "x"}')).toBe('{"context": "x"}');
+  });
+});

--- a/test/paste-normalize.test.ts
+++ b/test/paste-normalize.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSubmitPayload,
+  normalizePasteContent,
+  userTranscriptText,
+} from "../src/cli/prompt-input.js";
+
+describe("paste normalization", () => {
+  test("normalizePasteContent converts CRLF and lone CR", () => {
+    expect(normalizePasteContent("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+
+  test("multi-line paste token counts normalized lines", () => {
+    const payload = buildSubmitPayload("[Pasted 3 lines  9 chars #1]", [
+      {
+        display: "[Pasted 3 lines  9 chars #1]",
+        content: "line1\r\nline2\rline3",
+        originalDisplay: "[Pasted 3 lines  9 chars #1]",
+        kind: "text",
+      },
+    ]);
+    const transcript = userTranscriptText(payload);
+    expect(transcript).not.toContain("\r");
+    expect(transcript.split("\n").length).toBe(3);
+  });
+});

--- a/test/planning-nudge.test.ts
+++ b/test/planning-nudge.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isSubstantiveToolBatch,
+  shouldInjectPlanningLoopNudge,
+  PLANNING_LOOP_NUDGE_MESSAGE,
+} from "../src/agent/planning-nudge.js";
+
+describe("planning loop nudge", () => {
+  test("substantive tools include file_write and task", () => {
+    expect(isSubstantiveToolBatch(["todo_write", "file_write"])).toBe(true);
+    expect(isSubstantiveToolBatch(["bash", "todo_write"])).toBe(true);
+    expect(isSubstantiveToolBatch(["todo_write", "set_header"])).toBe(false);
+    expect(isSubstantiveToolBatch(["task"])).toBe(true);
+  });
+
+  test("fires after three planning-only iterations", () => {
+    expect(
+      shouldInjectPlanningLoopNudge({
+        planningIterations: 3,
+        nudgeUsed: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldInjectPlanningLoopNudge({
+        planningIterations: 2,
+        nudgeUsed: false,
+      })
+    ).toBe(false);
+  });
+
+  test("does not fire on duplicate bash alone", () => {
+    expect(
+      shouldInjectPlanningLoopNudge({
+        planningIterations: 0,
+        nudgeUsed: false,
+      })
+    ).toBe(false);
+  });
+
+  test("fires at most once per turn", () => {
+    expect(
+      shouldInjectPlanningLoopNudge({
+        planningIterations: 5,
+        nudgeUsed: true,
+      })
+    ).toBe(false);
+  });
+
+  test("nudge message tells model to execute todos", () => {
+    expect(PLANNING_LOOP_NUDGE_MESSAGE).toContain("Stop replanning");
+    expect(PLANNING_LOOP_NUDGE_MESSAGE).toContain("substantive tools");
+    expect(PLANNING_LOOP_NUDGE_MESSAGE).toContain("unchanged todo list");
+    expect(PLANNING_LOOP_NUDGE_MESSAGE).toContain("status updates are good");
+    expect(PLANNING_LOOP_NUDGE_MESSAGE).toContain("follow the user's message");
+  });
+});

--- a/test/question-dedup.test.ts
+++ b/test/question-dedup.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeQuestionTopic,
+  partitionQuestionsByPriorAnswers,
+  priorAnsweredQuestionsFromSession,
+  questionAnswerKey,
+} from "../src/tools/question-dedup.js";
+import type { Message } from "../src/session/store.js";
+
+describe("question dedup", () => {
+  test("normalizes topic names for comparison", () => {
+    expect(normalizeQuestionTopic("Location")).toBe("location");
+    expect(normalizeQuestionTopic("Test  folder")).toBe("test folder");
+  });
+
+  test("builds answer keys from topic and question text", () => {
+    expect(questionAnswerKey("Cleanup action", "What should we delete?")).not.toBe(
+      questionAnswerKey("Cleanup action", "Delete all 8 folders?")
+    );
+  });
+
+  test("parses prior answers from linked assistant tool calls", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            tool: "question",
+            arguments: {
+              questions: [
+                { topic: "Location", question: "Where?", options: [] },
+              ],
+            },
+          },
+        ],
+        timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        role: "tool",
+        content: "User responded:\nLocation: Sandboxed in repo",
+        tool_call_id: "call_1",
+        timestamp: "2026-01-01T00:00:01.000Z",
+      },
+    ];
+    const prior = priorAnsweredQuestionsFromSession(messages);
+    expect(prior.byAnswerKey.get(questionAnswerKey("Location", "Where?"))).toEqual([
+      "Sandboxed in repo",
+    ]);
+  });
+
+  test("partitions only when topic and question text both match", () => {
+    const prior = {
+      byAnswerKey: new Map([
+        [questionAnswerKey("Location", "Where?"), ["Sandboxed in repo"]],
+      ]),
+    };
+    const { unanswered, cachedAnswers } = partitionQuestionsByPriorAnswers(
+      [
+        { topic: "Location", question: "Where?" },
+        { topic: "Location", question: "How deep?" },
+        { topic: "Depth", question: "How deep?" },
+      ],
+      prior
+    );
+    expect(unanswered).toHaveLength(2);
+    expect(unanswered.map((q) => q.question)).toEqual(["How deep?", "How deep?"]);
+    expect(cachedAnswers).toEqual([["Sandboxed in repo"]]);
+  });
+});

--- a/test/question-overlay-review.test.ts
+++ b/test/question-overlay-review.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { QuestionOverlay } from "../src/cli/components/question-overlay.js";
+import { OVERLAY_SCROLL_FOOTER } from "../src/cli/components/overlay-scroll-region.js";
+
+function makeQuestion(topic: string) {
+  return {
+    topic,
+    question: `Question for ${topic}?`,
+    options: [
+      { label: "A", description: "Option A" },
+      { label: "B", description: "Option B" },
+    ],
+  };
+}
+
+function advanceToReview(overlay: QuestionOverlay, topicCount: number): void {
+  for (let index = 0; index < topicCount; index += 1) {
+    overlay.handleInput("\r");
+    overlay.handleInput("\r");
+  }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+describe("QuestionOverlay review screen", () => {
+  test("clamps to maxHeight with bottom border and scroll footer when review overflows", () => {
+    const overlay = new QuestionOverlay({
+      context: undefined,
+      questions: Array.from({ length: 5 }, (_, i) => makeQuestion(`T${i + 1}`)),
+    });
+    advanceToReview(overlay, 5);
+
+    const maxHeight = 14;
+    overlay.setMaxHeight(maxHeight);
+    const rendered = overlay.render(100);
+
+    expect(rendered).toHaveLength(maxHeight);
+    expect(stripAnsi(rendered[rendered.length - 1]!)).toContain("└");
+    expect(stripAnsi(rendered[rendered.length - 2]!)).toContain(OVERLAY_SCROLL_FOOTER);
+  });
+
+  test("arrow-down scroll changes visible review body", () => {
+    const overlay = new QuestionOverlay({
+      context: undefined,
+      questions: Array.from({ length: 5 }, (_, i) => makeQuestion(`T${i + 1}`)),
+    });
+    advanceToReview(overlay, 5);
+    overlay.setMaxHeight(14);
+
+    const before = overlay.render(100);
+    overlay.handleInput("\x1b[B");
+    const after = overlay.render(100);
+
+    expect(before[2]).not.toBe(after[2]);
+  });
+
+  test("no scroll footer when review fits within maxHeight", () => {
+    const overlay = new QuestionOverlay({
+      context: undefined,
+      questions: [makeQuestion("Only")],
+    });
+    advanceToReview(overlay, 1);
+    overlay.setMaxHeight(40);
+
+    const rendered = overlay.render(100);
+    const footer = stripAnsi(rendered[rendered.length - 2] ?? "");
+    expect(footer).not.toContain(OVERLAY_SCROLL_FOOTER);
+    expect(footer).toContain("Esc go back");
+  });
+});

--- a/test/question-topic-cap.test.ts
+++ b/test/question-topic-cap.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { QuestionEvents } from "../src/bus/events.js";
+import { Bus } from "../src/bus/index.js";
+import { Tool } from "../src/tools/registry.js";
+import "../src/tools/init.js";
+import { QUESTION_TOPIC_HARD_LIMIT, rejectQuestion } from "../src/tools/question.js";
+
+function makeQuestion(topic: string) {
+  return {
+    topic,
+    question: `Question for ${topic}?`,
+    options: [
+      { label: "A", description: "Option A" },
+      { label: "B", description: "Option B" },
+    ],
+  };
+}
+
+describe("question topic cap", () => {
+  test("rejects more than hard limit topics", async () => {
+    const questions = Array.from({ length: QUESTION_TOPIC_HARD_LIMIT + 1 }, (_, i) =>
+      makeQuestion(`T${i + 1}`)
+    );
+    const result = await Tool.execute("question", { questions });
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Too many topics");
+    expect(result.output).toContain(`Max ${QUESTION_TOPIC_HARD_LIMIT} per call`);
+    expect(result.output).toContain("prefer 1-3");
+  });
+
+  test("asks all topics within limit (no truncation)", async () => {
+    const questions = Array.from({ length: 5 }, (_, i) => makeQuestion(`T${i + 1}`));
+    const asked: string[] = [];
+
+    const unsub = Bus.subscribe((event) => {
+      if (event.type !== QuestionEvents.Asked.name) return;
+      const payload = event.properties as { questions: Array<{ topic: string }> };
+      asked.push(...payload.questions.map((q) => q.topic));
+      rejectQuestion();
+    });
+
+    const result = await Tool.execute("question", { questions });
+    unsub();
+
+    expect(asked).toHaveLength(5);
+    expect(asked).toEqual(questions.map((q) => q.topic));
+    expect(result.output).not.toContain("only the first 3");
+  });
+});

--- a/test/repeat-notes.test.ts
+++ b/test/repeat-notes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  bashRepeatNote,
+  batchCompletionNote,
+  countPendingToCompleted,
+  todoUnchangedRepeatNote,
+} from "../src/agent/repeat-notes.js";
+
+describe("repeat notes", () => {
+  test("bashRepeatNote returns nothing on first run", () => {
+    expect(bashRepeatNote(1)).toBeUndefined();
+  });
+
+  test("bashRepeatNote returns full note on second identical run", () => {
+    const note = bashRepeatNote(2);
+    expect(note).toContain("identical command already run this turn");
+    expect(note).toContain("Avoid re-verifying");
+  });
+
+  test("bashRepeatNote returns short counter on third+ run", () => {
+    expect(bashRepeatNote(3)).toBe("\nNote: command run 3 times this turn.");
+    expect(bashRepeatNote(5)).toBe("\nNote: command run 5 times this turn.");
+  });
+
+  test("todoUnchangedRepeatNote returns nothing on first unchanged", () => {
+    expect(todoUnchangedRepeatNote(1)).toBeUndefined();
+  });
+
+  test("todoUnchangedRepeatNote returns note on second+ consecutive unchanged", () => {
+    const note = todoUnchangedRepeatNote(2);
+    expect(note).toContain("todo_write already returned unchanged");
+    expect(todoUnchangedRepeatNote(3)).toBe(note);
+  });
+
+  test("countPendingToCompleted matches by content and ignores in_progress transitions", () => {
+    const current = [
+      { content: "A", status: "pending" },
+      { content: "B", status: "in_progress" },
+      { content: "C", status: "pending" },
+    ];
+    const incoming = [
+      { content: "A", status: "completed" },
+      { content: "B", status: "completed" },
+      { content: "C", status: "completed" },
+    ];
+    expect(countPendingToCompleted(current, incoming)).toBe(2);
+  });
+
+  test("batchCompletionNote returns nothing below threshold", () => {
+    expect(batchCompletionNote(2)).toBeUndefined();
+  });
+
+  test("batchCompletionNote returns corrective note at 3+", () => {
+    const note = batchCompletionNote(4);
+    expect(note).toContain("4 items jumped pending -> completed");
+    expect(note).toContain("mark in_progress when starting");
+  });
+});

--- a/test/session-race.test.ts
+++ b/test/session-race.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { SessionManager } from "../src/session/manager.js";
+import { SessionStoreInstance } from "../src/session/store.js";
+
+const assistantWithToolCalls = {
+  role: "assistant" as const,
+  content: "",
+  tool_calls: [
+    {
+      id: "call_race_1",
+      tool: "bash",
+      arguments: { command: "echo hello" },
+      timestamp: new Date().toISOString(),
+    },
+  ],
+  timestamp: new Date().toISOString(),
+};
+
+describe("session clobbering race", () => {
+  beforeEach(async () => {
+    SessionStoreInstance.setSaveDelay(60_000);
+    await SessionManager.createNew("session-race-test");
+  });
+
+  afterEach(async () => {
+    SessionStoreInstance.setSaveDelay(1000);
+    await SessionManager.exitCurrent();
+  });
+
+  test("update({ todos }) preserves debounced messages in memory", async () => {
+    await SessionManager.addMessage(assistantWithToolCalls);
+
+    await SessionManager.update({
+      todos: [
+        {
+          id: "1",
+          content: "Phase 0",
+          status: "in_progress",
+          priority: "high",
+        },
+      ],
+    });
+
+    const session = SessionManager.getCurrentSession();
+    expect(session?.messages).toHaveLength(1);
+    expect(session?.messages[0]?.role).toBe("assistant");
+    expect(session?.messages[0]?.tool_calls?.[0]?.tool).toBe("bash");
+    expect(session?.todos).toHaveLength(1);
+  });
+
+  test("update({ todos }) preserves debounced messages on disk after flush", async () => {
+    await SessionManager.addMessage(assistantWithToolCalls);
+
+    await SessionManager.update({
+      todos: [
+        {
+          id: "1",
+          content: "Phase 0",
+          status: "in_progress",
+          priority: "high",
+        },
+      ],
+    });
+
+    await SessionManager.flushCurrent();
+
+    const session = SessionManager.getCurrentSession();
+    const onDisk = await SessionStoreInstance.read(session!.id);
+    expect(onDisk.messages).toHaveLength(1);
+    expect(onDisk.messages[0]?.tool_calls?.[0]?.id).toBe("call_race_1");
+    expect(onDisk.todos).toHaveLength(1);
+  });
+
+  test("setHeaderTitle preserves debounced messages in memory and on disk", async () => {
+    await SessionManager.addMessage(assistantWithToolCalls);
+
+    await SessionManager.setHeaderTitle("Round 2 smoke test");
+
+    const session = SessionManager.getCurrentSession();
+    expect(session?.messages).toHaveLength(1);
+    expect(session?.headerTitle).toBe("Round 2 smoke test");
+
+    await SessionManager.flushCurrent();
+
+    const onDisk = await SessionStoreInstance.read(session!.id);
+    expect(onDisk.messages).toHaveLength(1);
+    expect(onDisk.headerTitle).toBe("Round 2 smoke test");
+  });
+});

--- a/test/set-header-unchanged.test.ts
+++ b/test/set-header-unchanged.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { SessionManager } from "../src/session/manager.js";
+import { SessionStoreInstance } from "../src/session/store.js";
+import { Tool } from "../src/tools/registry.js";
+import "../src/tools/init.js";
+
+describe("set_header unchanged dedup", () => {
+  beforeEach(async () => {
+    SessionStoreInstance.setSaveDelay(60_000);
+    await SessionManager.createNew("set-header-unchanged-test");
+    await Tool.execute("set_header", { title: "Cap smoke test" });
+    await SessionManager.flushCurrent();
+  });
+
+  test("returns unchanged metadata when title matches current header", async () => {
+    const sessionBefore = SessionManager.getCurrentSession()!;
+    const updatedAtBefore = sessionBefore.updated_at;
+
+    const result = await Tool.execute("set_header", { title: "Cap smoke test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Header unchanged.");
+    expect(result.metadata?.unchanged).toBe(true);
+
+    const sessionAfter = SessionManager.getCurrentSession()!;
+    expect(sessionAfter.headerTitle).toBe("Cap smoke test");
+    expect(sessionAfter.updated_at).toBe(updatedAtBefore);
+  });
+
+  test("updates header when title changes", async () => {
+    const result = await Tool.execute("set_header", { title: "New title" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Header updated to:");
+    expect(SessionManager.getCurrentSession()?.headerTitle).toBe("New title");
+  });
+});

--- a/test/startup-flags.test.ts
+++ b/test/startup-flags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { parseStartupFlags } from "../src/cli/startup-flags.js";
+
+describe("parseStartupFlags", () => {
+  test("detects --aa and strips it from argv", () => {
+    const { flags, argv } = parseStartupFlags(["--aa", "hello"]);
+    expect(flags.allowAllOnStartup).toBe(true);
+    expect(argv).toEqual(["hello"]);
+  });
+
+  test("detects --allow-all alias", () => {
+    const { flags, argv } = parseStartupFlags(["impulse", "--allow-all"]);
+    expect(flags.allowAllOnStartup).toBe(true);
+    expect(argv).toEqual(["impulse"]);
+  });
+
+  test("respects IMPULSE_ALLOW_ALL=1", () => {
+    const prev = process.env["IMPULSE_ALLOW_ALL"];
+    process.env["IMPULSE_ALLOW_ALL"] = "1";
+    try {
+      const { flags } = parseStartupFlags([]);
+      expect(flags.allowAllOnStartup).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env["IMPULSE_ALLOW_ALL"];
+      else process.env["IMPULSE_ALLOW_ALL"] = prev;
+    }
+  });
+
+  test("defaults to false without flags or env", () => {
+    const prev = process.env["IMPULSE_ALLOW_ALL"];
+    delete process.env["IMPULSE_ALLOW_ALL"];
+    try {
+      const { flags } = parseStartupFlags(["--verbose"]);
+      expect(flags.allowAllOnStartup).toBe(false);
+    } finally {
+      if (prev !== undefined) process.env["IMPULSE_ALLOW_ALL"] = prev;
+    }
+  });
+});

--- a/test/steer-injection.test.ts
+++ b/test/steer-injection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { formatSteeringNote } from "../src/agent/steer-injection.js";
+import { PLANNING_LOOP_NUDGE_MESSAGE } from "../src/agent/planning-nudge.js";
+import { ALLOW_ALL_TODO_NUDGE_MESSAGE } from "../src/agent/allow-all-nudge.js";
+
+describe("steer injection", () => {
+  test("formatSteeringNote tells model to override and acknowledge", () => {
+    const note = formatSteeringNote("hold on and wipe the folder");
+    expect(note).toContain("overrides prior instructions");
+    expect(note).toContain("hold on and wipe the folder");
+    expect(note).toContain("briefly acknowledge");
+    expect(note).not.toContain("do not acknowledge");
+  });
+
+  test("steering note and nudge messages are distinct", () => {
+    const steer = formatSteeringNote("skip phase 5");
+    expect(steer).not.toContain(PLANNING_LOOP_NUDGE_MESSAGE);
+    expect(steer).not.toContain(ALLOW_ALL_TODO_NUDGE_MESSAGE);
+  });
+});

--- a/test/todo-write-noop.test.ts
+++ b/test/todo-write-noop.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { SessionManager } from "../src/session/manager.js";
+import { Todo } from "../src/session/todo.js";
+import { Tool } from "../src/tools/registry.js";
+import "../src/tools/init.js";
+
+describe("todo_write no-op dedup", () => {
+  beforeEach(async () => {
+    await SessionManager.createNew("todo-noop-test");
+    await Todo.update([
+      {
+        id: "1",
+        content: "Task one",
+        status: "in_progress",
+        priority: "high",
+      },
+      {
+        id: "2",
+        content: "Task two",
+        status: "pending",
+        priority: "medium",
+      },
+    ]);
+  });
+
+  test("returns unchanged metadata when list is identical by content+status", async () => {
+    const result = await Tool.execute("todo_write", {
+      todos: [
+        {
+          id: "new-id-1",
+          content: "Task one",
+          status: "in_progress",
+          priority: "low",
+        },
+        {
+          id: "new-id-2",
+          content: "Task two",
+          status: "pending",
+          priority: "high",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Todos unchanged.");
+    expect(result.metadata?.["unchanged"]).toBe(true);
+  });
+
+  test("updates when status changes", async () => {
+    const result = await Tool.execute("todo_write", {
+      todos: [
+        {
+          id: "1",
+          content: "Task one",
+          status: "completed",
+          priority: "high",
+        },
+        {
+          id: "2",
+          content: "Task two",
+          status: "pending",
+          priority: "medium",
+        },
+      ],
+    });
+
+    expect(result.output).toContain("Todo list updated");
+    expect(result.metadata?.["unchanged"]).toBeUndefined();
+  });
+
+  test("appends batch note when 4 items jump pending to completed", async () => {
+    await Todo.update([
+      { id: "1", content: "One", status: "pending", priority: "high" },
+      { id: "2", content: "Two", status: "pending", priority: "high" },
+      { id: "3", content: "Three", status: "pending", priority: "high" },
+      { id: "4", content: "Four", status: "pending", priority: "high" },
+    ]);
+
+    const result = await Tool.execute("todo_write", {
+      todos: [
+        { id: "1", content: "One", status: "completed", priority: "high" },
+        { id: "2", content: "Two", status: "completed", priority: "high" },
+        { id: "3", content: "Three", status: "completed", priority: "high" },
+        { id: "4", content: "Four", status: "completed", priority: "high" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("4 items jumped pending -> completed");
+  });
+
+  test("does not append batch note for in_progress plus one pending completion", async () => {
+    await Todo.update([
+      { id: "1", content: "Active", status: "in_progress", priority: "high" },
+      { id: "2", content: "Next", status: "pending", priority: "medium" },
+    ]);
+
+    const result = await Tool.execute("todo_write", {
+      todos: [
+        { id: "1", content: "Active", status: "completed", priority: "high" },
+        { id: "2", content: "Next", status: "completed", priority: "medium" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain("jumped pending -> completed");
+  });
+});

--- a/test/tool-block-duration.test.ts
+++ b/test/tool-block-duration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { ToolBlock } from "../src/cli/components/tool-block.js";
+import { formatDurationBracketed } from "../src/cli/format-helpers.js";
+
+describe("ToolBlock duration tail", () => {
+  test("formatDurationBracketed wraps seconds in brackets", () => {
+    expect(formatDurationBracketed(4500)).toBe("[4.5s]");
+  });
+
+  test("duration appears on last wrapped summary line", () => {
+    const command =
+      "cd /Users/spencer/GitHub/impulse && ls -la && cat package.json 2>/dev/null | head";
+    const block = new ToolBlock("bash", { command });
+    block.setDone({ success: true, output: "ok" }, 4500);
+
+    const lines = block.render(72);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]).not.toContain("[4.5s]");
+    expect(lines[lines.length - 1]).toContain("[4.5s]");
+  });
+
+  test("compact bash shows bracketed duration", () => {
+    const block = new ToolBlock("bash", { command: "echo hi" });
+    block.setDone({ success: true, output: "hi" }, 50, { compact: true });
+    const lines = block.render(72);
+    expect(lines.join("\n")).toContain("[50ms]");
+  });
+});

--- a/test/tool-block-question.test.ts
+++ b/test/tool-block-question.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { ToolBlock } from "../src/cli/components/tool-block.js";
+
+describe("ToolBlock question row", () => {
+  test("running row shows missing questions when args are invalid", () => {
+    const block = new ToolBlock("question", { context: "context only, no questions key" });
+    const line = block.render(100)[0]!;
+    expect(line).toContain("missing questions array");
+    expect(line).not.toContain("clarifying");
+  });
+
+  test("running row shows topic tabs not waiting placeholder", () => {
+    const block = new ToolBlock("question", {
+      questions: [
+        { topic: "Location", question: "Where?", options: [{ label: "A", description: "a" }] },
+        { topic: "Scope", question: "How much?", options: [{ label: "B", description: "b" }] },
+      ],
+    });
+    const line = block.render(100)[0]!;
+    expect(line).toContain("Location");
+    expect(line).toContain("Scope");
+    expect(line).not.toContain("waiting for your answer");
+  });
+
+  test("done row shows topic answers after user responds", () => {
+    const block = new ToolBlock("question", {
+      questions: [{ topic: "Location", question: "Where?", options: [{ label: "A", description: "a" }] }],
+    });
+    block.setDone(
+      {
+        success: true,
+        output: "User responded:\nLocation: In repo",
+        metadata: {
+          type: "question",
+          questions: [
+            {
+              topic: "Location",
+              question: "Where?",
+              options: ["In repo"],
+              answers: ["In repo"],
+            },
+          ],
+        },
+      },
+      61_000,
+      { collapsed: true }
+    );
+    const rendered = block.render(120).join("\n");
+    expect(rendered).toContain("Location: In repo");
+    expect(rendered).not.toContain("waiting for your answer");
+    expect(rendered).not.toContain("clarifying");
+  });
+});

--- a/test/tool-block-wrap.test.ts
+++ b/test/tool-block-wrap.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { ToolBlock } from "../src/cli/components/tool-block.js";
+import { maxLineWidth } from "../src/cli/gutter.js";
+
+describe("ToolBlock compact wrap", () => {
+  test("compact bash wraps long commands instead of truncating", () => {
+    const command =
+      "cd /Users/spencer/GitHub/impulse && ls -la && cat package.json 2>/dev/null | head";
+    const block = new ToolBlock("bash", { command });
+    block.setDone({ success: true, output: "ok" }, 120, { compact: true });
+
+    const lines = block.render(72);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(maxLineWidth(72));
+      expect(line).not.toContain("…");
+    }
+    expect(lines.join("\n")).toContain("package.json");
+  });
+});

--- a/test/truncation-policy.test.ts
+++ b/test/truncation-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { ToolBlock } from "../src/cli/components/tool-block.js";
+import { ShellCommandBlock } from "../src/cli/components/shell-command-block.js";
+import { maxLineWidth } from "../src/cli/gutter.js";
+
+describe("truncation policy", () => {
+  test("summarizeArgs source does not pre-slice argument text", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/cli/components/tool-block.ts"),
+      "utf8"
+    );
+    expect(source).not.toMatch(/slice\(0,\s*70\)/);
+  });
+
+  test("long bash tool args wrap without horizontal ellipsis", () => {
+    const command = "npm run test -- " + "very-long-segment-".repeat(12);
+    const block = new ToolBlock("bash", { command });
+    block.setDone({ success: true, output: "ok" }, 50, { compact: true });
+
+    const width = 72;
+    const lines = block.render(width);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(maxLineWidth(width));
+      expect(line).not.toContain("…");
+    }
+    expect(lines.join("\n")).toContain("very-long-segment");
+  });
+
+  test("long shell command header wraps without horizontal ellipsis", () => {
+    const command = "python3 " + "validate_planet_data_".repeat(8) + ".py";
+    const block = new ShellCommandBlock(command);
+    block.setDone(0, 120);
+
+    const width = 80;
+    const lines = block.render(width);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(maxLineWidth(width));
+      expect(line).not.toContain("…");
+    }
+    expect(lines.join("\n")).toContain("validate_planet_data");
+  });
+});


### PR DESCRIPTION
## Summary

- PR #75 merged `loop.ts` and `renderer.ts` changes that import 12 new modules which were never committed (they existed only as local untracked files).
- Restores those modules from stash plus supporting exports (`formatDurationBracketed`, `overlayViewportMaxHeight`, `todo_write` no-op dedup, etc.) and their tests.
- Fixes the Release workflow `bun run build` failure on `main`.

## Changes

- 12 new `src/` modules: loop guard, tool-call accumulator, token estimate, parse-tool-args, resolve-tool-path, silent-tools, startup-flags, overlays, etc.
- Supporting updates to `constants.ts`, `debug-log.ts`, `path.ts`, `todo-write.ts`, `set-header.ts`, and related CLI helpers.
- 26 test files covering the restored behavior.


Made with [Cursor](https://cursor.com)