### PR TITLE
fix: open bugs #56–#74 — narrow render, context safety, queue UX (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.1] - 2026-06-11
 
   **Type:** patch
-  **Title:** Open bug batch — narrow render, context safety, queue UX, paste replay
+  **Title:** Open bug batch — narrow render, context safety, queue UX, paste replay, session auto-resume
+
+  ### Added
+  - **Session auto-resume** — interrupted sessions (dev watch reload, crash, kill) automatically resume on next launch via a per-project active-session marker; cleared on clean `/exit`/`/quit`
+  - **Branch-change notice** — dim `Git branch changed — session unaffected` line when the git branch switches mid-session
 
   ### Changed
   - **Context bar** — `Allow-All` label (was `All Permissions Bypassed`) for narrow terminals
@@ -25,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **#70** — bash byte/per-line caps, tool-result cap at history insert, compaction survives giant messages
   - **#72** — bash command titles sanitize newlines/control chars; failure output strips ANSI
   - **#74** — queue preview no longer ellipsizes after wrap; delete queued item via empty Enter while editing
+  - **#78** — process restarts no longer discard the live session; startup resume also skips the eager blank session (no more orphan empty session files)
 
 ## [1.5.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-  **Type:** patch
-  **Title:** Tool UX hardening — file_edit fallback, injected replay, queue preview, /copy
+## [1.5.1] - 2026-06-11
 
-  ### Added
-  - **`/copy`** — copy last assistant response to clipboard (OSC 52 + native fallback; gutter-free markdown)
+  **Type:** patch
+  **Title:** Open bug batch — narrow render, context safety, queue UX, paste replay
 
   ### Changed
-  - **Queue preview** — `Queued messages` header; dim numbered lines (restored from cyan user styling)
-  - **Question tool** — `options[].description` optional; collapsed validation errors for repeated array issues
-  - **Session replay** — injected steer/nudge/interrupt notes render as dim `[system note]` (not under user name)
+  - **Context bar** — `Allow-All` label (was `All Permissions Bypassed`) for narrow terminals
+  - **Question tool** — topic tab cap raised to 60 characters
+  - **Queue preview** — wrap-only lines; expanded paste text; empty Enter deletes while editing
 
   ### Fixed
-  - **`file_edit`** — whitespace-normalized fallback when unique trimmed match; closest-line hint on failure
-  - **Silent `todo_write`** — unchanged no-ops no longer leave a blank gap in chat
+  - **#56** — failed tool rows, `!` shell headers, and question overlay footer wrap on narrow panes
+  - **#57** — question topics longer than 20 characters accepted (up to 60)
+  - **#61** — CR line endings normalized in stored transcripts and session replay (dictation/CRLF paste)
+  - **#68** — back-to-back relabeled `todo_write` lists collapse into one block
+  - **#70** — bash byte/per-line caps, tool-result cap at history insert, compaction survives giant messages
+  - **#72** — bash command titles sanitize newlines/control chars; failure output strips ANSI
+  - **#74** — queue preview no longer ellipsizes after wrap; delete queued item via empty Enter while editing
 
 ## [1.5.0] - 2026-06-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -301,6 +301,19 @@ export class AgentLoop {
           ? (buildUserMessageContent(segments, nativeVision) as Message["apiContent"])
           : userMessage;
 
+      const storedApiContent: Message["apiContent"] =
+        apiContent === undefined
+          ? undefined
+          : typeof apiContent === "string"
+            ? apiContent.includes("\r")
+              ? normalizePasteContent(apiContent)
+              : apiContent
+            : apiContent.map((part) =>
+                part.type === "text" && part.text.includes("\r")
+                  ? { ...part, text: normalizePasteContent(part.text) }
+                  : part
+              );
+
       const orderedImages =
         segments && segments.length > 0
           ? segments
