### PR TITLE
feat: open enhancements v1.6.0 — #50 #60 #62 #65 #80 #83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ### Changed
   - **File edit/write diffs** — compact diff always computed for large files; only the true changed hunks render, with truncation footer when output exceeds the cap
 
+  ### Fixed
+  - **#80** — first-run CLI onboarding now sets `modelExplicitlySet` so the first prompt works without re-running `/model`; existing broken configs repaired on load when `defaultModel` is saved
+
 ## [1.5.1] - 2026-06-11
 
   **Type:** patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-06-11
+
+  **Type:** minor
+  **Title:** Bottom bar visuals, smarter diffs, prompt history upgrades, github_issue URLs
+
+  ### Added
+  - **Bottom bar visuals** — `/settings` option `full` / `reduced` / `minimal` / `off` for a quieter footer; persisted globally in `~/.impulse/config.json`
+  - **Prompt history** — Up recalls slash commands and `!` shell commands; draft restore on Down; per-project persistence (20 entries) under `~/.impulse/history/`
+  - **`github_issue` URL input** — full `https://github.com/owner/repo/issues/N` URLs accepted in the `number` or `url` field, including cross-repo links
+
+  ### Changed
+  - **File edit/write diffs** — compact diff always computed for large files; only the true changed hunks render, with truncation footer when output exceeds the cap
+
 ## [1.5.1] - 2026-06-11
 
   **Type:** patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   ### Fixed
   - **#80** — first-run CLI onboarding now sets `modelExplicitlySet` so the first prompt works without re-running `/model`; existing broken configs repaired on load when `defaultModel` is saved
+  - **`/settings` overlay** — scrollable body with pinned footer; viewport-sized height so key hints are never clipped when options grow
+  - **#83** — `--aa` / `--allow-all` now prompt the allow-all disclaimer at launch (agree to enable; sticky across `/new` and `/resume` for the run, shown in context bar); unknown CLI flags are rejected instead of silently starting
+  - **Allow-all context bar** — indicator stays visible in reduced/minimal bottom-bar visuals (shown as `AA`)
 
 ## [1.5.1] - 2026-06-11
 

--- a/docs/tools/github-issue.md
+++ b/docs/tools/github-issue.md
@@ -4,9 +4,9 @@ Read a GitHub issue using GitHub CLI (`gh`). **Requires `gh` installed and authe
 
 ## Parameters
 
-- `number` (required): Issue number
+- `number` (required unless `url` is provided): Issue number, numeric string, or full issue URL
 - `owner`, `repo` (optional): default to workspace repo from Repository context
-- `url` (optional): full issue URL (parses owner/repo/number)
+- `url` (optional): full issue URL (parses owner/repo/number; sufficient on its own)
 
 ## When to use
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/cli/components/context-bar.ts
+++ b/src/cli/components/context-bar.ts
@@ -354,16 +354,14 @@ export class ContextBarComponent implements Component {
         : "";
 
     let statsFull = "";
-    if (visual === "full") {
-      if (s.allowAllBypass) {
-        statsFull = c.fg(214, "Allow-All");
-      } else if (s.showTurnSpeed) {
-        if (s.tokensPerSecond !== undefined && s.tokensPerSecond > 0) {
-          statsFull += clr.dim(`\u26a1 ${s.tokensPerSecond} tk/s`);
-        }
-        if (s.lastTurnMs !== undefined && s.lastTurnMs > 0) {
-          statsFull += ` ${clr.dim(`\u29d7 ${formatDurationMs(s.lastTurnMs)}`)}`;
-        }
+    if (s.allowAllBypass) {
+      statsFull = c.fg(214, visual === "full" ? "Allow-All" : "AA");
+    } else if (visual === "full" && s.showTurnSpeed) {
+      if (s.tokensPerSecond !== undefined && s.tokensPerSecond > 0) {
+        statsFull += clr.dim(`\u26a1 ${s.tokensPerSecond} tk/s`);
+      }
+      if (s.lastTurnMs !== undefined && s.lastTurnMs > 0) {
+        statsFull += ` ${clr.dim(`\u29d7 ${formatDurationMs(s.lastTurnMs)}`)}`;
       }
     }
 

--- a/src/cli/components/context-bar.ts
+++ b/src/cli/components/context-bar.ts
@@ -10,7 +10,11 @@
 import type { Component } from "@mariozechner/pi-tui";
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import { GUTTER, GUTTER_WIDTH } from "../gutter.js";
-import { formatContextBarRight } from "../context-bar-date.js";
+import {
+  formatContextBarRight,
+  formatContextBarVersionOnly,
+} from "../context-bar-date.js";
+import type { BottomBarVisual } from "../../util/config.js";
 import {
   COMPACT_WARNING_THRESHOLD,
   COMPACT_TRIGGER_THRESHOLD,
@@ -267,6 +271,7 @@ export interface ContextBarState {
   queueDepth?: number;
   goalLabel?: string;
   showAdvisorInBar?: boolean;
+  bottomBarVisual?: BottomBarVisual;
 }
 
 export class ContextBarComponent implements Component {
@@ -288,9 +293,16 @@ export class ContextBarComponent implements Component {
 
   render(width: number): string[] {
     const s = this.state;
-    const cwd = s.cwd ?? process.cwd();
+    const visual = s.bottomBarVisual ?? "full";
 
-    if (this.cachedBranch === null || this.branchCwd !== cwd) {
+    if (visual === "off") {
+      return [truncateToWidth(GUTTER, width)];
+    }
+
+    const cwd = s.cwd ?? process.cwd();
+    const showBranch = visual === "full";
+
+    if (showBranch && (this.cachedBranch === null || this.branchCwd !== cwd)) {
       this.cachedBranch = gitBranch(cwd);
       this.branchCwd = cwd;
     }
@@ -305,49 +317,63 @@ export class ContextBarComponent implements Component {
     const worker = shortModel(s.workerModel);
     const modelSeg = clr.model(worker);
     const rlSeg =
-      s.reasoningLevel && s.reasoningLevel !== "off"
+      visual === "full" && s.reasoningLevel && s.reasoningLevel !== "off"
         ? ` (${clr.model(s.reasoningLevel)})`
         : "";
     const advisorSeg =
-      s.showAdvisorInBar !== false && s.advisorModel
+      visual === "full" && s.showAdvisorInBar !== false && s.advisorModel
         ? ` ${sep}${clr.advisor(shortModel(s.advisorModel))}`
         : "";
     const modelFull = modelSeg + rlSeg + advisorSeg;
 
-    const ctxSeg = `${clr.ctx(tokStr)} ${formatPercentColored(pct, pctStr)}`;
-    const dirSeg = clr.dir(shortDir(cwd));
-    const branchSeg = this.cachedBranch
-      ? ` ${clr.dir("⎇")} ${clr.dir(this.cachedBranch)}`
-      : "";
+    const ctxSeg =
+      visual === "full"
+        ? `${clr.ctx(tokStr)} ${formatPercentColored(pct, pctStr)}`
+        : formatPercentColored(pct, pctStr);
+    const dirSeg = visual !== "minimal" ? clr.dir(shortDir(cwd)) : "";
+    const branchSeg =
+      showBranch && this.cachedBranch
+        ? ` ${clr.dir("⎇")} ${clr.dir(this.cachedBranch)}`
+        : "";
     const dirBranchFull = dirSeg + branchSeg;
 
     const queueSeg =
-      s.queueDepth && s.queueDepth > 0
+      visual === "full" && s.queueDepth && s.queueDepth > 0
         ? clr.sep(` Queue: ${s.queueDepth}`)
         : "";
-    const goalSeg = s.goalLabel
-      ? clr.sep(` Goal: ${truncateToWidth(s.goalLabel, 24)}`)
-      : "";
+    const goalSeg =
+      visual === "full" && s.goalLabel
+        ? clr.sep(` Goal: ${truncateToWidth(s.goalLabel, 24)}`)
+        : "";
     const modeFull =
-      (s.mode === "AGENT" ? "" : c.fg(MODE_COLOR[s.mode] ?? 34, s.mode)) +
-      queueSeg +
-      goalSeg +
-      (s.autoCompactOff ? clr.sep(" compact:OFF") : "");
+      visual === "full"
+        ? (s.mode === "AGENT" ? "" : c.fg(MODE_COLOR[s.mode] ?? 34, s.mode)) +
+          queueSeg +
+          goalSeg +
+          (s.autoCompactOff ? clr.sep(" compact:OFF") : "")
+        : "";
 
     let statsFull = "";
-    if (s.allowAllBypass) {
-      statsFull = c.fg(214, "Allow-All");
-    } else if (s.showTurnSpeed) {
-      if (s.tokensPerSecond !== undefined && s.tokensPerSecond > 0) {
-        statsFull += clr.dim(`\u26a1 ${s.tokensPerSecond} tk/s`);
-      }
-      if (s.lastTurnMs !== undefined && s.lastTurnMs > 0) {
-        statsFull += ` ${clr.dim(`\u29d7 ${formatDurationMs(s.lastTurnMs)}`)}`;
+    if (visual === "full") {
+      if (s.allowAllBypass) {
+        statsFull = c.fg(214, "Allow-All");
+      } else if (s.showTurnSpeed) {
+        if (s.tokensPerSecond !== undefined && s.tokensPerSecond > 0) {
+          statsFull += clr.dim(`\u26a1 ${s.tokensPerSecond} tk/s`);
+        }
+        if (s.lastTurnMs !== undefined && s.lastTurnMs > 0) {
+          statsFull += ` ${clr.dim(`\u29d7 ${formatDurationMs(s.lastTurnMs)}`)}`;
+        }
       }
     }
 
     const now = new Date();
-    const rightSeg = clr.dim(formatContextBarRight(s.impulseVersion, now));
+    const rightSeg =
+      visual === "minimal"
+        ? ""
+        : visual === "reduced"
+          ? clr.dim(formatContextBarVersionOnly(s.impulseVersion))
+          : clr.dim(formatContextBarRight(s.impulseVersion, now));
     const rightWidth = visibleWidth(rightSeg);
     const avail = width - GUTTER_WIDTH;
     const leftAvail = Math.max(0, avail - rightWidth - RIGHT_PAD_COLS);

--- a/src/cli/components/overlay-scroll-region.ts
+++ b/src/cli/components/overlay-scroll-region.ts
@@ -58,3 +58,46 @@ export function handleOverlayScrollInput(
   }
   return null;
 }
+
+export interface ScrollableOverlayInput {
+  top: string[];
+  body: string[];
+  bottom: string[];
+  maxHeight: number;
+  scrollTop: number;
+  keepVisible?: { start: number; length: number };
+}
+
+export interface ScrollableOverlayResult {
+  lines: string[];
+  scrollTop: number;
+  needsScroll: boolean;
+}
+
+/** Pinned top/bottom chrome with a vertically sliced body. */
+export function composeScrollableOverlay(
+  input: ScrollableOverlayInput
+): ScrollableOverlayResult {
+  const chrome = input.top.length + input.bottom.length;
+  if (input.maxHeight <= 0 || input.body.length + chrome <= input.maxHeight) {
+    return {
+      lines: [...input.top, ...input.body, ...input.bottom],
+      scrollTop: 0,
+      needsScroll: false,
+    };
+  }
+  const viewport = Math.max(1, input.maxHeight - chrome);
+  let scrollTop = input.scrollTop;
+  if (input.keepVisible) {
+    const { start, length } = input.keepVisible;
+    const end = start + Math.max(1, length) - 1;
+    if (start < scrollTop) scrollTop = start;
+    else if (end > scrollTop + viewport - 1) scrollTop = end - viewport + 1;
+  }
+  const slice = sliceOverlayBody(input.body, viewport, scrollTop);
+  return {
+    lines: [...input.top, ...slice.visibleLines, ...input.bottom],
+    scrollTop: Math.min(Math.max(0, scrollTop), slice.maxScrollTop),
+    needsScroll: slice.needsScroll,
+  };
+}

--- a/src/cli/components/settings-overlay.ts
+++ b/src/cli/components/settings-overlay.ts
@@ -4,6 +4,7 @@ import type {
   ReasoningLevel,
   ThinkingDisplay,
 } from "../../util/config.js";
+import { composeScrollableOverlay } from "./overlay-scroll-region.js";
 import {
   intrinsicFramedBoxWidth,
   overlayAnsi,
@@ -66,6 +67,7 @@ type SettingsRow = {
 
 const SETTINGS_FOOTER =
   "↑/↓ move   Space: cycle/toggle   Enter: save (vision/model: pick)   Esc: cancel";
+const SETTINGS_FOOTER_SCROLL_SUFFIX = "   (more ↑/↓)";
 
 function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
@@ -104,6 +106,8 @@ export class SettingsOverlay implements Component {
   private values: SettingsValues;
   private selectedIndex = 0;
   private measureTerminalWidth: number | null = null;
+  private maxHeight = 0;
+  private scrollTop = 0;
 
   private readonly rows: SettingsRow[] = [
     {
@@ -194,12 +198,18 @@ export class SettingsOverlay implements Component {
     this.measureTerminalWidth = cols;
   }
 
+  setMaxHeight(lines: number): void {
+    this.maxHeight = Math.max(0, lines);
+  }
+
   preferredBoxWidth(terminalWidth: number): number {
     const terminal = this.measureTerminalWidth ?? terminalWidth;
     const widths = this.rows.map((r) =>
       visibleWidth(formatSettingRowInner(r.label, this.displayValue(r), true, 60))
     );
-    widths.push(visibleWidth(SETTINGS_FOOTER));
+    widths.push(
+      visibleWidth(SETTINGS_FOOTER + SETTINGS_FOOTER_SCROLL_SUFFIX)
+    );
     return intrinsicFramedBoxWidth(terminal, "Settings", widths);
   }
 
@@ -272,6 +282,14 @@ export class SettingsOverlay implements Component {
       this.selectedIndex = Math.min(this.rows.length - 1, this.selectedIndex + 1);
       return;
     }
+    if (data === "\x1b[H" || data === "\x1bOH") {
+      this.selectedIndex = 0;
+      return;
+    }
+    if (data === "\x1b[F" || data === "\x1bOF") {
+      this.selectedIndex = this.rows.length - 1;
+      return;
+    }
     if (data === " ") {
       const row = this.rows[this.selectedIndex];
       if (!row) return;
@@ -336,12 +354,16 @@ export class SettingsOverlay implements Component {
   render(width: number): string[] {
     const boxWidth = overlayRenderBoxWidth(width);
     const innerWidth = Math.max(20, boxWidth - 4);
-    const lines: string[] = [];
 
-    lines.push(overlayTitleLine("Settings", boxWidth));
-    lines.push(overlayEmptyLine(boxWidth));
+    const top = [
+      overlayTitleLine("Settings", boxWidth),
+      overlayEmptyLine(boxWidth),
+    ];
 
+    const body: string[] = [];
+    const rowSpans: { start: number; length: number }[] = [];
     for (let i = 0; i < this.rows.length; i++) {
+      const start = body.length;
       const row = this.rows[i]!;
       const selected = i === this.selectedIndex;
       const inner = formatSettingRowInner(
@@ -351,18 +373,41 @@ export class SettingsOverlay implements Component {
         innerWidth
       );
       const hint = `     ${overlayMuted(row.hint)}`;
-      lines.push(
+      body.push(
         selected
           ? padSelectedSideLine(inner, innerWidth, boxWidth)
           : overlaySideLine(inner, innerWidth, boxWidth)
       );
-      lines.push(overlaySideLine(hint, innerWidth, boxWidth));
+      body.push(overlaySideLine(hint, innerWidth, boxWidth));
+      rowSpans.push({ start, length: body.length - start });
     }
 
-    lines.push(overlayEmptyLine(boxWidth));
-    overlayPushWrapped(lines, SETTINGS_FOOTER, innerWidth, boxWidth);
-    lines.push(overlayBottomBorder(boxWidth));
-    return lines;
+    const buildBottom = (footerText: string): string[] => {
+      const bottom: string[] = [overlayEmptyLine(boxWidth)];
+      overlayPushWrapped(bottom, footerText, innerWidth, boxWidth);
+      bottom.push(overlayBottomBorder(boxWidth));
+      return bottom;
+    };
+
+    let bottom = buildBottom(SETTINGS_FOOTER);
+    const needsScrollAffordance =
+      this.maxHeight > 0 &&
+      top.length + body.length + bottom.length > this.maxHeight;
+    if (needsScrollAffordance) {
+      bottom = buildBottom(SETTINGS_FOOTER + SETTINGS_FOOTER_SCROLL_SUFFIX);
+    }
+
+    const keepVisible = rowSpans[this.selectedIndex];
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: this.maxHeight,
+      scrollTop: this.scrollTop,
+      ...(keepVisible !== undefined ? { keepVisible } : {}),
+    });
+    this.scrollTop = result.scrollTop;
+    return result.lines;
   }
 }
 

--- a/src/cli/components/settings-overlay.ts
+++ b/src/cli/components/settings-overlay.ts
@@ -1,5 +1,9 @@
 import { visibleWidth, type Component } from "@mariozechner/pi-tui";
-import type { ReasoningLevel, ThinkingDisplay } from "../../util/config.js";
+import type {
+  BottomBarVisual,
+  ReasoningLevel,
+  ThinkingDisplay,
+} from "../../util/config.js";
 import {
   intrinsicFramedBoxWidth,
   overlayAnsi,
@@ -17,6 +21,7 @@ import {
 const COMM_STYLES = ["concise", "detailed", "casual", "technical"] as const;
 const THINKING_CYCLE: ThinkingDisplay[] = ["off", "summary", "full"];
 const REASONING_CYCLE: ReasoningLevel[] = ["off", "low", "medium", "high"];
+const BOTTOM_BAR_CYCLE: BottomBarVisual[] = ["full", "reduced", "minimal", "off"];
 
 export interface SettingsValues {
   thinkingDisplay: ThinkingDisplay;
@@ -28,6 +33,7 @@ export interface SettingsValues {
   subagentModel?: string;
   visionModelOverride?: string;
   compactToolOutput: boolean;
+  bottomBarVisual: BottomBarVisual;
 }
 
 export function settingsValuesEqual(a: SettingsValues, b: SettingsValues): boolean {
@@ -40,7 +46,8 @@ export function settingsValuesEqual(a: SettingsValues, b: SettingsValues): boole
     a.useSubagentModel === b.useSubagentModel &&
     (a.subagentModel?.trim() ?? "") === (b.subagentModel?.trim() ?? "") &&
     (a.visionModelOverride?.trim() ?? "") === (b.visionModelOverride?.trim() ?? "") &&
-    a.compactToolOutput === b.compactToolOutput
+    a.compactToolOutput === b.compactToolOutput &&
+    a.bottomBarVisual === b.bottomBarVisual
   );
 }
 
@@ -124,6 +131,12 @@ export class SettingsOverlay implements Component {
       kind: "bool",
     },
     {
+      key: "bottomBarVisual",
+      label: "Bottom bar visuals",
+      hint: "full → reduced → minimal → off",
+      kind: "cycle",
+    },
+    {
       key: "compactToolOutput",
       label: "Compact tool rows",
       hint: "Dim one-liners for read-only tools; expand to see detail",
@@ -202,6 +215,8 @@ export class SettingsOverlay implements Component {
         return formatCycleValue(row.label, this.values.responsePreference);
       case "statsOnExit":
         return formatBool(this.values.statsOnExit);
+      case "bottomBarVisual":
+        return formatCycleValue(row.label, this.values.bottomBarVisual);
       case "compactToolOutput":
         return formatBool(this.values.compactToolOutput);
       case "showSubagentThinking":
@@ -287,6 +302,12 @@ export class SettingsOverlay implements Component {
       }
       case "statsOnExit":
         this.values.statsOnExit = !this.values.statsOnExit;
+        break;
+      case "bottomBarVisual":
+        this.values.bottomBarVisual = cycleValue(
+          this.values.bottomBarVisual,
+          BOTTOM_BAR_CYCLE
+        );
         break;
       case "compactToolOutput":
         this.values.compactToolOutput = !this.values.compactToolOutput;

--- a/src/cli/components/tool-block.ts
+++ b/src/cli/components/tool-block.ts
@@ -601,22 +601,42 @@ function renderDiffSkipped(reason: string | undefined, width: number): string[] 
   return [truncateGutterLine(`       ${clr.dim(`diff skipped: ${reason ?? "not available"}`)}`, width)];
 }
 
+function appendDiffTruncatedFooter(
+  lines: string[],
+  metadata: FileEditMetadata | FileWriteMetadata,
+  width: number
+): void {
+  if (metadata.diffTruncatedLines && metadata.diffTruncatedLines > 0) {
+    lines.push(
+      truncateGutterLine(
+        `       ${clr.dim(`… ${metadata.diffTruncatedLines} more lines`)}`,
+        width
+      )
+    );
+  }
+}
+
 function renderFileEditMetadata(
   metadata: FileEditMetadata,
   width: number,
   maxDiffLines?: number
 ): string[] {
+  const replacements = metadata.replacements ?? 1;
+  const summaryLine = truncateGutterLine(
+    `       ${clr.dim("~")} ${clr.dim(`${replacements} ${pluralize(replacements, "replacement")},`)} ${clr.success(`+${metadata.linesAdded}`)} ${clr.error(`-${metadata.linesRemoved}`)}`,
+    width,
+  );
+
   if (metadata.diffSkipped) {
-    return renderDiffSkipped(metadata.diffReason, width);
+    const lines: string[] = [];
+    if (metadata.linesAdded > 0 || metadata.linesRemoved > 0) {
+      lines.push(summaryLine);
+    }
+    lines.push(...renderDiffSkipped(metadata.diffReason, width));
+    return lines;
   }
 
-  const replacements = metadata.replacements ?? 1;
-  const lines = [
-    truncateGutterLine(
-      `       ${clr.dim("~")} ${clr.dim(`${replacements} ${pluralize(replacements, "replacement")},`)} ${clr.success(`+${metadata.linesAdded}`)} ${clr.error(`-${metadata.linesRemoved}`)}`,
-      width,
-    ),
-  ];
+  const lines = [summaryLine];
 
   if (metadata.compactDiff && metadata.compactDiff.length > 0) {
     if (maxDiffLines === undefined || maxDiffLines > 0) {
@@ -634,6 +654,7 @@ function renderFileEditMetadata(
           )
         );
       }
+      appendDiffTruncatedFooter(lines, metadata, width);
     }
   } else if (metadata.diff) {
     lines.push(SUB_INDENT);
@@ -658,6 +679,11 @@ function renderFileWriteMetadata(
   const lines = [truncateGutterLine(`       ${summary}`, width)];
 
   if (metadata.diffSkipped) {
+    if (linesAdded > 0 || linesRemoved > 0) {
+      // summary already in lines[0]
+    } else {
+      lines.length = 0;
+    }
     lines.push(...renderDiffSkipped(metadata.diffReason, width));
     return lines;
   }
@@ -678,6 +704,7 @@ function renderFileWriteMetadata(
           )
         );
       }
+      appendDiffTruncatedFooter(lines, metadata, width);
     }
   } else if (metadata.diff) {
     lines.push(SUB_INDENT);

--- a/src/cli/components/tool-block.ts
+++ b/src/cli/components/tool-block.ts
@@ -679,11 +679,6 @@ function renderFileWriteMetadata(
   const lines = [truncateGutterLine(`       ${summary}`, width)];
 
   if (metadata.diffSkipped) {
-    if (linesAdded > 0 || linesRemoved > 0) {
-      // summary already in lines[0]
-    } else {
-      lines.length = 0;
-    }
     lines.push(...renderDiffSkipped(metadata.diffReason, width));
     return lines;
   }

--- a/src/cli/context-bar-date.ts
+++ b/src/cli/context-bar-date.ts
@@ -11,3 +11,8 @@ export function formatContextBarDate(now: Date = new Date()): string {
 export function formatContextBarRight(version: string, now: Date = new Date()): string {
   return `v${version} | ${formatContextBarDate(now)}`;
 }
+
+/** Version only for reduced bottom bar mode (no ANSI). */
+export function formatContextBarVersionOnly(version: string): string {
+  return `v${version}`;
+}

--- a/src/cli/prompt-history.ts
+++ b/src/cli/prompt-history.ts
@@ -1,19 +1,30 @@
 /**
- * Session-scoped submitted prompt recall (Up arrow).
+ * Project-scoped submitted prompt recall (Up arrow).
  */
+
+const MAX_ENTRIES = 20;
 
 export class PromptHistory {
   private entries: string[] = [];
   /** -1 = at end (not browsing); otherwise index into entries */
   private index = -1;
+  private draft: string | null = null;
 
   push(text: string): void {
     const t = text.trim();
     if (!t) return;
     const last = this.entries[this.entries.length - 1];
-    if (last === t) return;
+    if (last === t) {
+      this.index = -1;
+      this.draft = null;
+      return;
+    }
     this.entries.push(t);
+    if (this.entries.length > MAX_ENTRIES) {
+      this.entries.splice(0, this.entries.length - MAX_ENTRIES);
+    }
     this.index = -1;
+    this.draft = null;
   }
 
   /** Older entry on repeated Up; null when empty. */
@@ -27,6 +38,27 @@ export class PromptHistory {
     return this.entries[this.index] ?? null;
   }
 
+  /** Call before previous() on the first Up of a browse (index === -1). */
+  saveDraft(current: string): void {
+    if (this.index !== -1) return;
+    this.draft = current.trim() ? current : null;
+  }
+
+  /**
+   * Down semantics (jump): leave browsing in one press.
+   * Returns draft text to restore, or null when caller should clear the prompt.
+   */
+  takeDraft(): string | null {
+    const wasBrowsing = this.index !== -1;
+    this.index = -1;
+    if (!wasBrowsing) return null;
+    return this.draft;
+  }
+
+  isBrowsing(): boolean {
+    return this.index !== -1;
+  }
+
   resetIndex(): void {
     this.index = -1;
   }
@@ -34,10 +66,26 @@ export class PromptHistory {
   reset(): void {
     this.entries = [];
     this.index = -1;
+    this.draft = null;
+  }
+
+  toJSON(): string[] {
+    return [...this.entries];
+  }
+
+  loadEntries(entries: string[]): void {
+    this.entries = entries.slice(-MAX_ENTRIES);
+    this.index = -1;
+    this.draft = null;
   }
 
   /** Test helper */
   size(): number {
     return this.entries.length;
+  }
+
+  /** Test helper */
+  getDraft(): string | null {
+    return this.draft;
   }
 }

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -4861,6 +4861,7 @@ export class ImpulseRenderer {
     }
 
     if (isAllowAllBypass()) {
+      this.allowAllStartupAgreed = false;
       setAllowAllBypass(false);
       this.syncAllowAllBypassUi();
       this.addChatLine(clr.dim("Permission bypass off"));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -332,7 +332,7 @@ export interface ImpulseRendererOptions {
   resume?: ResumeStartup;
   /** "interrupted" when resume came from the active-session marker (#78). */
   resumeReason?: "interrupted";
-  /** Skip disclaimer; set via --aa / --allow-all / IMPULSE_ALLOW_ALL=1 */
+  /** Prompt the allow-all disclaimer at startup; set via --aa / --allow-all / IMPULSE_ALLOW_ALL=1 */
   allowAllOnStartup?: boolean;
 }
 
@@ -343,6 +343,8 @@ export class ImpulseRenderer {
   private readonly startupResume: ResumeStartup | null;
   private readonly startupResumeReason: "interrupted" | null;
   private readonly allowAllOnStartup: boolean;
+  /** True once the startup disclaimer is accepted; keeps allow-all sticky across session switches. */
+  private allowAllStartupAgreed = false;
   private skipGoalContinuation = false;
   /** Chat children below welcome header (fixed); cleared on /new and /resume */
   private welcomeChildCount = 0;
@@ -1809,11 +1811,7 @@ export class ImpulseRenderer {
     // ?? Start TUI (takes over terminal raw mode) ??????????????????????????
     this.syncModeColor(); // set initial arrow color
     this.tui.setFocus(this.promptInput);
-    resetAllowAllBypass();
-    if (this.allowAllOnStartup) {
-      setAllowAllBypass(true);
-    }
-    this.syncAllowAllBypassUi();
+    this.applyAllowAllForSessionScope();
 
     this.tui.addInputListener((data) => {
       if (this.shellTakeoverActive && this.shellCommandRunning) {
@@ -1844,7 +1842,14 @@ export class ImpulseRenderer {
 
     this.tui.start();
     if (this.allowAllOnStartup) {
-      this.addChatLine(clr.dim("All permissions bypassed"));
+      const agreed = await this.showAllowAllDisclaimer();
+      if (agreed) {
+        this.allowAllStartupAgreed = true;
+        this.applyAllowAllForSessionScope();
+        this.addChatLine(clr.dim("All permissions bypassed"));
+      } else {
+        this.addChatLine(clr.dim("Allow-all not enabled."));
+      }
       this.tui.requestRender();
     }
     // Discover reasoning capabilities in background (non-blocking)
@@ -3078,8 +3083,7 @@ export class ImpulseRenderer {
     if (newCfg.defaultModel?.trim()) {
       await SessionManager.update({ model: newCfg.defaultModel });
     }
-    resetAllowAllBypass();
-    this.syncAllowAllBypassUi();
+    this.applyAllowAllForSessionScope();
     this.speedoEnabled = false;
     this.syncSpeedoUi();
     this.promptHistory.resetIndex();
@@ -4548,7 +4552,10 @@ export class ImpulseRenderer {
     };
 
     await new Promise<void>((resolve) => {
-      const handle = this.showContentSizedOverlay(overlay, { maxHeight: 20 });
+      const rows = this.tui.terminal?.rows ?? this.terminal.rows ?? 24;
+      const maxHeight = overlayViewportMaxHeight(rows);
+      overlay.setMaxHeight(maxHeight);
+      const handle = this.showContentSizedOverlay(overlay, { maxHeight });
       this.settingsOverlayHandle = handle;
 
       const cleanupNav = this.tui.addInputListener((data: string) => {
@@ -4782,6 +4789,14 @@ export class ImpulseRenderer {
     } else {
       this.addChatLine(`  ${clr.error("!")} Unknown mode. Options: ${displayModeOptions()}`);
     }
+  }
+
+  private applyAllowAllForSessionScope(): void {
+    resetAllowAllBypass();
+    if (this.allowAllStartupAgreed) {
+      setAllowAllBypass(true);
+    }
+    this.syncAllowAllBypassUi();
   }
 
   private syncAllowAllBypassUi(): void {
@@ -5389,8 +5404,7 @@ export class ImpulseRenderer {
   private async applyResumeSession(sessionID: string): Promise<void> {
     try {
       const session = await SessionManager.load(sessionID);
-      resetAllowAllBypass();
-      this.syncAllowAllBypassUi();
+      this.applyAllowAllForSessionScope();
       this.resetTurnUiState();
       this.clearChatView();
       this.applySessionToRenderer(session);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -72,6 +72,7 @@ const LIST_OVERLAY_MAX_HEIGHT = 18;
 import { overlayMinWidth } from "./layout.js";
 import { overlayMaxHeightForContent, overlayViewportMaxHeight } from "./overlay-height.js";
 import { PromptHistory } from "./prompt-history.js";
+import { loadPromptHistory, savePromptHistory } from "../util/prompt-history-store.js";
 import {
   isAllowAllBypass,
   resetAllowAllBypass,
@@ -1526,6 +1527,9 @@ export class ImpulseRenderer {
     this.contextWindow = SessionManager.getCurrentSession()?.context_window ?? this.contextWindow;
     this.contextTokens = this.estimateCurrentSessionTokens();
 
+    const historyEntries = await loadPromptHistory();
+    this.promptHistory.loadEntries(historyEntries);
+
     // Debug logging
     debugLog(`Session started`);
     debugLog(`thinking: ${config.thinking}, reasoningLevel: ${config.reasoningLevel}`);
@@ -1659,13 +1663,15 @@ export class ImpulseRenderer {
         return;
       }
       if (this.isRunning) return;
+      this.promptHistory.saveDraft(this.promptInput.getText());
       const prev = this.promptHistory.previous();
       if (prev !== null) this.promptInput.setText(prev);
     };
     this.promptInput.onArrowDown = () => {
       if (this.modelSetup) return;
-      this.promptHistory.resetIndex();
-      this.promptInput.clear();
+      const draft = this.promptHistory.takeDraft();
+      if (draft !== null) this.promptInput.setText(draft);
+      else this.promptInput.clear();
     };
     this.promptInput.onTabForward = () => {
       if (this.modelSetup) return;
@@ -2226,6 +2232,7 @@ export class ImpulseRenderer {
 
     const bangCommand = parseBangCommand(input);
     if (bangCommand) {
+      this.recordSubmittedPrompt(input);
       this.promptInput.clear();
       void this.runBangCommand(bangCommand);
       return;
@@ -2248,6 +2255,7 @@ export class ImpulseRenderer {
     }
 
     if (shouldTreatAsSlashCommand(input)) {
+      this.recordSubmittedPrompt(payload.apiText.trim());
       await this.handleSlash(payload.apiText.trim());
       this.tui.requestRender();
       return;
@@ -2258,8 +2266,8 @@ export class ImpulseRenderer {
       // Save the prompt to history even when model isn't configured
       // so the user can retrieve it with the up arrow after configuring the model
       const transcript = userTranscriptText(payload);
-      this.promptHistory.push(transcript);
-      
+      this.recordSubmittedPrompt(transcript);
+
       this.addChatLine(
         clr.warn("No model selected. Run ") + clr.tool("/model") + clr.warn(" to choose a provider and model first.")
       );
@@ -2277,6 +2285,13 @@ export class ImpulseRenderer {
   }
 
   // ?? Agent turn ????????????????????????????????????????????????????????????
+
+  private recordSubmittedPrompt(text: string): void {
+    const t = text.trim();
+    if (!t) return;
+    this.promptHistory.push(t);
+    void savePromptHistory(this.promptHistory.toJSON()).catch(() => {});
+  }
 
   private async runTurn(payload: PromptSubmitPayload): Promise<void> {
     if (!this.isNonemptySubmitPayload(payload)) {
@@ -2323,7 +2338,7 @@ export class ImpulseRenderer {
     }
 
     this.promptInput.clear();
-    this.promptHistory.push(transcript);
+    this.recordSubmittedPrompt(transcript);
 
     this.isRunning = true;
     this.modeChangeText = null;
@@ -3063,7 +3078,7 @@ export class ImpulseRenderer {
     this.syncAllowAllBypassUi();
     this.speedoEnabled = false;
     this.syncSpeedoUi();
-    this.promptHistory.reset();
+    this.promptHistory.resetIndex();
     this.resetTurnUiState();
     this.clearChatView();
     this.addChatLine(clr.dim("New session started"));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -1796,6 +1796,7 @@ export class ImpulseRenderer {
       reasoningLevel: this.reasoningDisplayLabel(),
       ...(this.advisorModel ? { advisorModel: this.advisorModel } : {}),
       showAdvisorInBar: this.experimentalAdvisorEnabled && (config.advisorMode ?? false),
+      bottomBarVisual: config.bottomBarVisual ?? "full",
     });
     this.syncVisionFromConfig(config);
     this.syncSpeedoUi();
@@ -2832,8 +2833,11 @@ export class ImpulseRenderer {
       chatLines += this.measureComponentLines(child as Component, width);
     }
 
-    // Spacer above spinner (1) + separator + prompt + separator + context bar (3)
-    let otherLines = 1 + 1 + 1 + 1 + 3;
+    // Spacer above spinner (1) + separator + prompt + separator + context bar
+    const contextBarLines = this.contextBar
+      ? this.measureComponentLines(this.contextBar, width)
+      : 3;
+    let otherLines = 1 + 1 + 1 + 1 + contextBarLines;
     otherLines += this.measureComponentLines(this.spinnerText, width);
     otherLines += this.measureComponentLines(this.modelSetupText, width);
     otherLines += this.measureComponentLines(this.autocompleteText, width);
@@ -3748,6 +3752,7 @@ export class ImpulseRenderer {
     this.thinkingDisplay = config.thinkingDisplay ?? "summary";
     this.responsePreference = config.userProfile?.responsePreference?.trim() || "concise";
     this.compactToolOutputEnabled = config.compactToolOutput ?? true;
+    this.contextBar?.update({ bottomBarVisual: config.bottomBarVisual ?? "full" });
     this.applyThinkingDisplayMode();
   }
 
@@ -4503,6 +4508,7 @@ export class ImpulseRenderer {
       showSubagentThinking: config.showSubagentThinking,
       useSubagentModel: config.useSubagentModel,
       compactToolOutput: config.compactToolOutput ?? true,
+      bottomBarVisual: config.bottomBarVisual ?? "full",
       ...(config.subagentModel !== undefined ? { subagentModel: config.subagentModel } : {}),
       ...(config.visionModelOverride !== undefined
         ? { visionModelOverride: config.visionModelOverride }
@@ -4524,6 +4530,7 @@ export class ImpulseRenderer {
       config.showSubagentThinking = values.showSubagentThinking;
       config.useSubagentModel = values.useSubagentModel;
       config.compactToolOutput = values.compactToolOutput;
+      config.bottomBarVisual = values.bottomBarVisual;
       config.visionModelOverride = values.visionModelOverride;
       if (values.subagentModel !== undefined) {
         config.subagentModel = values.subagentModel;

--- a/src/cli/startup-flags.ts
+++ b/src/cli/startup-flags.ts
@@ -42,14 +42,18 @@ export function findUnknownFlag(argv: string[]): string | undefined {
 }
 
 export function parseStartupFlags(argv: string[]): { flags: StartupFlags; argv: string[] } {
+  const sepIdx = argv.indexOf("--");
+  const flagArgv = sepIdx >= 0 ? argv.slice(0, sepIdx) : argv;
+
   let allowAllOnStartup =
-    argv.includes("--aa") ||
-    argv.includes("--allow-all") ||
+    flagArgv.includes("--aa") ||
+    flagArgv.includes("--allow-all") ||
     process.env["IMPULSE_ALLOW_ALL"] === "1";
 
   const argvOut: string[] = [];
-  for (const arg of argv) {
-    if (arg === "--aa" || arg === "--allow-all") continue;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if ((arg === "--aa" || arg === "--allow-all") && (sepIdx < 0 || i < sepIdx)) continue;
     argvOut.push(arg);
   }
 

--- a/src/cli/startup-flags.ts
+++ b/src/cli/startup-flags.ts
@@ -6,6 +6,41 @@ export interface StartupFlags {
   allowAllOnStartup: boolean;
 }
 
+/** Boolean flags (no value). */
+export const KNOWN_BOOLEAN_FLAGS = new Set([
+  "--version",
+  "-v",
+  "--update",
+  "--help",
+  "-h",
+  "--setup",
+  "--list-sessions",
+  "--enrich-session-titles",
+  "--dry-run",
+  "--aa",
+  "--allow-all",
+  "--resume",
+  "-r",
+]);
+
+/** Flags that consume the following token as a value. */
+export const VALUE_FLAGS = new Set(["--limit", "--project"]);
+
+/** Returns the first unrecognized flag token, or undefined. Honors `--` end-of-options. */
+export function findUnknownFlag(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--") return undefined;
+    if (!a.startsWith("-")) continue;
+    if (KNOWN_BOOLEAN_FLAGS.has(a) || VALUE_FLAGS.has(a)) {
+      if (VALUE_FLAGS.has(a)) i++;
+      continue;
+    }
+    return a;
+  }
+  return undefined;
+}
+
 export function parseStartupFlags(argv: string[]): { flags: StartupFlags; argv: string[] } {
   let allowAllOnStartup =
     argv.includes("--aa") ||

--- a/src/cli/startup-flags.ts
+++ b/src/cli/startup-flags.ts
@@ -31,7 +31,8 @@ export function findUnknownFlag(argv: string[]): string | undefined {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
     if (a === "--") return undefined;
-    if (!a.startsWith("-")) continue;
+    // Stop at the first non-flag token; trailing args are message text (may include -words).
+    if (!a.startsWith("-")) return undefined;
     if (KNOWN_BOOLEAN_FLAGS.has(a) || VALUE_FLAGS.has(a)) {
       if (VALUE_FLAGS.has(a)) i++;
       continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { testOllamaConnection } from "./api/providers/ollama.js";
 import { discoverModels } from "./cli/model-setup.js";
 import "./tools/init.js";
 import { ImpulseRenderer, type ResumeStartup } from "./cli/renderer.js";
+import { parseStartupFlags, findUnknownFlag } from "./cli/startup-flags.js";
 import { printStartupSplash, waitForTuiStart } from "./cli/startup-splash.js";
 import { initPty } from "./pty/index.js";
 import { migrateHomeIfNeeded } from "./session/migrate-home.js";
@@ -34,6 +35,12 @@ import * as path from "path";
 registerCrashRecoveryHandlers();
 
 const args = process.argv.slice(2);
+
+const unknownFlag = findUnknownFlag(args);
+if (unknownFlag) {
+  console.error(`unknown flag: ${unknownFlag}\nTry 'impulse --help'.`);
+  process.exit(1);
+}
 
 // ─── --version ───────────────────────────────────────────────────────────────
 if (args.includes("--version") || args.includes("-v")) {
@@ -112,6 +119,15 @@ function parseResumeArg(argv: string[]): ResumeStartup | undefined {
     return { sessionId: next };
   }
   return "picker";
+}
+
+function buildMessageArgs(argv: string[]): string[] {
+  const stripped = stripResumeArgs(argv).filter((a) => a !== "--setup");
+  const sepIdx = stripped.indexOf("--");
+  if (sepIdx >= 0) {
+    return stripped.slice(sepIdx + 1);
+  }
+  return stripped.filter((a) => !a.startsWith("-"));
 }
 
 function stripResumeArgs(argv: string[]): string[] {
@@ -253,9 +269,8 @@ if (!resumeStartup) {
     resumeReason = "interrupted";
   }
 }
-const messageArgs = stripResumeArgs(args).filter(
-  (a) => !a.startsWith("-") && a !== "--setup"
-);
+const { flags: startupFlags } = parseStartupFlags(args);
+const messageArgs = buildMessageArgs(args);
 
 // ─── Init tools & start ──────────────────────────────────────────────────────
 await printStartupSplash(
@@ -264,11 +279,12 @@ await printStartupSplash(
 await waitForTuiStart({ timeoutMs: 3000 });
 await initPty();
 
-const renderer = new ImpulseRenderer(
-  resumeStartup
+const renderer = new ImpulseRenderer({
+  ...(resumeStartup
     ? { resume: resumeStartup, ...(resumeReason ? { resumeReason } : {}) }
-    : undefined
-);
+    : {}),
+  allowAllOnStartup: startupFlags.allowAllOnStartup,
+});
 await renderer.start();
 
 if (messageArgs.length > 0 && messageArgs[0]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,6 +442,7 @@ async function runSetup(): Promise<void> {
       providers: {},
       defaultProvider: providerKey,
       defaultModel,
+      modelExplicitlySet: Boolean(defaultModel?.trim()),
       hasSeenWelcome: true,
     })
   );
@@ -454,6 +455,7 @@ async function runSetup(): Promise<void> {
   };
   cfg.defaultProvider = providerKey;
   cfg.defaultModel = defaultModel;
+  cfg.modelExplicitlySet = Boolean(defaultModel?.trim());
   if (envVar) process.env[envVar] = key;
 
   await saveConfig(cfg as Parameters<typeof saveConfig>[0]);

--- a/src/tools/file-edit.ts
+++ b/src/tools/file-edit.ts
@@ -3,7 +3,12 @@ import { Tool, ToolResult } from "./registry";
 import { readFile, writeFile } from "fs/promises";
 import { resolve, relative, isAbsolute } from "path";
 import { createPatch } from "diff";
-import { createCompactDiff } from "../util/compact-diff";
+import {
+  capCompactDiffResult,
+  createCompactDiff,
+  MAX_DIFF_INPUT_BYTES,
+  MAX_DIFF_PATCH_BYTES,
+} from "../util/compact-diff";
 import { resolveToolPath } from "./resolve-tool-path.js";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
@@ -33,7 +38,6 @@ const EditSchema = z.object({
 });
 
 type EditInput = z.infer<typeof EditSchema>;
-const MAX_DIFF_BYTES = 200_000; // 200KB
 
 /**
  * Check if a path is within the current working directory
@@ -123,7 +127,9 @@ export const fileEdit: Tool<EditInput> = Tool.define(
         newContent = applyReplacement(content, match, input.newString);
       }
 
-      const shouldSkipDiff = Buffer.byteLength(content, "utf-8") + Buffer.byteLength(newContent, "utf-8") > MAX_DIFF_BYTES;
+      const combinedBytes =
+        Buffer.byteLength(content, "utf-8") + Buffer.byteLength(newContent, "utf-8");
+      const shouldSkipDiff = combinedBytes > MAX_DIFF_INPUT_BYTES;
       let diff = "";
       let compactDiff: string[] | undefined;
       let linesAdded = 0;
@@ -131,25 +137,29 @@ export const fileEdit: Tool<EditInput> = Tool.define(
       let firstChangedLine: number | undefined;
       let diffSkipped = false;
       let diffReason: string | undefined;
+      let diffTruncatedLines: number | undefined;
 
       if (shouldSkipDiff) {
         diffSkipped = true;
         diffReason = "File too large to diff";
       } else {
-        // Generate unified diff before writing
-        diff = createPatch(
-          input.filePath,
-          content,      // old content
-          newContent,   // new content
-          "original",
-          "modified"
-        );
-
         const compact = createCompactDiff(content, newContent);
-        compactDiff = compact.lines;
-        linesAdded = compact.additions;
-        linesRemoved = compact.removals;
-        firstChangedLine = compact.firstChangedLine;
+        const capped = capCompactDiffResult(compact);
+        compactDiff = capped.compactDiff;
+        linesAdded = capped.linesAdded;
+        linesRemoved = capped.linesRemoved;
+        firstChangedLine = capped.firstChangedLine;
+        diffTruncatedLines = capped.diffTruncatedLines;
+
+        if (combinedBytes <= MAX_DIFF_PATCH_BYTES) {
+          diff = createPatch(
+            input.filePath,
+            content,
+            newContent,
+            "original",
+            "modified"
+          );
+        }
       }
 
       await writeFile(safePath, newContent, "utf-8");
@@ -178,6 +188,7 @@ export const fileEdit: Tool<EditInput> = Tool.define(
           firstChangedLine,
           diffSkipped,
           diffReason,
+          diffTruncatedLines,
         },
       };
     } catch (error) {

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -6,7 +6,13 @@ import { sanitizePath } from "../util/path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
 import { createPatch } from "diff";
-import { createAddedFileCompactDiff, createCompactDiff } from "../util/compact-diff";
+import {
+  capCompactDiffResult,
+  createAddedFileCompactDiff,
+  createCompactDiff,
+  MAX_DIFF_INPUT_BYTES,
+  MAX_DIFF_PATCH_BYTES,
+} from "../util/compact-diff";
 import { Bus } from "../bus";
 import { FileEvents } from "../format/events";
 import { zFilePath } from "./schemas/branded";
@@ -22,7 +28,6 @@ const WriteSchema = z.object({
 });
 
 type WriteInput = z.infer<typeof WriteSchema>;
-const MAX_DIFF_BYTES = 200_000; // 200KB
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -117,7 +122,8 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
       }
 
       const newSize = Buffer.byteLength(input.content, "utf-8");
-      const shouldSkipDiff = existingSize + newSize > MAX_DIFF_BYTES;
+      const combinedBytes = existingSize + newSize;
+      const shouldSkipDiff = combinedBytes > MAX_DIFF_INPUT_BYTES;
 
       if (!isNewFile && !shouldSkipDiff) {
         try {
@@ -145,25 +151,32 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
       let firstChangedLine: number | undefined;
       let diffSkipped = false;
       let diffReason: string | undefined;
+      let diffTruncatedLines: number | undefined;
       if (shouldSkipDiff) {
         diffSkipped = true;
         diffReason = "File too large to diff";
       } else if (isNewFile) {
-        // For new files, create a diff showing all lines as additions
-        diff = createPatch(fileName, "", input.content, "", "");
         const compact = createAddedFileCompactDiff(input.content);
-        compactDiff = compact.lines;
-        linesAdded = compact.additions;
-        linesRemoved = compact.removals;
-        firstChangedLine = compact.firstChangedLine;
+        const capped = capCompactDiffResult(compact);
+        compactDiff = capped.compactDiff;
+        linesAdded = capped.linesAdded;
+        linesRemoved = capped.linesRemoved;
+        firstChangedLine = capped.firstChangedLine;
+        diffTruncatedLines = capped.diffTruncatedLines;
+        if (combinedBytes <= MAX_DIFF_PATCH_BYTES) {
+          diff = createPatch(fileName, "", input.content, "", "");
+        }
       } else {
-        // For overwrites, create a proper diff
-        diff = createPatch(fileName, existingContent, input.content, "", "");
         const compact = createCompactDiff(existingContent, input.content);
-        compactDiff = compact.lines;
-        linesAdded = compact.additions;
-        linesRemoved = compact.removals;
-        firstChangedLine = compact.firstChangedLine;
+        const capped = capCompactDiffResult(compact);
+        compactDiff = capped.compactDiff;
+        linesAdded = capped.linesAdded;
+        linesRemoved = capped.linesRemoved;
+        firstChangedLine = capped.firstChangedLine;
+        diffTruncatedLines = capped.diffTruncatedLines;
+        if (combinedBytes <= MAX_DIFF_PATCH_BYTES) {
+          diff = createPatch(fileName, existingContent, input.content, "", "");
+        }
       }
 
       // Emit file edited event for formatters
@@ -187,6 +200,7 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
           firstChangedLine,
           diffSkipped,
           diffReason,
+          diffTruncatedLines,
         },
       };
     } catch (error) {

--- a/src/tools/github-issue.ts
+++ b/src/tools/github-issue.ts
@@ -12,28 +12,9 @@ const DESCRIPTION = `Read a GitHub issue via GitHub CLI (gh). Requires gh instal
 
 Does not use web_fetch. If gh is unavailable, the tool returns the canonical issue URL — use web_fetch on that URL instead.
 
-For "issue #N" in the current workspace, omit owner/repo (uses Repository context).`;
+For "issue #N" in the current workspace, omit owner/repo (uses Repository context).
 
-const GithubIssueSchema = z.object({
-  number: z.number().int().positive().describe("Issue number"),
-  owner: z.string().optional().describe("Repository owner (defaults to workspace repo)"),
-  repo: z.string().optional().describe("Repository name (defaults to workspace repo)"),
-  url: z
-    .string()
-    .optional()
-    .describe("Full GitHub issue URL (overrides number/owner/repo when parseable)"),
-});
-
-type GithubIssueInput = z.infer<typeof GithubIssueSchema>;
-
-interface GhIssueJson {
-  title?: string;
-  body?: string;
-  state?: string;
-  url?: string;
-  labels?: Array<{ name?: string }>;
-  comments?: Array<{ author?: { login?: string }; body?: string }>;
-}
+Accepts an issue number or a full https://github.com/owner/repo/issues/N URL (URLs may be passed in either the number or url field).`;
 
 function parseIssueUrl(url: string): { owner: string; repo: string; number: number } | null {
   try {
@@ -51,6 +32,56 @@ function parseIssueUrl(url: string): { owner: string; repo: string; number: numb
     return null;
   }
   return null;
+}
+
+function preprocessGithubIssueInput(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const obj = { ...(raw as Record<string, unknown>) };
+  if (typeof obj.number === "string") {
+    const fromUrl = parseIssueUrl(obj.number);
+    if (fromUrl) {
+      obj.url = obj.url ?? obj.number;
+      obj.number = fromUrl.number;
+      obj.owner = obj.owner ?? fromUrl.owner;
+      obj.repo = obj.repo ?? fromUrl.repo;
+    } else {
+      const n = parseInt(obj.number, 10);
+      if (!Number.isNaN(n) && n > 0) obj.number = n;
+    }
+  }
+  if (obj.number === undefined && typeof obj.url === "string") {
+    const fromUrl = parseIssueUrl(obj.url);
+    if (fromUrl) obj.number = fromUrl.number;
+  }
+  return obj;
+}
+
+export const GithubIssueSchema = z.preprocess(
+  preprocessGithubIssueInput,
+  z.object({
+    number: z
+      .number()
+      .int()
+      .positive()
+      .describe("Issue number, or paste a full GitHub issue URL here"),
+    owner: z.string().optional().describe("Repository owner (defaults to workspace repo)"),
+    repo: z.string().optional().describe("Repository name (defaults to workspace repo)"),
+    url: z
+      .string()
+      .optional()
+      .describe("Full GitHub issue URL (overrides number/owner/repo when parseable)"),
+  })
+);
+
+type GithubIssueInput = z.infer<typeof GithubIssueSchema>;
+
+interface GhIssueJson {
+  title?: string;
+  body?: string;
+  state?: string;
+  url?: string;
+  labels?: Array<{ name?: string }>;
+  comments?: Array<{ author?: { login?: string }; body?: string }>;
 }
 
 function resolveTarget(input: GithubIssueInput, ctx: RepoContext | null): {

--- a/src/tools/github-issue.ts
+++ b/src/tools/github-issue.ts
@@ -45,9 +45,9 @@ function preprocessGithubIssueInput(raw: unknown): unknown {
       obj["number"] = fromUrl.number;
       obj["owner"] = obj["owner"] ?? fromUrl.owner;
       obj["repo"] = obj["repo"] ?? fromUrl.repo;
-    } else {
+    } else if (/^\d+$/.test(numStr)) {
       const n = parseInt(numStr, 10);
-      if (!Number.isNaN(n) && n > 0) obj["number"] = n;
+      if (n > 0) obj["number"] = n;
     }
   }
   if (obj["number"] === undefined && typeof obj["url"] === "string") {

--- a/src/tools/github-issue.ts
+++ b/src/tools/github-issue.ts
@@ -37,21 +37,22 @@ function parseIssueUrl(url: string): { owner: string; repo: string; number: numb
 function preprocessGithubIssueInput(raw: unknown): unknown {
   if (typeof raw !== "object" || raw === null) return raw;
   const obj = { ...(raw as Record<string, unknown>) };
-  if (typeof obj.number === "string") {
-    const fromUrl = parseIssueUrl(obj.number);
+  if (typeof obj["number"] === "string") {
+    const numStr = obj["number"];
+    const fromUrl = parseIssueUrl(numStr);
     if (fromUrl) {
-      obj.url = obj.url ?? obj.number;
-      obj.number = fromUrl.number;
-      obj.owner = obj.owner ?? fromUrl.owner;
-      obj.repo = obj.repo ?? fromUrl.repo;
+      obj["url"] = obj["url"] ?? numStr;
+      obj["number"] = fromUrl.number;
+      obj["owner"] = obj["owner"] ?? fromUrl.owner;
+      obj["repo"] = obj["repo"] ?? fromUrl.repo;
     } else {
-      const n = parseInt(obj.number, 10);
-      if (!Number.isNaN(n) && n > 0) obj.number = n;
+      const n = parseInt(numStr, 10);
+      if (!Number.isNaN(n) && n > 0) obj["number"] = n;
     }
   }
-  if (obj.number === undefined && typeof obj.url === "string") {
-    const fromUrl = parseIssueUrl(obj.url);
-    if (fromUrl) obj.number = fromUrl.number;
+  if (obj["number"] === undefined && typeof obj["url"] === "string") {
+    const fromUrl = parseIssueUrl(obj["url"]);
+    if (fromUrl) obj["number"] = fromUrl.number;
   }
   return obj;
 }

--- a/src/types/tool-metadata.ts
+++ b/src/types/tool-metadata.ts
@@ -34,6 +34,8 @@ export interface FileWriteMetadata {
   firstChangedLine?: number; // First changed line in the new file
   diffSkipped?: boolean;     // True if diff was skipped due to size
   diffReason?: string;       // Reason diff was skipped
+  /** Number of compactDiff lines dropped due to metadata size cap. */
+  diffTruncatedLines?: number;
 }
 
 // ============================================
@@ -50,6 +52,8 @@ export interface FileEditMetadata {
   firstChangedLine?: number; // First changed line in the new file
   diffSkipped?: boolean;     // True if diff was skipped due to size
   diffReason?: string;       // Reason diff was skipped
+  /** Number of compactDiff lines dropped due to metadata size cap. */
+  diffTruncatedLines?: number;
 }
 
 // ============================================

--- a/src/util/compact-diff.ts
+++ b/src/util/compact-diff.ts
@@ -15,6 +15,44 @@ export interface CompactDiffResult {
 
 const DEFAULT_CONTEXT_LINES = 2;
 
+/** Hard input safety valve: skip diffing entirely above this (pathological files). */
+export const MAX_DIFF_INPUT_BYTES = 2_000_000;
+
+/** Max compactDiff lines stored in tool metadata; excess is truncated. */
+export const MAX_COMPACT_DIFF_LINES = 200;
+
+/** Legacy unified patch gate — UI prefers compactDiff. */
+export const MAX_DIFF_PATCH_BYTES = 200_000;
+
+export interface CappedCompactDiff {
+  compactDiff: string[];
+  linesAdded: number;
+  linesRemoved: number;
+  firstChangedLine?: number;
+  diffTruncatedLines?: number;
+}
+
+/** Store compact diff lines with a metadata cap; counts reflect the full change. */
+export function capCompactDiffResult(compact: CompactDiffResult): CappedCompactDiff {
+  const base: Pick<CappedCompactDiff, "linesAdded" | "linesRemoved"> & {
+    firstChangedLine?: number;
+  } = {
+    linesAdded: compact.additions,
+    linesRemoved: compact.removals,
+  };
+  if (compact.firstChangedLine !== undefined) {
+    base.firstChangedLine = compact.firstChangedLine;
+  }
+  if (compact.lines.length <= MAX_COMPACT_DIFF_LINES) {
+    return { compactDiff: compact.lines, ...base };
+  }
+  return {
+    compactDiff: compact.lines.slice(0, MAX_COMPACT_DIFF_LINES),
+    diffTruncatedLines: compact.lines.length - MAX_COMPACT_DIFF_LINES,
+    ...base,
+  };
+}
+
 function normalizeToLf(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -18,6 +18,10 @@ const ReasoningLevelSchema = z.enum(["off", "low", "medium", "high"]);
 export type ThinkingDisplay = "off" | "summary" | "full";
 const ThinkingDisplaySchema = z.enum(["off", "summary", "full"]);
 
+/** Bottom context bar verbosity. */
+export type BottomBarVisual = "full" | "reduced" | "minimal" | "off";
+const BottomBarVisualSchema = z.enum(["full", "reduced", "minimal", "off"]);
+
 const ProviderKeySchema = z.object({
   /** API key for this provider */
   apiKey: z.string().optional(),
@@ -120,6 +124,9 @@ const ConfigSchema = z.object({
 
   /** Dim one-liner for read-only tool success rows */
   compactToolOutput: z.boolean().default(true),
+
+  /** Bottom context bar verbosity: full | reduced | minimal | off */
+  bottomBarVisual: BottomBarVisualSchema.default("full"),
 
   /** Per-model reliability overrides when tool continuations fail */
   modelProfiles: z

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -243,13 +243,7 @@ export async function load(): Promise<Config> {
     parsed.thinkingDisplay =
       fileConfig.showMainThinking === false ? "off" : "summary";
   }
-  // Legacy configs: existing defaultModel implies explicit choice
-  if (
-    fileConfig.defaultModel &&
-    typeof (fileConfig as { modelExplicitlySet?: boolean }).modelExplicitlySet !== "boolean"
-  ) {
-    parsed.modelExplicitlySet = true;
-  }
+  repairModelExplicitlySet(fileConfig, parsed);
   // Advisor requires experimental flag
   if (parsed.advisorMode && !isExperimentalAdvisorEnabled(parsed)) {
     parsed.advisorMode = false;
@@ -298,6 +292,19 @@ export function applySessionVision(config: Config): Config {
     };
   }
   return { ...config, visionMode: false };
+}
+
+/**
+ * Non-empty defaultModel implies the user chose a model (onboarding, /model, cli setup).
+ * Repairs first-run onboarding configs that saved defaultModel without modelExplicitlySet (#80).
+ */
+export function repairModelExplicitlySet(
+  fileConfig: Partial<Config>,
+  parsed: Config
+): void {
+  if (fileConfig.defaultModel?.trim() && parsed.modelExplicitlySet !== true) {
+    parsed.modelExplicitlySet = true;
+  }
 }
 
 /** Whether the user has saved a default model (required before chat). */

--- a/src/util/prompt-history-store.ts
+++ b/src/util/prompt-history-store.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import { Global } from "../global.js";
+import { getCurrentProjectID } from "../session/store.js";
+
+const DEFAULT_HISTORY_DIR = path.join(Global.Path.home, "history");
+
+function historyPath(projectID: string, baseDir?: string): string {
+  return path.join(baseDir ?? DEFAULT_HISTORY_DIR, `${projectID}.json`);
+}
+
+export async function loadPromptHistory(opts?: {
+  projectID?: string;
+  baseDir?: string;
+}): Promise<string[]> {
+  const projectID = opts?.projectID ?? getCurrentProjectID();
+  const file = historyPath(projectID, opts?.baseDir);
+  try {
+    const raw = await fs.readFile(file, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") return [];
+    return [];
+  }
+}
+
+export async function savePromptHistory(
+  entries: string[],
+  opts?: { projectID?: string; baseDir?: string }
+): Promise<void> {
+  const projectID = opts?.projectID ?? getCurrentProjectID();
+  const dir = opts?.baseDir ?? DEFAULT_HISTORY_DIR;
+  const file = historyPath(projectID, opts?.baseDir);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(entries, null, 2), "utf-8");
+  await fs.rename(tmp, file);
+}

--- a/src/util/prompt-history-store.ts
+++ b/src/util/prompt-history-store.ts
@@ -5,6 +5,8 @@ import { getCurrentProjectID } from "../session/store.js";
 
 const DEFAULT_HISTORY_DIR = path.join(Global.Path.home, "history");
 
+const saveChains = new Map<string, Promise<void>>();
+
 function historyPath(projectID: string, baseDir?: string): string {
   return path.join(baseDir ?? DEFAULT_HISTORY_DIR, `${projectID}.json`);
 }
@@ -34,8 +36,21 @@ export async function savePromptHistory(
   const projectID = opts?.projectID ?? getCurrentProjectID();
   const dir = opts?.baseDir ?? DEFAULT_HISTORY_DIR;
   const file = historyPath(projectID, opts?.baseDir);
-  await fs.mkdir(dir, { recursive: true });
-  const tmp = `${file}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(entries, null, 2), "utf-8");
-  await fs.rename(tmp, file);
+  const key = file;
+
+  const write = async (): Promise<void> => {
+    await fs.mkdir(dir, { recursive: true });
+    const tmp = `${file}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(entries, null, 2), "utf-8");
+    await fs.rename(tmp, file);
+  };
+
+  const prev = saveChains.get(key) ?? Promise.resolve();
+  const next = prev.then(write, write);
+  saveChains.set(key, next);
+  try {
+    await next;
+  } finally {
+    if (saveChains.get(key) === next) saveChains.delete(key);
+  }
 }

--- a/test/allow-all-startup.test.ts
+++ b/test/allow-all-startup.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  isAllowAllBypass,
+  resetAllowAllBypass,
+  setAllowAllBypass,
+} from "../src/permission/index.js";
+
+/**
+ * Mirrors ImpulseRenderer.applyAllowAllForSessionScope (session switch contract).
+ * Stickiness is driven by the accepted startup disclaimer, not the raw --aa flag.
+ */
+function applyAllowAllForSessionScope(allowAllStartupAgreed: boolean): void {
+  resetAllowAllBypass();
+  if (allowAllStartupAgreed) {
+    setAllowAllBypass(true);
+  }
+}
+
+describe("startup allow-all session scope", () => {
+  beforeEach(() => {
+    resetAllowAllBypass();
+  });
+
+  test("agreed disclaimer re-applies after session-scope reset", () => {
+    applyAllowAllForSessionScope(true);
+    expect(isAllowAllBypass()).toBe(true);
+    applyAllowAllForSessionScope(true);
+    expect(isAllowAllBypass()).toBe(true);
+  });
+
+  test("declined startup disclaimer stays off across session switch", () => {
+    applyAllowAllForSessionScope(false);
+    expect(isAllowAllBypass()).toBe(false);
+  });
+
+  test("per-session allow-all cleared on session switch when not sticky", () => {
+    setAllowAllBypass(true);
+    expect(isAllowAllBypass()).toBe(true);
+    applyAllowAllForSessionScope(false);
+    expect(isAllowAllBypass()).toBe(false);
+  });
+});

--- a/test/allow-all-startup.test.ts
+++ b/test/allow-all-startup.test.ts
@@ -39,4 +39,16 @@ describe("startup allow-all session scope", () => {
     applyAllowAllForSessionScope(false);
     expect(isAllowAllBypass()).toBe(false);
   });
+
+  test("user toggle off clears startup sticky across session switch", () => {
+    let allowAllStartupAgreed = true;
+    applyAllowAllForSessionScope(allowAllStartupAgreed);
+    expect(isAllowAllBypass()).toBe(true);
+
+    allowAllStartupAgreed = false;
+    setAllowAllBypass(false);
+
+    applyAllowAllForSessionScope(allowAllStartupAgreed);
+    expect(isAllowAllBypass()).toBe(false);
+  });
 });

--- a/test/compact-diff-cap.test.ts
+++ b/test/compact-diff-cap.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  capCompactDiffResult,
+  createCompactDiff,
+  MAX_COMPACT_DIFF_LINES,
+  MAX_DIFF_INPUT_BYTES,
+} from "../src/util/compact-diff.js";
+
+describe("compact diff caps", () => {
+  test("small edit on large file produces short compact diff", () => {
+    const large = `${"x".repeat(32)}\n`.repeat(8000);
+    const appended = `${large}line1\nline2\nline3\n`;
+    const compact = createCompactDiff(large, appended);
+    expect(compact.additions).toBe(3);
+    expect(compact.lines.length).toBeLessThan(20);
+    const combined = Buffer.byteLength(large) + Buffer.byteLength(appended);
+    expect(combined).toBeGreaterThan(200_000);
+    expect(combined).toBeLessThan(MAX_DIFF_INPUT_BYTES);
+  });
+
+  test("capCompactDiffResult truncates long output but keeps full counts", () => {
+    const oldLines = Array.from({ length: 250 }, (_, i) => `old-${i}`).join("\n");
+    const newLines = Array.from({ length: 250 }, (_, i) => `new-${i}`).join("\n");
+    const compact = createCompactDiff(oldLines, newLines);
+    expect(compact.lines.length).toBeGreaterThan(MAX_COMPACT_DIFF_LINES);
+    const capped = capCompactDiffResult(compact);
+    expect(capped.compactDiff.length).toBe(MAX_COMPACT_DIFF_LINES);
+    expect(capped.diffTruncatedLines).toBe(compact.lines.length - MAX_COMPACT_DIFF_LINES);
+    expect(capped.linesAdded).toBe(compact.additions);
+    expect(capped.linesRemoved).toBe(compact.removals);
+  });
+
+  test("combined input above MAX_DIFF_INPUT_BYTES is the skip threshold", () => {
+    const half = "a".repeat(MAX_DIFF_INPUT_BYTES / 2 + 1);
+    const combined = Buffer.byteLength(half) + Buffer.byteLength(half);
+    expect(combined).toBeGreaterThan(MAX_DIFF_INPUT_BYTES);
+  });
+});

--- a/test/config-model-flag.test.ts
+++ b/test/config-model-flag.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDefaultConfig,
+  isModelConfigured,
+  repairModelExplicitlySet,
+} from "../src/util/config.js";
+
+describe("isModelConfigured", () => {
+  test("requires modelExplicitlySet and non-empty defaultModel", () => {
+    expect(
+      isModelConfigured(
+        createDefaultConfig({
+          defaultModel: "ollama/nemotron-3-ultra",
+          modelExplicitlySet: true,
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("false when modelExplicitlySet is false despite defaultModel", () => {
+    expect(
+      isModelConfigured(
+        createDefaultConfig({
+          defaultModel: "ollama/nemotron-3-ultra",
+          modelExplicitlySet: false,
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("false when defaultModel is empty regardless of flag", () => {
+    expect(
+      isModelConfigured(
+        createDefaultConfig({
+          defaultModel: "",
+          modelExplicitlySet: true,
+        })
+      )
+    ).toBe(false);
+    expect(
+      isModelConfigured(
+        createDefaultConfig({
+          defaultModel: "   ",
+          modelExplicitlySet: true,
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("repairModelExplicitlySet", () => {
+  test("repairs onboarding configs with defaultModel but modelExplicitlySet false", () => {
+    const parsed = createDefaultConfig({
+      defaultModel: "ollama/nemotron-3-ultra",
+      modelExplicitlySet: false,
+    });
+    repairModelExplicitlySet(
+      { defaultModel: "ollama/nemotron-3-ultra", modelExplicitlySet: false },
+      parsed
+    );
+    expect(parsed.modelExplicitlySet).toBe(true);
+    expect(isModelConfigured(parsed)).toBe(true);
+  });
+
+  test("leaves modelExplicitlySet true unchanged", () => {
+    const parsed = createDefaultConfig({
+      defaultModel: "ollama/x",
+      modelExplicitlySet: true,
+    });
+    repairModelExplicitlySet({ defaultModel: "ollama/x" }, parsed);
+    expect(parsed.modelExplicitlySet).toBe(true);
+  });
+
+  test("does not set flag when file has no defaultModel", () => {
+    const parsed = createDefaultConfig({ modelExplicitlySet: false });
+    repairModelExplicitlySet({}, parsed);
+    expect(parsed.modelExplicitlySet).toBe(false);
+  });
+});

--- a/test/context-bar-visuals.test.ts
+++ b/test/context-bar-visuals.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { ContextBarComponent } from "../src/cli/components/context-bar.js";
+
+const BASE_STATE = {
+  workerModel: "ollama/glm-4.7",
+  impulseVersion: "1.6.0",
+  contextTokens: 34_000,
+  contextWindow: 100_000,
+  mode: "WORK",
+  reasoningLevel: "medium",
+  cwd: "/tmp/impulse-test-no-git",
+};
+
+function renderBar(visual: "full" | "reduced" | "minimal" | "off"): string {
+  const bar = new ContextBarComponent({ ...BASE_STATE, bottomBarVisual: visual });
+  return bar.render(120).join("\n");
+}
+
+describe("context bar visuals", () => {
+  test("off renders a single blank row", () => {
+    const bar = new ContextBarComponent({ ...BASE_STATE, bottomBarVisual: "off" });
+    const lines = bar.render(120);
+    expect(lines.length).toBe(1);
+    expect(lines[0]?.trim()).toBe("");
+  });
+
+  test("minimal shows model and percentage only", () => {
+    const text = renderBar("minimal");
+    expect(text).toContain("glm-4.7");
+    expect(text).toContain("34%");
+    expect(text).not.toContain("/100");
+    expect(text).not.toContain("v1.6.0");
+    expect(text).not.toContain("impulse-test");
+  });
+
+  test("reduced shows model, percentage, directory, and version", () => {
+    const text = renderBar("reduced");
+    expect(text).toContain("glm-4.7");
+    expect(text).toContain("34%");
+    expect(text).toContain("impulse-test");
+    expect(text).toContain("v1.6.0");
+    expect(text).not.toContain("|");
+    expect(text).not.toContain("WORK");
+  });
+
+  test("full includes mode and date separator", () => {
+    const text = renderBar("full");
+    expect(text).toContain("WORK");
+    expect(text).toContain("v1.6.0 |");
+  });
+});

--- a/test/context-bar-visuals.test.ts
+++ b/test/context-bar-visuals.test.ts
@@ -16,6 +16,21 @@ function renderBar(visual: "full" | "reduced" | "minimal" | "off"): string {
   return bar.render(120).join("\n");
 }
 
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+function renderBarWithAllowAll(
+  visual: "full" | "reduced" | "minimal" | "off"
+): string {
+  const bar = new ContextBarComponent({
+    ...BASE_STATE,
+    bottomBarVisual: visual,
+    allowAllBypass: true,
+  });
+  return stripAnsi(bar.render(120).join("\n"));
+}
+
 describe("context bar visuals", () => {
   test("off renders a single blank row", () => {
     const bar = new ContextBarComponent({ ...BASE_STATE, bottomBarVisual: "off" });
@@ -47,5 +62,46 @@ describe("context bar visuals", () => {
     const text = renderBar("full");
     expect(text).toContain("WORK");
     expect(text).toContain("v1.6.0 |");
+  });
+});
+
+describe("context bar allow-all indicator", () => {
+  test("full shows Allow-All when bypass is on", () => {
+    const text = renderBarWithAllowAll("full");
+    expect(text).toContain("Allow-All");
+    expect(text).not.toContain(" AA");
+  });
+
+  test("reduced shows AA when bypass is on", () => {
+    const text = renderBarWithAllowAll("reduced");
+    expect(text).toContain("AA");
+    expect(text).not.toContain("Allow-All");
+  });
+
+  test("minimal shows AA when bypass is on", () => {
+    const text = renderBarWithAllowAll("minimal");
+    expect(text).toContain("AA");
+    expect(text).not.toContain("Allow-All");
+  });
+
+  test("off hides AA when bypass is on", () => {
+    const bar = new ContextBarComponent({
+      ...BASE_STATE,
+      bottomBarVisual: "off",
+      allowAllBypass: true,
+    });
+    const lines = bar.render(120);
+    const text = stripAnsi(lines.join("\n"));
+    expect(lines.length).toBe(1);
+    expect(text).not.toContain("AA");
+    expect(text).not.toContain("Allow-All");
+  });
+
+  test("no allow-all label when bypass is off", () => {
+    for (const visual of ["full", "reduced", "minimal", "off"] as const) {
+      const text = stripAnsi(renderBar(visual));
+      expect(text).not.toContain("Allow-All");
+      expect(text).not.toContain(" AA");
+    }
   });
 });

--- a/test/github-issue-tool.test.ts
+++ b/test/github-issue-tool.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, test } from "bun:test";
 import { Tool, isToolAllowedForMode } from "../src/tools/registry.js";
 import { probeGhCli } from "../src/git/gh-cli.js";
+import { GithubIssueSchema } from "../src/tools/github-issue.js";
 import "../src/tools/init.js";
 
 const ghReady = probeGhCli(true);
+
+describe("github_issue schema", () => {
+  test("accepts plain issue number", () => {
+    const parsed = GithubIssueSchema.parse({ number: 123 });
+    expect(parsed.number).toBe(123);
+  });
+
+  test("accepts URL string in number field", () => {
+    const parsed = GithubIssueSchema.parse({
+      number: "https://github.com/foo/bar/issues/9",
+    });
+    expect(parsed.number).toBe(9);
+    expect(parsed.owner).toBe("foo");
+    expect(parsed.repo).toBe("bar");
+    expect(parsed.url).toBe("https://github.com/foo/bar/issues/9");
+  });
+
+  test("accepts numeric string in number field", () => {
+    const parsed = GithubIssueSchema.parse({ number: "123" });
+    expect(parsed.number).toBe(123);
+  });
+
+  test("accepts url-only input", () => {
+    const parsed = GithubIssueSchema.parse({
+      url: "https://github.com/acme/widgets/issues/42",
+    });
+    expect(parsed.number).toBe(42);
+    expect(parsed.url).toBe("https://github.com/acme/widgets/issues/42");
+  });
+
+  test("accepts www.github.com URL", () => {
+    const parsed = GithubIssueSchema.parse({
+      number: "https://www.github.com/foo/bar/issues/7",
+    });
+    expect(parsed.number).toBe(7);
+    expect(parsed.owner).toBe("foo");
+    expect(parsed.repo).toBe("bar");
+  });
+
+  test("rejects non-issue URL in number field", () => {
+    expect(() =>
+      GithubIssueSchema.parse({ number: "https://github.com/foo/bar/pull/5" })
+    ).toThrow();
+  });
+});
 
 describe("github_issue tool", () => {
   test("allowed in PLAN mode as read_only", () => {
@@ -13,16 +59,16 @@ describe("github_issue tool", () => {
   test.skipIf(ghReady.installed && ghReady.authenticated)(
     "returns gh install message when gh missing",
     async () => {
-    const status = probeGhCli(true);
-    const result = await Tool.execute("github_issue", { number: 50 });
-    expect(result.success).toBe(false);
-    if (!status.installed) {
-      expect(result.output).toContain("not installed");
-    } else {
-      expect(result.output).toContain("auth");
-    }
-    expect(result.output).toContain("github.com");
-    expect(result.output).toContain("/issues/50");
+      const status = probeGhCli(true);
+      const result = await Tool.execute("github_issue", { number: 50 });
+      expect(result.success).toBe(false);
+      if (!status.installed) {
+        expect(result.output).toContain("not installed");
+      } else {
+        expect(result.output).toContain("auth");
+      }
+      expect(result.output).toContain("github.com");
+      expect(result.output).toContain("/issues/50");
     }
   );
 });

--- a/test/overlay-scroll-region.test.ts
+++ b/test/overlay-scroll-region.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { composeScrollableOverlay } from "../src/cli/components/overlay-scroll-region.js";
+
+describe("composeScrollableOverlay", () => {
+  const top = ["TOP"];
+  const body = ["L0", "L1", "L2", "L3", "L4", "L5"];
+  const bottom = ["FOOTER", "BORDER"];
+
+  test("returns everything when maxHeight is 0", () => {
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: 0,
+      scrollTop: 0,
+    });
+    expect(result.lines).toEqual([...top, ...body, ...bottom]);
+    expect(result.needsScroll).toBe(false);
+    expect(result.scrollTop).toBe(0);
+  });
+
+  test("returns everything when content fits maxHeight", () => {
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: 20,
+      scrollTop: 0,
+    });
+    expect(result.lines).toEqual([...top, ...body, ...bottom]);
+    expect(result.needsScroll).toBe(false);
+  });
+
+  test("pinned chrome always present when clamped", () => {
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: 5,
+      scrollTop: 0,
+    });
+    expect(result.lines.length).toBeLessThanOrEqual(5);
+    expect(result.lines[0]).toBe("TOP");
+    expect(result.lines.at(-2)).toBe("FOOTER");
+    expect(result.lines.at(-1)).toBe("BORDER");
+    expect(result.needsScroll).toBe(true);
+  });
+
+  test("output length equals maxHeight when clamped", () => {
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: 6,
+      scrollTop: 0,
+    });
+    expect(result.lines.length).toBe(6);
+  });
+
+  test("keepVisible scrolls to show selection near end", () => {
+    const result = composeScrollableOverlay({
+      top,
+      body,
+      bottom,
+      maxHeight: 5,
+      scrollTop: 0,
+      keepVisible: { start: 4, length: 2 },
+    });
+    expect(result.lines).toContain("L4");
+    expect(result.lines).toContain("L5");
+    expect(result.lines.at(-1)).toBe("BORDER");
+  });
+});

--- a/test/prompt-history-store.test.ts
+++ b/test/prompt-history-store.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  loadPromptHistory,
+  savePromptHistory,
+} from "../src/util/prompt-history-store.js";
+import { getCurrentProjectID } from "../src/session/store.js";
+
+let tmpDir: string;
+
+afterEach(() => {
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = "";
+  }
+});
+
+describe("prompt history store", () => {
+  test("round-trips entries per project", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-history-"));
+    const projectID = getCurrentProjectID();
+    const entries = ["/model", "! git status", "hello"];
+    await savePromptHistory(entries, { projectID, baseDir: tmpDir });
+    const loaded = await loadPromptHistory({ projectID, baseDir: tmpDir });
+    expect(loaded).toEqual(entries);
+  });
+
+  test("missing file returns empty array", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-history-"));
+    const loaded = await loadPromptHistory({
+      projectID: "missing-project",
+      baseDir: tmpDir,
+    });
+    expect(loaded).toEqual([]);
+  });
+
+  test("corrupt file returns empty array", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-history-"));
+    const projectID = getCurrentProjectID();
+    fs.writeFileSync(path.join(tmpDir, `${projectID}.json`), "not-json", "utf-8");
+    const loaded = await loadPromptHistory({ projectID, baseDir: tmpDir });
+    expect(loaded).toEqual([]);
+  });
+});

--- a/test/prompt-history-store.test.ts
+++ b/test/prompt-history-store.test.ts
@@ -43,4 +43,37 @@ describe("prompt history store", () => {
     const loaded = await loadPromptHistory({ projectID, baseDir: tmpDir });
     expect(loaded).toEqual([]);
   });
+
+  test("serialized overlapping saves keep all entries", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-history-"));
+    const projectID = getCurrentProjectID();
+    const baseDir = tmpDir;
+
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const originalWriteFile = fs.promises.writeFile;
+    let writeCount = 0;
+    fs.promises.writeFile = async (...args) => {
+      writeCount++;
+      if (writeCount === 1) await gate;
+      return originalWriteFile(...args);
+    };
+
+    try {
+      const saveChain = Promise.resolve()
+        .then(() => savePromptHistory(["first"], { projectID, baseDir }))
+        .then(() => savePromptHistory(["first", "second"], { projectID, baseDir }));
+
+      releaseFirst();
+      await saveChain;
+
+      const loaded = await loadPromptHistory({ projectID, baseDir });
+      expect(loaded).toEqual(["first", "second"]);
+    } finally {
+      fs.promises.writeFile = originalWriteFile;
+    }
+  });
 });

--- a/test/prompt-history.test.ts
+++ b/test/prompt-history.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { PromptHistory } from "../src/cli/prompt-history.js";
+
+describe("PromptHistory", () => {
+  test("caps at 20 entries", () => {
+    const h = new PromptHistory();
+    for (let i = 0; i < 25; i++) {
+      h.push(`entry-${i}`);
+    }
+    expect(h.size()).toBe(20);
+    expect(h.previous()).toBe("entry-24");
+  });
+
+  test("dedupes consecutive identical entries", () => {
+    const h = new PromptHistory();
+    h.push("same");
+    h.push("same");
+    expect(h.size()).toBe(1);
+  });
+
+  test("draft save and jump-down restore", () => {
+    const h = new PromptHistory();
+    h.push("older");
+    h.push("newer");
+    h.saveDraft("draft text");
+    expect(h.previous()).toBe("newer");
+    expect(h.getDraft()).toBe("draft text");
+    expect(h.takeDraft()).toBe("draft text");
+    expect(h.isBrowsing()).toBe(false);
+  });
+
+  test("takeDraft returns null when not browsing", () => {
+    const h = new PromptHistory();
+    h.saveDraft("draft");
+    expect(h.takeDraft()).toBeNull();
+  });
+
+  test("push clears draft", () => {
+    const h = new PromptHistory();
+    h.saveDraft("draft");
+    h.previous();
+    h.push("submitted");
+    expect(h.getDraft()).toBeNull();
+  });
+
+  test("loadEntries trims to cap", () => {
+    const h = new PromptHistory();
+    const entries = Array.from({ length: 30 }, (_, i) => `e-${i}`);
+    h.loadEntries(entries);
+    expect(h.size()).toBe(20);
+    expect(h.previous()).toBe("e-29");
+  });
+});

--- a/test/settings-overlay.test.ts
+++ b/test/settings-overlay.test.ts
@@ -12,6 +12,7 @@ describe("settingsValuesEqual", () => {
     subagentModel: "ollama/foo",
     visionModelOverride: undefined,
     compactToolOutput: true,
+    bottomBarVisual: "full" as const,
   };
 
   test("detects identical values", () => {
@@ -36,6 +37,12 @@ describe("settingsValuesEqual", () => {
   test("detects subagent model change", () => {
     expect(
       settingsValuesEqual(base, { ...base, subagentModel: "ollama/bar" })
+    ).toBe(false);
+  });
+
+  test("detects bottom bar visual change", () => {
+    expect(
+      settingsValuesEqual(base, { ...base, bottomBarVisual: "minimal" })
     ).toBe(false);
   });
 });

--- a/test/settings-overlay.test.ts
+++ b/test/settings-overlay.test.ts
@@ -1,19 +1,78 @@
 import { describe, expect, test } from "bun:test";
-import { settingsValuesEqual } from "../src/cli/components/settings-overlay.js";
+import {
+  SettingsOverlay,
+  settingsValuesEqual,
+} from "../src/cli/components/settings-overlay.js";
+
+const baseValues = {
+  thinkingDisplay: "summary" as const,
+  reasoningLevel: "medium" as const,
+  responsePreference: "concise",
+  statsOnExit: false,
+  showSubagentThinking: false,
+  useSubagentModel: false,
+  subagentModel: "ollama/foo",
+  visionModelOverride: undefined,
+  compactToolOutput: true,
+  bottomBarVisual: "full" as const,
+};
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+function assertFooterNeverClipped(lines: string[], maxHeight: number): void {
+  expect(lines.length).toBeLessThanOrEqual(maxHeight);
+  const plain = lines.map(stripAnsi);
+  expect(plain.some((l) => l.includes("Esc: cancel"))).toBe(true);
+  expect(plain.at(-1)?.startsWith("└")).toBe(true);
+}
+
+describe("SettingsOverlay render", () => {
+  test("footer and border never clipped across maxHeight range", () => {
+    const overlay = new SettingsOverlay({ values: baseValues });
+    for (let h = 8; h <= 40; h++) {
+      overlay.setMaxHeight(h);
+      const lines = overlay.render(100);
+      assertFooterNeverClipped(lines, h);
+    }
+  });
+
+  test("auto-scrolls to last row on End key", () => {
+    const overlay = new SettingsOverlay({ values: baseValues });
+    overlay.setMaxHeight(14);
+    overlay.handleInput("\x1b[F");
+    const lines = overlay.render(100);
+    assertFooterNeverClipped(lines, 14);
+    expect(lines.map(stripAnsi).some((l) => l.includes("Vision override"))).toBe(
+      true
+    );
+  });
+
+  test("Home key shows first row", () => {
+    const overlay = new SettingsOverlay({ values: baseValues });
+    overlay.setMaxHeight(14);
+    overlay.handleInput("\x1b[F");
+    overlay.handleInput("\x1b[H");
+    const lines = overlay.render(100);
+    expect(lines.map(stripAnsi).some((l) => l.includes("Thinking display"))).toBe(
+      true
+    );
+  });
+
+  test("tall viewport shows all rows", () => {
+    const overlay = new SettingsOverlay({ values: baseValues });
+    overlay.setMaxHeight(40);
+    const lines = overlay.render(100);
+    const plain = lines.map(stripAnsi);
+    expect(plain.some((l) => l.includes("Thinking display"))).toBe(true);
+    expect(plain.some((l) => l.includes("Vision override"))).toBe(true);
+    expect(plain.some((l) => l.includes("Esc: cancel"))).toBe(true);
+  });
+});
 
 describe("settingsValuesEqual", () => {
-  const base = {
-    thinkingDisplay: "summary" as const,
-    reasoningLevel: "medium" as const,
-    responsePreference: "concise",
-    statsOnExit: false,
-    showSubagentThinking: false,
-    useSubagentModel: false,
-    subagentModel: "ollama/foo",
-    visionModelOverride: undefined,
-    compactToolOutput: true,
-    bottomBarVisual: "full" as const,
-  };
+  const base = baseValues;
 
   test("detects identical values", () => {
     expect(settingsValuesEqual(base, { ...base })).toBe(true);

--- a/test/startup-flags.test.ts
+++ b/test/startup-flags.test.ts
@@ -29,6 +29,11 @@ describe("findUnknownFlag", () => {
     expect(findUnknownFlag(["--", "--weird"])).toBeUndefined();
     expect(findUnknownFlag(["--aa", "--", "--updat"])).toBeUndefined();
   });
+
+  test("ignores dash-prefixed words in trailing message args", () => {
+    expect(findUnknownFlag(["explain", "the", "-j", "option"])).toBeUndefined();
+    expect(findUnknownFlag(["--aa", "explain", "the", "-j", "option"])).toBeUndefined();
+  });
 });
 
 describe("parseStartupFlags", () => {

--- a/test/startup-flags.test.ts
+++ b/test/startup-flags.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { parseStartupFlags } from "../src/cli/startup-flags.js";
+import {
+  findUnknownFlag,
+  parseStartupFlags,
+} from "../src/cli/startup-flags.js";
+
+describe("findUnknownFlag", () => {
+  test("returns unknown typos", () => {
+    expect(findUnknownFlag(["--updat"])).toBe("--updat");
+    expect(findUnknownFlag(["--verbose"])).toBe("--verbose");
+  });
+
+  test("accepts known boolean flags", () => {
+    expect(findUnknownFlag(["--version"])).toBeUndefined();
+    expect(findUnknownFlag(["--update"])).toBeUndefined();
+    expect(findUnknownFlag(["--aa"])).toBeUndefined();
+    expect(findUnknownFlag(["--allow-all"])).toBeUndefined();
+    expect(findUnknownFlag(["--resume"])).toBeUndefined();
+    expect(findUnknownFlag(["-r"])).toBeUndefined();
+  });
+
+  test("accepts value flags with their values", () => {
+    expect(findUnknownFlag(["--limit", "5"])).toBeUndefined();
+    expect(findUnknownFlag(["--project", "current"])).toBeUndefined();
+    expect(findUnknownFlag(["--resume", "abc123"])).toBeUndefined();
+  });
+
+  test("ignores tokens after -- end-of-options", () => {
+    expect(findUnknownFlag(["--", "--weird"])).toBeUndefined();
+    expect(findUnknownFlag(["--aa", "--", "--updat"])).toBeUndefined();
+  });
+});
 
 describe("parseStartupFlags", () => {
   test("detects --aa and strips it from argv", () => {

--- a/test/startup-flags.test.ts
+++ b/test/startup-flags.test.ts
@@ -66,4 +66,20 @@ describe("parseStartupFlags", () => {
       if (prev !== undefined) process.env["IMPULSE_ALLOW_ALL"] = prev;
     }
   });
+
+  test("ignores --aa and --allow-all after -- end-of-options", () => {
+    const prev = process.env["IMPULSE_ALLOW_ALL"];
+    delete process.env["IMPULSE_ALLOW_ALL"];
+    try {
+      const aa = parseStartupFlags(["--", "--aa"]);
+      expect(aa.flags.allowAllOnStartup).toBe(false);
+      expect(aa.argv).toEqual(["--", "--aa"]);
+
+      const allowAll = parseStartupFlags(["--", "--allow-all"]);
+      expect(allowAll.flags.allowAllOnStartup).toBe(false);
+      expect(allowAll.argv).toEqual(["--", "--allow-all"]);
+    } finally {
+      if (prev !== undefined) process.env["IMPULSE_ALLOW_ALL"] = prev;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Bundles open enhancements into v1.6.0 plus follow-up fixes: quieter bottom bar modes, smarter file diffs on large files, richer prompt history, `github_issue` URL parsing, first-run model selection, scrollable `/settings`, and CLI flag hardening.

Fixes #50
Fixes #60
Fixes #62
Fixes #65
Fixes #80
Fixes #83

## Changes

- **#50 Bottom bar visuals** — `/settings` cycle row (`full` / `reduced` / `minimal` / `off`), global `bottomBarVisual` in config, context bar segment gating
- **#60 Prompt history** — slash/`!` commands recorded; draft save + jump-down restore; per-project disk persistence (20 entries) at `~/.impulse/history/`
- **#62 github_issue** — `z.preprocess` accepts full issue URLs and numeric strings in `number`; `url`-only input works
- **#65 File diffs** — compact diff always computed for large files; output line cap with `… N more lines` footer; 2MB input safety valve only
- **#80 Onboarding model** — `runSetup()` sets `modelExplicitlySet`; load migration repairs existing configs with saved `defaultModel`
- **`/settings` overlay** — scrollable body with pinned footer via `composeScrollableOverlay`; viewport-sized height so key hints never clip as rows grow
- **#83 CLI flags** — `--aa` / `--allow-all` / `IMPULSE_ALLOW_ALL=1` show the allow-all disclaimer at launch (agree to enable; sticky across `/new` and `/resume` for the run); unknown flags (e.g. `--updat`) rejected with `Try 'impulse --help'`; `--` end-of-options for messages
- **Allow-all context bar** — indicator stays visible in reduced/minimal bottom-bar visuals (`AA` abbreviation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permission bypass startup and session stickiness plus file-tool diff/metadata paths; changes are well-tested but affect security-adjacent CLI behavior.
> 
> **Overview**
> **v1.6.0** ships UX and CLI polish: configurable **bottom bar** density (`full` / `reduced` / `minimal` / `off` via `/settings` and `bottomBarVisual` in global config), with layout height and allow-all shown as **Allow-All** or **AA** when the bar is quieter.
> 
> **Prompt history** is per-project (20 entries under `~/.impulse/history/`): Up recalls slash and `!` commands with draft save/restore on Down; `/new` no longer wipes history.
> 
> **File edit/write** always builds compact diffs for large files (2MB skip threshold), caps stored diff lines with a **… N more lines** footer, and shows summary even when diff is skipped.
> 
> **`github_issue`** preprocesses full issue URLs and numeric strings in `number` or `url` alone.
> 
> **Onboarding / config (#80):** CLI setup sets `modelExplicitlySet`; load repairs configs that have `defaultModel` without the flag.
> 
> **CLI (#83):** `--aa` / `--allow-all` show the disclaimer at launch—bypass only after agree and stays sticky across `/new` and `/resume` until toggled off; unknown flags exit with help; `--` separates flags from message text.
> 
> **`/settings`** uses a scrollable body with pinned footer and viewport `maxHeight` so hints are not clipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69875c05957a8be32ed4bc30d30a0e7a95237dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->