@@ -311,13 +324,15 @@ export class AgentLoop {
 
       const hasTextPaste = segments?.some((s) => s.kind === "paste") ?? false;
       const rawTranscript =
-        hasTextPaste && typeof apiContent === "string" ? apiContent : displayMessage;
+        hasTextPaste && typeof storedApiContent === "string"
+          ? storedApiContent
+          : displayMessage;
       const transcriptContent = normalizePasteContent(rawTranscript);
 
       const userMsg: Message = {
         role: "user",
         content: transcriptContent,
-        ...(apiContent !== undefined ? { apiContent } : {}),
+        ...(storedApiContent !== undefined ? { apiContent: storedApiContent } : {}),
         timestamp: new Date().toISOString(),
       };
       await SessionManager.addMessage(userMsg);

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -97,7 +97,8 @@ import { shouldRetryInEnglish } from "./language-guard.js";
 import type { Mode } from "../constants";
 import { modelSupportsVision } from "../api/capabilities.js";
 import type { PromptSegment } from "../cli/prompt-input.js";
-import { buildUserMessageContent } from "../cli/prompt-input.js";
+import { buildUserMessageContent, normalizePasteContent } from "../cli/prompt-input.js";
+import { capToolResultContent } from "../util/tool-output-cap.js";
 import {
   MAX_CONCURRENT_SUBAGENTS,
   runTaskBatch,
@@ -309,8 +310,9 @@ export class AgentLoop {
           : [...this.pendingImages];
 
       const hasTextPaste = segments?.some((s) => s.kind === "paste") ?? false;
-      const transcriptContent =
+      const rawTranscript =
         hasTextPaste && typeof apiContent === "string" ? apiContent : displayMessage;
+      const transcriptContent = normalizePasteContent(rawTranscript);
 
       const userMsg: Message = {
         role: "user",
@@ -720,7 +722,7 @@ export class AgentLoop {
         ): Promise<void> => {
           await SessionManager.addMessage({
             role: "tool",
-            content: output,
+            content: capToolResultContent(output),
             tool_call_id: toolCallId,
             timestamp: new Date().toISOString(),
           });
@@ -1082,7 +1084,7 @@ export class AgentLoop {
           // Add tool result to session
           const toolResultMsg: Message = {
             role: "tool",
-            content: result.output,
+            content: capToolResultContent(result.output),
             tool_call_id: tc.id,
             timestamp: new Date().toISOString(),
           };

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -98,7 +98,7 @@ const QuestionOptionSchema = z.object({
 
 // Question schema for the question tool (v0.19.0 - topic-based tabs)
 const QuestionSchema = z.object({
-  topic: z.string().max(20).describe("Topic/category name shown as tab (max 20 chars)"),
+  topic: z.string().max(60).describe("Topic/category name shown as tab (max 60 chars)"),
   question: z.string().describe("Complete question text"),
   options: z.array(QuestionOptionSchema).describe("Available choices"),
   multiple: z.boolean().optional().describe("Allow selecting multiple choices"),

--- a/src/cli/components/context-bar.ts
+++ b/src/cli/components/context-bar.ts
@@ -336,7 +336,7 @@ export class ContextBarComponent implements Component {
 
     let statsFull = "";
     if (s.allowAllBypass) {
-      statsFull = c.fg(214, "All Permissions Bypassed");
+      statsFull = c.fg(214, "Allow-All");
     } else if (s.showTurnSpeed) {
       if (s.tokensPerSecond !== undefined && s.tokensPerSecond > 0) {
         statsFull += clr.dim(`\u26a1 ${s.tokensPerSecond} tk/s`);

--- a/src/cli/components/help-overlay.ts
+++ b/src/cli/components/help-overlay.ts
@@ -137,7 +137,7 @@ export function buildHelpContent(
   for (const statusLine of [
     "Processing... — model, thinking, or vision work",
     "Working... — tool runs",
-    "All Permissions Bypassed — shown when /allow-all is on",
+    "Allow-All — shown when /allow-all is on",
   ]) {
     for (const row of wrapIndentedProse(statusLine, innerWidth)) {
       push(row);

--- a/src/cli/components/question-overlay.ts
+++ b/src/cli/components/question-overlay.ts
@@ -1,4 +1,4 @@
-import { type Component, visibleWidth } from "@mariozechner/pi-tui";
+import { type Component, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { Question } from "../../tools/question.js";
 import { overlayBoxWidth } from "../layout.js";
 import {
@@ -71,8 +71,10 @@ export class QuestionOverlay implements Component {
     return Math.min(cap, intrinsicFramedBoxWidth(terminal, "Need your input", widths));
   }
 
-  private viewportBodyLines(): number {
-    const chromeLines = 1 + Math.max(1, this.allLinesLength - this.chromeBottomStart);
+  private viewportBodyLines(chromeBottomStart?: number, allLinesLength?: number): number {
+    const bottomStart = chromeBottomStart ?? this.chromeBottomStart;
+    const totalLength = allLinesLength ?? this.allLinesLength;
+    const chromeLines = 1 + Math.max(1, totalLength - bottomStart);
     if (this.maxHeight <= chromeLines) return 1;
     return Math.max(1, this.maxHeight - chromeLines);
   }
@@ -314,11 +316,15 @@ export class QuestionOverlay implements Component {
         pushBoxLine("");
       }
       const reviewBodyLines = lines.length - reviewBodyStart;
-      const reviewFooter =
-        reviewBodyLines > this.viewportBodyLines()
-          ? `Enter submit  e edit  ${OVERLAY_SCROLL_FOOTER}`
-          : "Enter submit  e edit  Esc go back";
       this.chromeBottomStart = lines.length;
+      const scrollFooter = `Enter submit  e edit  ${OVERLAY_SCROLL_FOOTER}`;
+      const projectedChromeBottom =
+        wrapTextWithAnsi(overlayDim(scrollFooter), innerWidth).length + 1;
+      const reviewFooter =
+        reviewBodyLines >
+        this.viewportBodyLines(this.chromeBottomStart, lines.length + projectedChromeBottom)
+          ? scrollFooter
+          : "Enter submit  e edit  Esc go back";
       overlayPushWrapped(lines, overlayDim(reviewFooter), innerWidth, boxWidth);
       lines.push(overlayBottomBorder(boxWidth));
       return lines;

--- a/src/cli/components/question-overlay.ts
+++ b/src/cli/components/question-overlay.ts
@@ -27,8 +27,6 @@ const A = {
 };
 const dimText = (s: string) => A.fg(90, s);
 
-const QUESTION_CHROME_LINES = 3; // title + blank + footer/border region
-
 export class QuestionOverlay implements Component {
   private readonly context: string | undefined;
   private readonly questions: Question[];
@@ -42,6 +40,9 @@ export class QuestionOverlay implements Component {
   private scrollTop = 0;
   private measureTerminalWidth: number | null = null;
   private lastBodyLineCount = 0;
+  /** Index in buildAllLines output where footer + bottom border begin. */
+  private chromeBottomStart = 0;
+  private allLinesLength = 0;
 
   onSubmit?: (answers: string[][]) => void;
   onAbort?: () => void;
@@ -71,8 +72,9 @@ export class QuestionOverlay implements Component {
   }
 
   private viewportBodyLines(): number {
-    if (this.maxHeight <= QUESTION_CHROME_LINES) return 1;
-    return Math.max(1, this.maxHeight - QUESTION_CHROME_LINES);
+    const chromeLines = 1 + Math.max(1, this.allLinesLength - this.chromeBottomStart);
+    if (this.maxHeight <= chromeLines) return 1;
+    return Math.max(1, this.maxHeight - chromeLines);
   }
 
   private get currentQuestion(): Question {
@@ -316,6 +318,7 @@ export class QuestionOverlay implements Component {
         reviewBodyLines > this.viewportBodyLines()
           ? `Enter submit  e edit  ${OVERLAY_SCROLL_FOOTER}`
           : "Enter submit  e edit  Esc go back";
+      this.chromeBottomStart = lines.length;
       overlayPushWrapped(lines, overlayDim(reviewFooter), innerWidth, boxWidth);
       lines.push(overlayBottomBorder(boxWidth));
       return lines;
@@ -361,6 +364,7 @@ export class QuestionOverlay implements Component {
         boxWidth
       );
       pushBoxLine("");
+      this.chromeBottomStart = lines.length;
       overlayPushWrapped(
         lines,
         `${A.dim}Type answer   Enter submit   Esc abort${A.reset}`,
@@ -396,6 +400,7 @@ export class QuestionOverlay implements Component {
     const hints = this.currentQuestion.multiple
       ? `${A.dim}↑/↓ move   Space toggle   Enter confirm/custom   Tab next topic   Esc abort${A.reset}`
       : `${A.dim}↑/↓ move   Enter select/advance   Space select   Tab next topic   Esc abort${A.reset}`;
+    this.chromeBottomStart = lines.length;
     overlayPushWrapped(lines, hints, innerWidth, boxWidth);
     lines.push(overlayBottomBorder(boxWidth));
 
@@ -405,15 +410,17 @@ export class QuestionOverlay implements Component {
   render(width: number): string[] {
     const boxWidth = overlayRenderBoxWidth(width);
     const allLines = this.buildAllLines(boxWidth);
+    this.allLinesLength = allLines.length;
+    const chromeBottomCount = allLines.length - this.chromeBottomStart;
     if (this.maxHeight <= 0 || allLines.length <= this.maxHeight) {
       this.scrollTop = 0;
-      this.lastBodyLineCount = Math.max(0, allLines.length - QUESTION_CHROME_LINES);
+      this.lastBodyLineCount = Math.max(0, allLines.length - 1 - chromeBottomCount);
       return allLines;
     }
 
     const chromeTop = [allLines[0]!];
-    const chromeBottom = allLines.slice(-2);
-    const body = allLines.slice(1, -2);
+    const chromeBottom = allLines.slice(this.chromeBottomStart);
+    const body = allLines.slice(1, this.chromeBottomStart);
     this.lastBodyLineCount = body.length;
 
     const slice = sliceOverlayBody(body, this.viewportBodyLines(), this.scrollTop);

--- a/src/cli/components/shell-command-block.ts
+++ b/src/cli/components/shell-command-block.ts
@@ -2,8 +2,8 @@
  * One user `!command` run in the chat transcript (history per command).
  */
 
-import { wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
-import { GUTTER, gutterContent, innerWidth, truncateGutterLine } from "../gutter.js";
+import { visibleWidth, wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
+import { GUTTER, gutterContent, innerWidth, maxLineWidth, truncateGutterLine } from "../gutter.js";
 import { formatDurationMs } from "../format-helpers.js";
 import { shellTakeoverHint } from "../shell-shortcuts.js";
 
@@ -17,6 +17,40 @@ const SPINNER = ["··●", "·●·", "●··", "·●·"];
 let spinFrame = 0;
 
 const MAX_BODY_LINES = 24;
+const SHELL_CONT_INDENT = GUTTER + "   ";
+
+function wrapShellHeaderLine(
+  prefix: string,
+  command: string,
+  width: number,
+  suffix = ""
+): string[] {
+  const bodyAvail = Math.max(8, maxLineWidth(width) - visibleWidth(prefix));
+  const wrapped = wrapTextWithAnsi(command.length > 0 ? command : " ", bodyAvail);
+  const lines: string[] = [];
+  if (wrapped.length === 0) {
+    lines.push(truncateGutterLine(`${prefix}${dim(" ")}`, width));
+  } else {
+    lines.push(truncateGutterLine(`${prefix}${dim(wrapped[0]!)}`, width));
+    const contAvail = Math.max(8, maxLineWidth(width) - visibleWidth(SHELL_CONT_INDENT));
+    for (let i = 1; i < wrapped.length; i++) {
+      for (const sub of wrapTextWithAnsi(wrapped[i]!, contAvail)) {
+        lines.push(truncateGutterLine(`${SHELL_CONT_INDENT}${dim(sub)}`, width));
+      }
+    }
+  }
+  if (suffix) {
+    const lastIdx = lines.length - 1;
+    const last = lines[lastIdx]!;
+    const candidate = `${last}${suffix}`;
+    if (visibleWidth(candidate) <= maxLineWidth(width)) {
+      lines[lastIdx] = truncateGutterLine(candidate, width);
+    } else {
+      lines.push(truncateGutterLine(`${SHELL_CONT_INDENT}${suffix.trimStart()}`, width));
+    }
+  }
+  return lines;
+}
 
 export type ShellBlockPhase = "running" | "done" | "cancelled";
 
@@ -71,19 +105,21 @@ export class ShellCommandBlock implements Component {
     if (this.phase === "running") {
       const sp = yellow(SPINNER[spinFrame]!);
       lines.push(
-        truncateGutterLine(`${GUTTER}${sp} ${cyan("!")} ${dim(this.command)}`, width)
+        ...wrapShellHeaderLine(`${GUTTER}${sp} ${cyan("!")} `, this.command, width)
       );
     } else if (this.phase === "cancelled") {
       lines.push(
-        truncateGutterLine(`${GUTTER}${red("✗")} ${cyan("!")} ${dim(this.command)}`, width)
+        ...wrapShellHeaderLine(`${GUTTER}${red("✗")} ${cyan("!")} `, this.command, width)
       );
     } else {
       const icon = this.exitCode === 0 ? green("✓") : red("✗");
       const dur = dim(formatDurationMs(this.durationMs));
       lines.push(
-        truncateGutterLine(
-          `${GUTTER}${icon} ${cyan("!")} ${dim(this.command)}  ${dur}`,
-          width
+        ...wrapShellHeaderLine(
+          `${GUTTER}${icon} ${cyan("!")} `,
+          this.command,
+          width,
+          `  ${dur}`
         )
       );
     }

--- a/src/cli/components/tool-block.ts
+++ b/src/cli/components/tool-block.ts
@@ -265,6 +265,20 @@ function summarizeQuestionDone(metadata: QuestionMetadata): string {
   return parts.length > 0 ? parts.join(" · ") : "answered";
 }
 
+function stripAnsiForWrap(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Collapse control chars / newlines so tool row titles stay single-logical-line for pi-tui. */
+function sanitizeToolArgText(text: string): string {
+  return stripAnsiForWrap(text)
+    .replace(/\r\n/g, " ")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function summarizeArgs(name: string, args: Record<string, unknown>): string {
   if (name === "question") {
     return summarizeQuestionRunning(args);
@@ -295,7 +309,7 @@ function summarizeArgs(name: string, args: Record<string, unknown>): string {
   const keys = ["path", "filePath", "file", "command", "pattern", "query", "description", "prompt", "url"];
   for (const key of keys) {
     if (typeof args[key] === "string") {
-      return String(args[key]);
+      return sanitizeToolArgText(String(args[key]));
     }
   }
 
@@ -317,6 +331,15 @@ export function isSilentUnchangedTodoWrite(
   if (name !== "todo_write") return false;
   const metadata = asToolMetadata(result.metadata);
   return metadata !== null && TypeGuards.isTodo(metadata) && metadata.unchanged === true;
+}
+
+export function isCosmeticTodoRewrite(
+  name: string,
+  result: { metadata?: Record<string, unknown> }
+): boolean {
+  if (name !== "todo_write") return false;
+  const metadata = asToolMetadata(result.metadata);
+  return metadata !== null && TypeGuards.isTodo(metadata) && metadata.cosmetic === true;
 }
 
 function wrapPrefixed(prefix: string, text: string, width: number): string[] {
@@ -384,7 +407,7 @@ function wrapCompactToolLine(
 }
 
 function renderTrimmedOutput(output: string, width: number, maxRows: number): string[] {
-  const normalized = output.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trimEnd();
+  const normalized = stripAnsiForWrap(output.replace(/\r\n/g, "\n").replace(/\r/g, "\n")).trimEnd();
   if (!normalized) return [];
 
   const rendered: string[] = [];
@@ -1160,12 +1183,8 @@ export class ToolBlock implements Component {
       const outcome = classifyOutcome(state.result);
       if (outcome !== "success") {
         const icon = clr.error("✗");
-        return [
-          truncateGutterLine(
-            `${GUTTER}${icon} ${clr.toolName(toolLabel)}  ${clr.args(state.argsSummary)}`,
-            width
-          ),
-        ];
+        const prefix = `${GUTTER}${icon} ${clr.toolName(toolLabel)}  `;
+        return wrapToolSummaryLine(prefix, state.argsSummary, width);
       }
       const verb =
         state.name === "file_read"

--- a/src/cli/queue-preview.ts
+++ b/src/cli/queue-preview.ts
@@ -1,7 +1,8 @@
 import { visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import { clr } from "./ansi-theme.js";
-import { GUTTER, innerWidth, truncateGutterLine } from "./gutter.js";
+import { GUTTER, innerWidth } from "./gutter.js";
 import type { PromptSubmitPayload } from "./prompt-input.js";
+import { userTranscriptText } from "./prompt-input.js";
 
 export type QueuePreviewInput = {
   items: PromptSubmitPayload[];
@@ -9,6 +10,45 @@ export type QueuePreviewInput = {
   editIndex: number;
   width: number;
 };
+
+const MAX_PREVIEW_LINES_PER_ITEM = 3;
+const contIndent = "   ";
+
+function queueItemDisplayText(item: PromptSubmitPayload): { text: string; moreLines: number } {
+  const full = userTranscriptText(item).trim();
+  if (!full) return { text: "", moreLines: 0 };
+  const lines = full.split("\n");
+  if (lines.length <= MAX_PREVIEW_LINES_PER_ITEM) {
+    return { text: full, moreLines: 0 };
+  }
+  return {
+    text: lines.slice(0, MAX_PREVIEW_LINES_PER_ITEM).join("\n"),
+    moreLines: lines.length - MAX_PREVIEW_LINES_PER_ITEM,
+  };
+}
+
+function pushWrappedQueueLines(
+  lines: string[],
+  prefix: string,
+  text: string,
+  width: number
+): void {
+  const firstAvail = Math.max(8, innerWidth(width) - visibleWidth(prefix));
+  const wrapped = wrapTextWithAnsi(text, firstAvail);
+  const contAvail = Math.max(8, innerWidth(width) - visibleWidth(contIndent));
+
+  if (wrapped.length === 0) {
+    lines.push(`${GUTTER}${prefix}`);
+    return;
+  }
+
+  lines.push(`${GUTTER}${prefix}${clr.dim(wrapped[0]!)}`);
+  for (let j = 1; j < wrapped.length; j++) {
+    for (const sub of wrapTextWithAnsi(wrapped[j]!, contAvail)) {
+      lines.push(`${GUTTER}${contIndent}${clr.dim(sub)}`);
+    }
+  }
+}
 
 /** Build stacked queue preview above the prompt (dim text, header when non-empty). */
 export function buildQueuePreviewText(input: QueuePreviewInput): string {
@@ -20,18 +60,16 @@ export function buildQueuePreviewText(input: QueuePreviewInput): string {
   const lines: string[] = [];
 
   if (holdDrain) {
-    lines.push(
-      `${GUTTER}${clr.dim(
-        `editing #${editIndex + 1} — ↑ next queued · Esc cancel · Enter save`
-      )}`
-    );
+    const hint = `editing #${editIndex + 1} — Enter save · empty Enter delete · Esc keep original · ↑ next queued`;
+    for (const hl of wrapTextWithAnsi(hint, innerWidth(width))) {
+      lines.push(`${GUTTER}${clr.dim(hl)}`);
+    }
   }
 
-  const contIndent = "   ";
   let queueHeaderAdded = false;
 
   for (let i = 0; i < items.length; i++) {
-    const text = items[i]!.displayMessage.trim();
+    const { text, moreLines } = queueItemDisplayText(items[i]!);
     if (!text) continue;
     if (!queueHeaderAdded) {
       lines.push(`${GUTTER}${clr.dim("Queued messages")}`);
@@ -39,25 +77,15 @@ export function buildQueuePreviewText(input: QueuePreviewInput): string {
     }
     const active = holdDrain && i === editIndex;
     const marker = active ? clr.dim(`> ${i + 1} `) : clr.dim(`${i + 1} `);
-    const firstAvail = Math.max(8, innerWidth(width) - visibleWidth(marker));
-    const wrapped = wrapTextWithAnsi(text, firstAvail);
-    const contAvail = Math.max(8, innerWidth(width) - visibleWidth(contIndent));
-
-    if (wrapped.length === 0) {
-      lines.push(truncateGutterLine(`${GUTTER}${marker}`, width));
-      continue;
-    }
-
-    lines.push(truncateGutterLine(`${GUTTER}${marker}${clr.dim(wrapped[0]!)}`, width));
-    for (let j = 1; j < wrapped.length; j++) {
-      for (const sub of wrapTextWithAnsi(wrapped[j]!, contAvail)) {
-        lines.push(truncateGutterLine(`${GUTTER}${contIndent}${clr.dim(sub)}`, width));
-      }
+    pushWrappedQueueLines(lines, marker, text, width);
+    if (moreLines > 0) {
+      lines.push(`${GUTTER}${contIndent}${clr.dim(`… ${moreLines} more lines`)}`);
     }
   }
 
   if (lines.length === 0 && holdDrain) {
-    return `${GUTTER}${clr.dim(`editing #${editIndex + 1} — ↑ next queued · Esc cancel · Enter save`)}`;
+    const hint = `editing #${editIndex + 1} — Enter save · empty Enter delete · Esc keep original`;
+    return `${GUTTER}${clr.dim(hint)}`;
   }
 
   return lines.join("\n");

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -82,6 +82,7 @@ import { BottomAnchorSpacer } from "./components/bottom-anchor-spacer.js";
 import {
   DIFF_REVEAL_TICK_MS,
   extractDiffLinesFromMetadata,
+  isCosmeticTodoRewrite,
   isSilentUnchangedTodoWrite,
   ToolBlock,
   shouldCompactToolOutput,
@@ -406,6 +407,27 @@ export class ImpulseRenderer {
     }
     this.latestTodoBlock = block;
     block.setTodoBlinkEnabled(this.isRunning);
+  }
+
+  private removeSilentTodoToolBlock(block: ToolBlock, id: string): void {
+    if (this.latestTodoBlock === block) {
+      this.latestTodoBlock = null;
+    }
+    if (this.lastExpandableTool === block) {
+      this.lastExpandableTool = null;
+    }
+    this.chat.removeChild(block);
+    if (this.lastToolGapSpacer) {
+      this.chat.removeChild(this.lastToolGapSpacer);
+      this.lastToolGapSpacer = null;
+    }
+    if (this.preToolSpacing) {
+      this.lastBandWasTool = this.preToolSpacing.lastBandWasTool;
+      this.lastBandToolHadBody = this.preToolSpacing.lastBandToolHadBody;
+      this.hasTrailingGap = this.preToolSpacing.hasTrailingGap;
+      this.preToolSpacing = null;
+    }
+    this.toolBlocks.delete(id);
   }
 
   /** Check if advisor mode should be turned off (all tasks complete) */
@@ -1251,6 +1273,14 @@ export class ImpulseRenderer {
     this.tui.requestRender();
   }
 
+  private deleteQueueEdit(): void {
+    const { editIndex } = this.turnQueue.editState;
+    this.turnQueue.deleteAt(editIndex);
+    this.promptInput.clear();
+    this.updateQueuePreview();
+    this.tui.requestRender();
+  }
+
   private commitQueueEdit(payload: PromptSubmitPayload): void {
     this.turnQueue.commitEdit(payload);
     this.promptInput.clear();
@@ -1351,6 +1381,8 @@ export class ImpulseRenderer {
   private turnShowsImpulseHeader = false;
   private toolBlocks = new Map<string, ToolBlock>();
   private latestTodoBlock: ToolBlock | null = null;
+  /** Todo block shown before the current in-flight todo_write (for cosmetic rewrites). */
+  private todoBlockBeforeRewrite: ToolBlock | null = null;
   private taskCodenames = new Map<string, string>();
   private diffRevealInterval: ReturnType<typeof setInterval> | null = null;
   private taskBatchOverlayHandle: OverlayHandle | null = null;
@@ -2130,7 +2162,7 @@ export class ImpulseRenderer {
     const input = payload.displayMessage.trim();
     if (!input) {
       if (this.turnQueue.isHoldDrain) {
-        this.cancelQueueEdit();
+        this.deleteQueueEdit();
         this.tui.requestRender();
         return;
       }
@@ -2402,6 +2434,9 @@ export class ImpulseRenderer {
         this.lastBandWasTool = true;
         this.lastBandToolHadBody = false;
         this.lastExpandableTool = block;
+        if (name === "todo_write") {
+          this.todoBlockBeforeRewrite = this.latestTodoBlock;
+        }
         if (name === "todo_write" || name === "todo_read") {
           this.markLatestTodoBlock(block);
         }
@@ -2424,24 +2459,25 @@ export class ImpulseRenderer {
         const block = this.toolBlocks.get(id);
         if (block) {
           if (isSilentUnchangedTodoWrite(_name, result)) {
-            if (this.latestTodoBlock === block) {
-              this.latestTodoBlock = null;
+            this.removeSilentTodoToolBlock(block, id);
+            if (!this.isRunning) {
+              this.tui.requestRender();
+              return;
             }
-            if (this.lastExpandableTool === block) {
-              this.lastExpandableTool = null;
+            this.setBusyStatus("Waiting for model ...", BUSY_PROCESSING);
+            this.updateLiveMetrics(result.output.length, true);
+            this.tui.requestRender();
+            return;
+          }
+
+          if (isCosmeticTodoRewrite(_name, result)) {
+            const prev = this.todoBlockBeforeRewrite;
+            this.todoBlockBeforeRewrite = null;
+            this.removeSilentTodoToolBlock(block, id);
+            if (prev) {
+              prev.setDone(result, durationMs, { collapsed: false, compact: false });
+              this.markLatestTodoBlock(prev);
             }
-            this.chat.removeChild(block);
-            if (this.lastToolGapSpacer) {
-              this.chat.removeChild(this.lastToolGapSpacer);
-              this.lastToolGapSpacer = null;
-            }
-            if (this.preToolSpacing) {
-              this.lastBandWasTool = this.preToolSpacing.lastBandWasTool;
-              this.lastBandToolHadBody = this.preToolSpacing.lastBandToolHadBody;
-              this.hasTrailingGap = this.preToolSpacing.hasTrailingGap;
-              this.preToolSpacing = null;
-            }
-            this.toolBlocks.delete(id);
             if (!this.isRunning) {
               this.tui.requestRender();
               return;

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -413,10 +413,18 @@ export class ImpulseRenderer {
     block.setTodoBlinkEnabled(this.isRunning);
   }
 
-  private removeSilentTodoToolBlock(block: ToolBlock, id: string): void {
-    if (this.latestTodoBlock === block) {
-      this.latestTodoBlock = null;
+  private findLatestVisibleTodoBlock(): ToolBlock | null {
+    for (let i = this.chat.children.length - 1; i >= 0; i--) {
+      const child = this.chat.children[i];
+      if (child instanceof ToolBlock && child.isTodoTool()) {
+        return child;
+      }
     }
+    return null;
+  }
+
+  private removeSilentTodoToolBlock(block: ToolBlock, id: string): void {
+    const wasLatestTodo = this.latestTodoBlock === block;
     if (this.lastExpandableTool === block) {
       this.lastExpandableTool = null;
     }
@@ -432,6 +440,9 @@ export class ImpulseRenderer {
       this.preToolSpacing = null;
     }
     this.toolBlocks.delete(id);
+    if (wasLatestTodo) {
+      this.latestTodoBlock = this.findLatestVisibleTodoBlock();
+    }
   }
 
   /** Check if advisor mode should be turned off (all tasks complete) */

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -78,6 +78,7 @@ import {
   setAllowAllBypass,
 } from "../permission/index.js";
 import { ContextBarComponent } from "./components/context-bar.js";
+import { clearActiveSessionMarker } from "../util/active-session-marker.js";
 import { BottomAnchorSpacer } from "./components/bottom-anchor-spacer.js";
 import {
   DIFF_REVEAL_TICK_MS,
@@ -328,6 +329,8 @@ export type ResumeStartup = "picker" | { sessionId: string };
 
 export interface ImpulseRendererOptions {
   resume?: ResumeStartup;
+  /** "interrupted" when resume came from the active-session marker (#78). */
+  resumeReason?: "interrupted";
   /** Skip disclaimer; set via --aa / --allow-all / IMPULSE_ALLOW_ALL=1 */
   allowAllOnStartup?: boolean;
 }
@@ -337,6 +340,7 @@ export class ImpulseRenderer {
   private terminal = new ProcessTerminal();
   private tui!: TUI;
   private readonly startupResume: ResumeStartup | null;
+  private readonly startupResumeReason: "interrupted" | null;
   private readonly allowAllOnStartup: boolean;
   private skipGoalContinuation = false;
   /** Chat children below welcome header (fixed); cleared on /new and /resume */
@@ -1451,6 +1455,7 @@ export class ImpulseRenderer {
 
   constructor(options?: ImpulseRendererOptions) {
     this.startupResume = options?.resume ?? null;
+    this.startupResumeReason = options?.resumeReason ?? null;
     this.allowAllOnStartup = options?.allowAllOnStartup ?? false;
   }
 
@@ -1483,10 +1488,24 @@ export class ImpulseRenderer {
     });
 
     if (!SessionManager.getCurrentSession()) {
-      await SessionManager.createNew();
-      const sess = SessionManager.getCurrentSession();
-      if (sess && config.defaultModel?.trim()) {
-        await SessionManager.update({ model: config.defaultModel });
+      // When startup resume targets a known session, load it directly instead
+      // of eagerly creating a blank session first (avoids orphan empty
+      // sessions; #78). Falls back to a fresh session if the load fails.
+      let resumedAtBoot = false;
+      if (this.startupResume && this.startupResume !== "picker") {
+        try {
+          await SessionManager.load(this.startupResume.sessionId);
+          resumedAtBoot = true;
+        } catch {
+          resumedAtBoot = false;
+        }
+      }
+      if (!resumedAtBoot) {
+        await SessionManager.createNew();
+        const sess = SessionManager.getCurrentSession();
+        if (sess && config.defaultModel?.trim()) {
+          await SessionManager.update({ model: config.defaultModel });
+        }
       }
     }
 
@@ -1552,6 +1571,9 @@ export class ImpulseRenderer {
 
       if (event.type === BranchEvents.Changed.name) {
         this.contextBar.invalidate();
+        // Session state is intentionally untouched on branch changes (#78) —
+        // surface a small note so users know why version/behavior may differ.
+        this.addChatLine(clr.dim("Git branch changed — session unaffected"));
         this.tui.requestRender();
         return;
       }
@@ -1815,6 +1837,15 @@ export class ImpulseRenderer {
       await this.cmdResume("");
     } else if (this.startupResume) {
       await this.applyResumeSession(this.startupResume.sessionId);
+      if (this.startupResumeReason === "interrupted") {
+        const sess = SessionManager.getCurrentSession();
+        const title =
+          sess?.headerTitle?.trim() || sess?.name?.trim() || "previous session";
+        this.addChatLine(
+          clr.dim(`Previous session interrupted — resumed '${title}'`)
+        );
+        this.tui.requestRender();
+      }
     }
   }
 
@@ -2845,6 +2876,7 @@ export class ImpulseRenderer {
 
   private async gracefulExit(): Promise<void> {
     await SessionManager.flushCurrent();
+    clearActiveSessionMarker();
     const session = SessionManager.getCurrentSession();
     const config = await loadConfig();
     this.branchWatcher?.dispose();
@@ -3670,6 +3702,7 @@ export class ImpulseRenderer {
     this.addChatLine(clr.dim("Installing update and relaunching..."));
     this.tui.requestRender();
     await SessionManager.flushCurrent();
+    clearActiveSessionMarker();
     const session = SessionManager.getCurrentSession();
     if (session?.id) {
       writeUpdateResumeHint(session.id);

--- a/src/cli/turn-queue.ts
+++ b/src/cli/turn-queue.ts
@@ -94,6 +94,16 @@ export class TurnQueueManager {
     this.editIndex = 0;
   }
 
+  /** Remove the queued item at index (used when user clears text and presses Enter while editing). */
+  deleteAt(index: number): boolean {
+    if (index < 0 || index >= this.queue.length) return false;
+    this.queue.splice(index, 1);
+    this.editOriginal = null;
+    this.holdDrain = false;
+    this.editIndex = 0;
+    return true;
+  }
+
   commitEdit(payload: PromptSubmitPayload): void {
     if (!this.holdDrain) return;
     if (this.isNonempty(payload) && this.editIndex < this.queue.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,7 @@ if (!currentConfig.userProfile?.name) {
 }
 
 let resumeStartup = parseResumeArg(args);
+let resumeReason: "interrupted" | undefined;
 if (!resumeStartup) {
   const { consumeUpdateResumeHint, isUpdateResumeHintValid } = await import(
     "./util/update-resume-hint.js"
@@ -239,6 +240,17 @@ if (!resumeStartup) {
   const updateHint = consumeUpdateResumeHint();
   if (updateHint && isUpdateResumeHintValid(updateHint)) {
     resumeStartup = { sessionId: updateHint.sessionId };
+  }
+}
+if (!resumeStartup) {
+  // Auto-resume sessions interrupted by dev watch reloads, crashes, or kills (#78).
+  const { resolveInterruptedSessionResume } = await import(
+    "./util/active-session-marker.js"
+  );
+  const interrupted = await resolveInterruptedSessionResume();
+  if (interrupted) {
+    resumeStartup = interrupted;
+    resumeReason = "interrupted";
   }
 }
 const messageArgs = stripResumeArgs(args).filter(
@@ -253,7 +265,9 @@ await waitForTuiStart({ timeoutMs: 3000 });
 await initPty();
 
 const renderer = new ImpulseRenderer(
-  resumeStartup ? { resume: resumeStartup } : undefined
+  resumeStartup
+    ? { resume: resumeStartup, ...(resumeReason ? { resumeReason } : {}) }
+    : undefined
 );
 await renderer.start();
 

--- a/src/session/compact.ts
+++ b/src/session/compact.ts
@@ -2,6 +2,10 @@ import { Bus, SessionEvents } from "../bus";
 import { SessionStoreInstance, Message } from "./store";
 import { getProviderManager } from "../api/manager";
 import type { ChatMessage } from "../api/types";
+import {
+  MAX_COMPACT_TOOL_MESSAGE_CHARS,
+  stubOversizedMessageContent,
+} from "../util/tool-output-cap.js";
 
 // Compact thresholds (exported for context bar + agent loop)
 export const COMPACT_WARNING_THRESHOLD = 0.50;  // Orange % in context bar (50–59%)
@@ -11,6 +15,8 @@ export const CONTEXT_WRAPUP_THRESHOLD = 0.80;
 /** Safety margin applied to token estimates before emergency compact / hard cutoff. */
 export const SAFETY_MARGIN = 1.15;
 const TOOL_OUTPUT_RETENTION = 3;               // Keep outputs for last N tool calls
+/** Max chars for a tool message kept in the recent tail after compaction. */
+const MAX_RECENT_TOOL_MESSAGE_CHARS = 8000;
 
 interface CompactConfig {
   threshold: number
@@ -163,6 +169,18 @@ class CompactManagerImpl {
     this.usageCache.delete(sessionID);
   }
 
+  private capOversizedToolMessages(messages: Message[]): Message[] {
+    return messages.map((msg) => {
+      if (msg.role !== "tool" || msg.content.length <= MAX_RECENT_TOOL_MESSAGE_CHARS) {
+        return msg;
+      }
+      return {
+        ...msg,
+        content: stubOversizedMessageContent(msg.content, MAX_RECENT_TOOL_MESSAGE_CHARS),
+      };
+    });
+  }
+
   private pruneToolOutputs(messages: Message[]): Message[] {
     const toolCallIndices: number[] = [];
 
@@ -203,7 +221,11 @@ class CompactManagerImpl {
       text.length > max ? `${text.slice(0, max - 3)}...` : text;
 
     for (const msg of messages) {
-      let text = `[${msg.role.toUpperCase()}]: ${msg.content}`;
+      const body =
+        msg.role === "tool"
+          ? truncateText(msg.content, MAX_COMPACT_TOOL_MESSAGE_CHARS)
+          : msg.content;
+      let text = `[${msg.role.toUpperCase()}]: ${body}`;
 
       if (msg.tool_calls && msg.tool_calls.length > 0) {
         const toolNames = msg.tool_calls.map(tc => tc.tool).filter(Boolean).join(", ");
@@ -391,7 +413,7 @@ IMPORTANT: This summary replaces the entire conversation history. Be thorough an
     try {
       await SessionStoreInstance.flushSave(sessionID);
       const session = await SessionStoreInstance.read(sessionID);
-      const messages = session.messages;
+      const messages = this.capOversizedToolMessages(session.messages);
       const todos = session.todos || [];
       const keepRecentCount =
         options.force && messages.length <= this.config.keepRecentCount

--- a/src/session/injected-message.ts
+++ b/src/session/injected-message.ts
@@ -1,8 +1,10 @@
 import type { Message } from "./store.js";
+import { normalizePasteContent } from "../cli/prompt-input.js";
 
 /** User-visible text for a stored message (API content when expanded). */
 export function messageDisplayText(msg: Message): string {
-  return typeof msg.apiContent === "string" ? msg.apiContent : (msg.content ?? "");
+  const raw = typeof msg.apiContent === "string" ? msg.apiContent : (msg.content ?? "");
+  return raw.includes("\r") ? normalizePasteContent(raw) : raw;
 }
 
 /**

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -109,7 +109,11 @@ class SessionManagerImpl {
 
   async load(sessionID: string): Promise<Session> {
     const session = await SessionStoreInstance.read(sessionID);
-    await this.exitCurrent();
+    if (this.currentSession?.id === sessionID) {
+      await this.flushCurrent();
+    } else {
+      await this.exitCurrent();
+    }
 
     this.currentSession = session;
     this.sessionHistory.push(session);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -9,6 +9,7 @@ import {
 import { CheckpointManager } from "./checkpoint";
 import { CompactManager } from "./compact";
 import type { OptionalPatch } from "../util/omit-undefined.js";
+import { writeActiveSessionMarker } from "../util/active-session-marker.js";
 
 interface SessionManagerOptions {
   defaultModel?: string
@@ -101,6 +102,7 @@ class SessionManagerImpl {
     const newSession = await SessionStoreInstance.create(session);
     this.currentSession = newSession;
     this.sessionHistory.push(newSession);
+    writeActiveSessionMarker(newSession.id);
 
     return newSession;
   }
@@ -111,6 +113,7 @@ class SessionManagerImpl {
 
     this.currentSession = session;
     this.sessionHistory.push(session);
+    writeActiveSessionMarker(session.id);
 
     Bus.publish(SessionEvents.Status, {
       sessionID,
@@ -207,6 +210,7 @@ class SessionManagerImpl {
     const snap = { ...this.currentSession, updated_at: new Date().toISOString() };
     await SessionStoreInstance.writeSnapshot(snap);
     this.currentSession = snap;
+    writeActiveSessionMarker(snap.id);
   }
 
   async save(name?: string): Promise<Session> {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -16,6 +16,7 @@ import { detectPowerShellVersion, translatePosixToPowerShell } from "./posix-tra
 import { detectShellEnvironment } from "../util/shell-env";
 import { detectAndPublishBranchChange } from "../git/branch-detect";
 import { SessionManager } from "../session/manager";
+import { capBashOutputLines } from "../util/tool-output-cap.js";
 
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
@@ -538,14 +539,9 @@ async function executeWithPty(
     
     const elapsed = Date.now() - startTime;
     const maxLines = 2000;
-    const outputLines = result.output.split("\n");
-    let output = result.output;
-    
-    if (outputLines.length >= maxLines) {
-      output = outputLines.slice(0, maxLines).join("\n");
-      output += `\n[Output truncated to ${maxLines} lines]`;
-    }
-    
+    const capped = capBashOutputLines(result.output, maxLines);
+    let output = capped.output;
+
     if (timedOut) {
       output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
     }
@@ -561,7 +557,7 @@ async function executeWithPty(
         workdir: input.workdir,
         exitCode: result.exitCode,
         duration: elapsed,
-        truncated: outputLines.length >= maxLines,
+        truncated: capped.truncated,
         interactive: true,
         pid: result.pid,
       },
@@ -652,15 +648,9 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
     }
   }
   
-  const outputLines = combinedOutput.length > 0 ? combinedOutput.split("\n") : [];
-
-  let output = combinedOutput;
-  let wasTruncated = false;
-  if (outputLines.length >= maxLines) {
-    output = outputLines.slice(0, maxLines).join("\n");
-    output += `\n[Output truncated to ${maxLines} lines]`;
-    wasTruncated = true;
-  }
+  const capped = capBashOutputLines(combinedOutput, maxLines);
+  let output = capped.output;
+  let wasTruncated = capped.truncated;
 
   if (exitCode === -1) {
     output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;

--- a/src/tools/question.ts
+++ b/src/tools/question.ts
@@ -26,9 +26,9 @@ const QuestionOptionSchema = z.object({
 const QuestionSchema = z.object({
   topic: z
     .string()
-    .transform((s) => s.trim().slice(0, 20))
+    .transform((s) => s.trim().slice(0, 60))
     .pipe(z.string().min(1))
-    .describe("Topic/category name shown as tab (max 20 chars, e.g. 'Project setup', 'UI stack')"),
+    .describe("Topic/category name shown as tab (max 60 chars, e.g. 'Project setup', 'UI stack')"),
   question: z.string().describe("Complete question text"),
   options: z.array(QuestionOptionSchema).describe("Available choices (user can also type custom answer)"),
   multiple: z.boolean().optional().describe("Allow selecting multiple choices"),

--- a/src/tools/todo-write.ts
+++ b/src/tools/todo-write.ts
@@ -11,7 +11,8 @@ Rules:
 - Mark a todo in_progress BEFORE starting work on it (exactly ONE in_progress at a time)
 - Mark completed IMMEDIATELY after finishing each item — never batch completions at end of turn
 - Only mark completed when actually done (verified); if blocked, keep in_progress and add a follow-up todo
-- Before ending your turn: every item must be completed or cancelled — never leave stale in_progress/pending for work you already finished`;
+- Before ending your turn: every item must be completed or cancelled — never leave stale in_progress/pending for work you already finished
+- Do not resubmit a relabeled or reworded list when only wording changed — update statuses in place instead`;
 
 const TodoWriteSchema = z.object({
   todos: z.array(z.object({
@@ -38,6 +39,45 @@ function todosSemanticallyEqual(
   return a.every((key, index) => key === b[index]);
 }
 
+function normalizeTodoTokens(content: string): string[] {
+  return content
+    .replace(/^T\d+:\s*/i, "")
+    .replace(/[^\w\s]/g, " ")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+function contentTokenOverlap(a: string, b: string): number {
+  const ta = normalizeTodoTokens(a);
+  const tb = normalizeTodoTokens(b);
+  if (ta.length === 0 && tb.length === 0) return 1;
+  if (ta.length === 0 || tb.length === 0) return 0;
+  const setB = new Set(tb);
+  let shared = 0;
+  for (const token of ta) {
+    if (setB.has(token)) shared++;
+  }
+  return shared / Math.max(ta.length, tb.length);
+}
+
+/** Same item count + status multiset + high per-item wording overlap (relabeled lists). */
+function isCosmeticTodoRewrite(
+  current: Array<{ content: string; status: string }>,
+  incoming: Array<{ content: string; status: string }>
+): boolean {
+  if (current.length !== incoming.length || current.length === 0) return false;
+  if (todosSemanticallyEqual(current, incoming)) return false;
+
+  const statusA = current.map((t) => t.status).sort();
+  const statusB = incoming.map((t) => t.status).sort();
+  if (!statusA.every((s, i) => s === statusB[i])) return false;
+
+  const overlaps = current.map((c, i) => contentTokenOverlap(c.content, incoming[i]!.content));
+  const avg = overlaps.reduce((sum, v) => sum + v, 0) / overlaps.length;
+  return avg >= 0.6;
+}
+
 export const todoWrite: Tool<TodoWriteInput> = Tool.define(
   "todo_write",
   DESCRIPTION,
@@ -62,6 +102,8 @@ export const todoWrite: Tool<TodoWriteInput> = Tool.define(
         };
       }
 
+      const cosmetic = isCosmeticTodoRewrite(current, input.todos);
+
       await Todo.update(input.todos as Todo[]);
 
       const incompleteCount = input.todos.filter(
@@ -77,6 +119,7 @@ export const todoWrite: Tool<TodoWriteInput> = Tool.define(
         metadata: {
           type: "todo",
           source: "write",
+          ...(cosmetic ? { cosmetic: true } : {}),
           todos: input.todos,
           total: input.todos.length,
           remaining: incompleteCount,

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -110,6 +110,8 @@ export interface TodoMetadata {
   source: "read" | "write";
   /** True when todo_write received an identical list — no write performed. */
   unchanged?: boolean;
+  /** True when todo_write only relabeled/reworded items (same statuses) — UI updates in place. */
+  cosmetic?: boolean;
   todos: Array<{
     id: string;
     content: string;

--- a/src/util/active-session-marker.ts
+++ b/src/util/active-session-marker.ts
@@ -84,13 +84,18 @@ function pidAlive(pid: number): boolean {
 }
 
 /**
- * Marker belongs to this project + cwd and its owning process is gone —
- * i.e. the session was interrupted, not currently open in another instance.
+ * Marker belongs to this project + cwd and the session was interrupted,
+ * not currently open in another instance.
+ *
+ * Pid semantics: `bun --watch` re-executes the script in the SAME process,
+ * so a marker carrying our own pid at startup means a watch reload of this
+ * process — resume it. Only a different, still-alive pid means another live
+ * instance owns the session.
  */
 export function isActiveSessionMarkerValid(marker: ActiveSessionMarker): boolean {
   if (marker.projectID !== getCurrentProjectID()) return false;
   if (marker.cwd && path.resolve(marker.cwd) !== path.resolve(process.cwd())) return false;
-  if (marker.pid === process.pid) return false;
+  if (marker.pid === process.pid) return true;
   if (pidAlive(marker.pid)) return false;
   return true;
 }

--- a/src/util/active-session-marker.ts
+++ b/src/util/active-session-marker.ts
@@ -1,0 +1,122 @@
+/**
+ * Active-session lifecycle marker (issue #78).
+ *
+ * Generalizes the /update resume hint to all abrupt restarts: dev watch
+ * reloads (bun --watch restarting after a git branch switch), crashes, and
+ * kills. The marker is written while a session is live and deleted on clean
+ * exit — so its presence at startup means the previous process died with a
+ * session open, and that session should be auto-resumed.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { Global } from "../global.js";
+import { getCurrentProjectID } from "../session/store.js";
+
+export interface ActiveSessionMarker {
+  sessionId: string;
+  projectID: string;
+  cwd: string;
+  pid: number;
+  updatedAt: string;
+}
+
+const DEFAULT_MARKER_DIR = path.join(Global.Path.config, "active");
+
+function markerPath(baseDir: string, projectID: string): string {
+  return path.join(baseDir, `${projectID}.json`);
+}
+
+export function writeActiveSessionMarker(
+  sessionId: string,
+  opts?: { cwd?: string; baseDir?: string }
+): void {
+  // Tests create real sessions through SessionManager; never let them leave a
+  // marker behind that a later real launch would auto-resume.
+  if (!opts?.baseDir && process.env.NODE_ENV === "test") return;
+  try {
+    const marker: ActiveSessionMarker = {
+      sessionId,
+      projectID: getCurrentProjectID(),
+      cwd: opts?.cwd ?? process.cwd(),
+      pid: process.pid,
+      updatedAt: new Date().toISOString(),
+    };
+    const dir = opts?.baseDir ?? DEFAULT_MARKER_DIR;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(markerPath(dir, marker.projectID), JSON.stringify(marker, null, 2), "utf-8");
+  } catch {
+    // Best-effort lifecycle hint — never let it break session flow.
+  }
+}
+
+export function clearActiveSessionMarker(baseDir?: string): void {
+  if (!baseDir && process.env.NODE_ENV === "test") return;
+  try {
+    fs.unlinkSync(markerPath(baseDir ?? DEFAULT_MARKER_DIR, getCurrentProjectID()));
+  } catch {
+    // already gone
+  }
+}
+
+export function readActiveSessionMarker(
+  baseDir = DEFAULT_MARKER_DIR
+): ActiveSessionMarker | undefined {
+  try {
+    const raw = fs.readFileSync(markerPath(baseDir, getCurrentProjectID()), "utf-8");
+    const parsed = JSON.parse(raw) as ActiveSessionMarker;
+    if (!parsed.sessionId?.trim()) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function pidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but we can't signal it.
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Marker belongs to this project + cwd and its owning process is gone —
+ * i.e. the session was interrupted, not currently open in another instance.
+ */
+export function isActiveSessionMarkerValid(marker: ActiveSessionMarker): boolean {
+  if (marker.projectID !== getCurrentProjectID()) return false;
+  if (marker.cwd && path.resolve(marker.cwd) !== path.resolve(process.cwd())) return false;
+  if (marker.pid === process.pid) return false;
+  if (pidAlive(marker.pid)) return false;
+  return true;
+}
+
+/**
+ * Startup resolution: returns the interrupted session to auto-resume, or
+ * undefined. Clears stale markers pointing at missing/empty sessions.
+ */
+export async function resolveInterruptedSessionResume(
+  baseDir = DEFAULT_MARKER_DIR
+): Promise<{ sessionId: string } | undefined> {
+  const marker = readActiveSessionMarker(baseDir);
+  if (!marker) return undefined;
+  if (!isActiveSessionMarkerValid(marker)) return undefined;
+
+  try {
+    const { SessionStoreInstance } = await import("../session/store.js");
+    const { sessionHasResumeableContent } = await import("../session/session-content.js");
+    const session = await SessionStoreInstance.read(marker.sessionId);
+    if (!sessionHasResumeableContent(session)) {
+      clearActiveSessionMarker(baseDir);
+      return undefined;
+    }
+    return { sessionId: marker.sessionId };
+  } catch {
+    clearActiveSessionMarker(baseDir);
+    return undefined;
+  }
+}

--- a/src/util/tool-output-cap.ts
+++ b/src/util/tool-output-cap.ts
@@ -1,0 +1,70 @@
+/** Max chars persisted on any single tool result message (API + session history). */
+export const MAX_TOOL_RESULT_CHARS = 150_000;
+
+/** Max bytes returned from bash stdout/stderr after line caps. */
+export const MAX_BASH_OUTPUT_BYTES = 200_000;
+
+/** Per-line cap for bash output (mirrors file_read). */
+export const MAX_BASH_LINE_CHARS = 2000;
+
+/** Max chars for a single tool message kept in compaction tail / prompts. */
+export const MAX_COMPACT_TOOL_MESSAGE_CHARS = 2000;
+
+export function capToolResultContent(content: string, maxChars = MAX_TOOL_RESULT_CHARS): string {
+  if (content.length <= maxChars) return content;
+  const omitted = content.length - maxChars;
+  return `${content.slice(0, maxChars)}\n[output truncated: ${omitted} chars omitted]`;
+}
+
+export function capBashOutputLines(
+  raw: string,
+  maxLines: number,
+  maxLineChars = MAX_BASH_LINE_CHARS,
+  maxBytes = MAX_BASH_OUTPUT_BYTES
+): { output: string; truncated: boolean } {
+  const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const rawLines = normalized.length > 0 ? normalized.split("\n") : [];
+  const cappedLines: string[] = [];
+  let totalBytes = 0;
+  let truncated = false;
+
+  for (let i = 0; i < rawLines.length && cappedLines.length < maxLines; i++) {
+    let line = rawLines[i]!;
+    if (line.length > maxLineChars) {
+      line = `${line.slice(0, maxLineChars)}…`;
+      truncated = true;
+    }
+    const lineBytes = Buffer.byteLength(line, "utf8") + (cappedLines.length > 0 ? 1 : 0);
+    if (totalBytes + lineBytes > maxBytes) {
+      truncated = true;
+      break;
+    }
+    cappedLines.push(line);
+    totalBytes += lineBytes;
+  }
+
+  if (rawLines.length > maxLines) truncated = true;
+
+  let output = cappedLines.join("\n");
+  if (truncated) {
+    const parts: string[] = [];
+    if (rawLines.length > maxLines) {
+      parts.push(`line limit ${maxLines}`);
+    }
+    if (totalBytes >= maxBytes) {
+      parts.push(`byte limit ${maxBytes}`);
+    }
+    const reason = parts.length > 0 ? parts.join(", ") : "size limit";
+    output += `\n[Output truncated: ${reason}]`;
+  }
+
+  return { output, truncated };
+}
+
+export function stubOversizedMessageContent(
+  content: string,
+  maxChars: number
+): string {
+  if (content.length <= maxChars) return content;
+  return `[truncated ${content.length} chars]\n${content.slice(0, maxChars)}`;
+}

--- a/test/active-session-marker.test.ts
+++ b/test/active-session-marker.test.ts
@@ -59,8 +59,15 @@ describe("active session marker", () => {
     expect(readActiveSessionMarker(tmpDir)).toBeUndefined();
   });
 
-  test("marker from our own pid is not valid (still running)", () => {
+  test("marker from our own pid is valid (bun --watch reload reuses the pid)", () => {
     writeActiveSessionMarker("sess_self", { baseDir: tmpDir });
+    const marker = readActiveSessionMarker(tmpDir)!;
+    expect(isActiveSessionMarkerValid(marker)).toBe(true);
+  });
+
+  test("marker from a different live pid is not valid (other instance owns it)", () => {
+    // PID 1 (launchd/init) is always alive and never us.
+    writeRawMarker({ pid: 1 });
     const marker = readActiveSessionMarker(tmpDir)!;
     expect(isActiveSessionMarkerValid(marker)).toBe(false);
   });

--- a/test/active-session-marker.test.ts
+++ b/test/active-session-marker.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  clearActiveSessionMarker,
+  isActiveSessionMarkerValid,
+  readActiveSessionMarker,
+  resolveInterruptedSessionResume,
+  writeActiveSessionMarker,
+  type ActiveSessionMarker,
+} from "../src/util/active-session-marker.js";
+import { getCurrentProjectID } from "../src/session/store.js";
+import { SessionManager } from "../src/session/manager.js";
+
+const DEAD_PID = 999_999_999;
+
+let tmpDir: string;
+const createdSessionIds: string[] = [];
+
+function writeRawMarker(overrides: Partial<ActiveSessionMarker>): void {
+  const marker: ActiveSessionMarker = {
+    sessionId: "sess_test",
+    projectID: getCurrentProjectID(),
+    cwd: process.cwd(),
+    pid: DEAD_PID,
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+  fs.mkdirSync(tmpDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, `${getCurrentProjectID()}.json`),
+    JSON.stringify(marker),
+    "utf-8"
+  );
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-marker-"));
+});
+
+afterEach(async () => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  while (createdSessionIds.length > 0) {
+    const id = createdSessionIds.pop()!;
+    await SessionManager.deleteSession(id);
+  }
+});
+
+describe("active session marker", () => {
+  test("write/read/clear roundtrip", () => {
+    writeActiveSessionMarker("sess_abc", { baseDir: tmpDir });
+    const marker = readActiveSessionMarker(tmpDir);
+    expect(marker?.sessionId).toBe("sess_abc");
+    expect(marker?.pid).toBe(process.pid);
+    expect(marker?.projectID).toBe(getCurrentProjectID());
+
+    clearActiveSessionMarker(tmpDir);
+    expect(readActiveSessionMarker(tmpDir)).toBeUndefined();
+  });
+
+  test("marker from our own pid is not valid (still running)", () => {
+    writeActiveSessionMarker("sess_self", { baseDir: tmpDir });
+    const marker = readActiveSessionMarker(tmpDir)!;
+    expect(isActiveSessionMarkerValid(marker)).toBe(false);
+  });
+
+  test("marker with dead pid for this project is valid", () => {
+    writeRawMarker({ pid: DEAD_PID });
+    const marker = readActiveSessionMarker(tmpDir)!;
+    expect(isActiveSessionMarkerValid(marker)).toBe(true);
+  });
+
+  test("marker for another project is not valid", () => {
+    writeRawMarker({ projectID: "deadbeef", pid: DEAD_PID });
+    const marker = readActiveSessionMarker(tmpDir)!;
+    expect(isActiveSessionMarkerValid(marker)).toBe(false);
+  });
+
+  test("marker for another cwd is not valid", () => {
+    writeRawMarker({ cwd: "/somewhere/else", pid: DEAD_PID });
+    const marker = readActiveSessionMarker(tmpDir)!;
+    expect(isActiveSessionMarkerValid(marker)).toBe(false);
+  });
+
+  test("resolve returns session id for interrupted session with content", async () => {
+    const session = await SessionManager.createNew("marker-resume-test");
+    createdSessionIds.push(session.id);
+    await SessionManager.addMessage({
+      role: "user",
+      content: "hello from interrupted session",
+      timestamp: new Date().toISOString(),
+    });
+    await SessionManager.flushCurrent();
+
+    writeRawMarker({ sessionId: session.id, pid: DEAD_PID });
+    const resolved = await resolveInterruptedSessionResume(tmpDir);
+    expect(resolved?.sessionId).toBe(session.id);
+  });
+
+  test("resolve clears marker and returns undefined for empty session", async () => {
+    const session = await SessionManager.createNew("marker-empty-test");
+    createdSessionIds.push(session.id);
+    await SessionManager.flushCurrent();
+
+    writeRawMarker({ sessionId: session.id, pid: DEAD_PID });
+    const resolved = await resolveInterruptedSessionResume(tmpDir);
+    expect(resolved).toBeUndefined();
+    expect(readActiveSessionMarker(tmpDir)).toBeUndefined();
+  });
+
+  test("resolve clears marker for missing session", async () => {
+    writeRawMarker({ sessionId: "sess_does_not_exist", pid: DEAD_PID });
+    const resolved = await resolveInterruptedSessionResume(tmpDir);
+    expect(resolved).toBeUndefined();
+    expect(readActiveSessionMarker(tmpDir)).toBeUndefined();
+  });
+});

--- a/test/message-display-text.test.ts
+++ b/test/message-display-text.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { messageDisplayText } from "../src/session/injected-message.js";
+import type { Message } from "../src/session/store.js";
+
+describe("messageDisplayText", () => {
+  test("strips carriage returns for session replay", () => {
+    const msg: Message = {
+      role: "user",
+      content: "line one\rline two\r\nline three",
+      timestamp: new Date().toISOString(),
+    };
+    const text = messageDisplayText(msg);
+    expect(text).not.toContain("\r");
+    expect(text).toContain("line one\nline two\nline three");
+  });
+});

--- a/test/question-topic-cap.test.ts
+++ b/test/question-topic-cap.test.ts
@@ -28,6 +28,28 @@ describe("question topic cap", () => {
     expect(result.output).toContain("prefer 1-3");
   });
 
+  test("accepts topic up to 60 characters", async () => {
+    const longTopic = "Clarifying the reduced level - what stays and what goes";
+    expect(longTopic.length).toBeLessThanOrEqual(60);
+    expect(longTopic.length).toBeGreaterThan(20);
+
+    const asked: string[] = [];
+    const unsub = Bus.subscribe((event) => {
+      if (event.type !== QuestionEvents.Asked.name) return;
+      const payload = event.properties as { questions: Array<{ topic: string }> };
+      asked.push(...payload.questions.map((q) => q.topic));
+      rejectQuestion();
+    });
+
+    await Tool.execute("question", {
+      questions: [makeQuestion(longTopic)],
+    });
+    unsub();
+
+    expect(asked).toEqual([longTopic]);
+    expect(asked[0]!.length).toBeLessThanOrEqual(60);
+  });
+
   test("asks all topics within limit (no truncation)", async () => {
     const questions = Array.from({ length: 5 }, (_, i) => makeQuestion(`T${i + 1}`));
     const asked: string[] = [];

--- a/test/todo-write-noop.test.ts
+++ b/test/todo-write-noop.test.ts
@@ -46,6 +46,45 @@ describe("todo_write no-op dedup", () => {
     expect(result.metadata?.["unchanged"]).toBe(true);
   });
 
+  test("flags cosmetic rewrite when only wording changes", async () => {
+    await Todo.update([
+      {
+        id: "1",
+        content: "Create feature branch fix/branch-contextbar-refresh",
+        status: "in_progress",
+        priority: "high",
+      },
+      {
+        id: "2",
+        content: "Add branch.changed event to src/bus/events.ts",
+        status: "pending",
+        priority: "medium",
+      },
+    ]);
+
+    const result = await Tool.execute("todo_write", {
+      todos: [
+        {
+          id: "1",
+          content: "T0: Create feature branch fix/branch-contextbar-refresh",
+          status: "in_progress",
+          priority: "high",
+        },
+        {
+          id: "2",
+          content: "T1: Add branch.changed event to src/bus/events.ts",
+          status: "pending",
+          priority: "medium",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Todo list updated");
+    expect(result.metadata?.["cosmetic"]).toBe(true);
+    expect(result.metadata?.["unchanged"]).toBeUndefined();
+  });
+
   test("updates when status changes", async () => {
     const result = await Tool.execute("todo_write", {
       todos: [

--- a/test/tool-block-wrap.test.ts
+++ b/test/tool-block-wrap.test.ts
@@ -18,4 +18,24 @@ describe("ToolBlock compact wrap", () => {
     }
     expect(lines.join("\n")).toContain("package.json");
   });
+
+  test("multiline bash command collapses newlines in summary", () => {
+    const command = "gh issue create \\\n--repo spenceriam/impulse \\\n--title bug";
+    const block = new ToolBlock("bash", { command });
+    const lines = block.render(80);
+    expect(lines.join("\n")).not.toContain("\r");
+    expect(lines.join("\n")).toContain("gh issue create");
+    expect(lines.join("\n")).toContain("--repo");
+  });
+
+  test("failed compact bash wraps instead of horizontal ellipsis", () => {
+    const command = "npm run test -- " + "segment-".repeat(20);
+    const block = new ToolBlock("bash", { command });
+    block.setDone({ success: false, output: "fail" }, 40, { compact: true });
+    const lines = block.render(40);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line).not.toContain("…");
+    }
+  });
 });

--- a/test/tool-output-cap.test.ts
+++ b/test/tool-output-cap.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  capBashOutputLines,
+  capToolResultContent,
+  MAX_BASH_LINE_CHARS,
+  MAX_TOOL_RESULT_CHARS,
+} from "../src/util/tool-output-cap.js";
+
+describe("tool output caps", () => {
+  test("capToolResultContent truncates oversized tool results", () => {
+    const raw = "x".repeat(MAX_TOOL_RESULT_CHARS + 5000);
+    const capped = capToolResultContent(raw);
+    expect(capped.length).toBeLessThan(raw.length);
+    expect(capped).toContain("[output truncated:");
+  });
+
+  test("capBashOutputLines enforces per-line and byte limits", () => {
+    const longLine = "a".repeat(MAX_BASH_LINE_CHARS + 500);
+    const raw = Array.from({ length: 5 }, () => longLine).join("\n");
+    const { output, truncated } = capBashOutputLines(raw, 2000, MAX_BASH_LINE_CHARS, 500);
+    expect(truncated).toBe(true);
+    expect(output).toContain("[Output truncated:");
+    expect(output.split("\n")[0]!.length).toBeLessThanOrEqual(MAX_BASH_LINE_CHARS + 1);
+  });
+});

--- a/test/turn-queue.test.ts
+++ b/test/turn-queue.test.ts
@@ -53,6 +53,17 @@ describe("TurnQueueManager", () => {
     expect(q.isHoldDrain).toBe(false);
   });
 
+  test("deleteAt removes item at index and ends edit when queue empty", () => {
+    const q = new TurnQueueManager(5, nonempty);
+    q.enqueue(payload("one"));
+    q.enqueue(payload("two"));
+    expect(q.beginEdit()).toBe(true);
+    expect(q.deleteAt(0)).toBe(true);
+    expect(q.length).toBe(1);
+    expect(q.isHoldDrain).toBe(false);
+    expect(q.at(0)?.displayMessage).toBe("two");
+  });
+
   test("clearHead removes first item", () => {
     const q = new TurnQueueManager(5, nonempty);
     q.enqueue(payload("first"));
@@ -86,6 +97,43 @@ describe("buildQueuePreviewText", () => {
       width: 80,
     });
     expect(text).not.toContain("Queued messages");
+  });
+
+  test("long queued text wraps without horizontal ellipsis", () => {
+    const long = "fix the failing grep test and ".repeat(8);
+    const text = buildQueuePreviewText({
+      items: [payload(long)],
+      holdDrain: false,
+      editIndex: 0,
+      width: 80,
+    });
+    expect(text.split("\n").length).toBeGreaterThan(1);
+    expect(text).not.toContain("…");
+    expect(text).toContain("fix the failing");
+  });
+
+  test("expands pasted queue preview text", () => {
+    const text = buildQueuePreviewText({
+      items: [
+        {
+          apiText: "line one\nline two\nline three",
+          displayMessage: "[Pasted 3 lines  30 chars #1]",
+          orderedImages: [],
+          segments: [
+            {
+              kind: "paste",
+              display: "[Pasted 3 lines  30 chars #1]",
+              content: "line one\nline two\nline three",
+            },
+          ],
+        },
+      ],
+      holdDrain: false,
+      editIndex: 0,
+      width: 80,
+    });
+    expect(text).toContain("line one");
+    expect(text).not.toContain("[Pasted");
   });
 
   test("returns empty when queue is empty and not editing", () => {


### PR DESCRIPTION
## Summary

Fixes all eight open bug issues in one branch: narrow-terminal rendering (#56, #72), context-window blowup recovery (#70), turn-queue polish (#74), cosmetic todo dedup (#68), question topic cap (#57), CR paste/dictation replay (#61), and session auto-resume after process restarts (#78).

Fixes #56
Fixes #57
Fixes #61
Fixes #68
Fixes #70
Fixes #72
Fixes #74
Fixes #78

## Changes

- **#72 / #56** — Sanitize newlines/control chars/ANSI in bash tool titles; wrap failed compact tool rows and `!` shell headers; fix question overlay footer chrome on narrow widths; shorten context bar label to `Allow-All`
- **#70** — Bash per-line/byte caps; 150K tool-result cap at history insert; compaction truncates oversized tool messages in prompts and recent tail
- **#74** — Queue preview wrap-only (no post-wrap ellipsis); expanded paste text in preview; empty Enter while editing deletes the queued item
- **#68** — Similarity-based cosmetic `todo_write` rewrites update the previous block in place
- **#57** — Question topic cap raised to 60 chars (tool schema + bus event)
- **#61** — Normalize CR in stored user transcripts and `messageDisplayText` replay (any dictation/CRLF paste, not WisprFlow-specific)
- **#78** — Per-project active-session marker written while a session is live, cleared on clean exit; startup auto-resumes interrupted sessions (dev watch reload, crash, kill) when the marker's pid is dead and the session has content. Startup resume now loads the session directly instead of eagerly creating a blank one (no more orphan empty session files). Branch changes mid-session show a dim "session unaffected" notice
- **v1.5.1** — CHANGELOG + version bump; regression tests for each area

Made with [Cursor](https://cursor.com)