### PR TITLE
feat: Add Windows on ARM as a binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,11 @@ jobs:
             platform: windows
             arch: x64
             target: bun-windows-x64
-          # NOTE: Windows ARM64 not supported - Bun doesn't have cross-compile target yet
-          # Error: "Unsupported compile target: bun-windows-aarch64"
-          # Will add when Bun supports it
+          # Windows ARM64 (cross-compiled from Linux — Bun target bun-windows-arm64)
+          - os: ubuntu-latest
+            platform: windows
+            arch: arm64
+            target: bun-windows-arm64
 
     runs-on: ${{ matrix.os }}
     
@@ -310,7 +312,8 @@ jobs:
               "@spenceriam/impulse-linux-arm64": "$VERSION",
               "@spenceriam/impulse-darwin-x64": "$VERSION",
               "@spenceriam/impulse-darwin-arm64": "$VERSION",
-              "@spenceriam/impulse-windows-x64": "$VERSION"
+              "@spenceriam/impulse-windows-x64": "$VERSION",
+              "@spenceriam/impulse-windows-arm64": "$VERSION"
             }
           }
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1466,7 +1466,7 @@ impulse --verbose
 
 ### Overview
 
-impulse uses GitHub Actions for automated builds and npm publishing. The pipeline builds standalone binaries for 6 platform/architecture combinations and publishes them as scoped npm packages.
+impulse uses GitHub Actions for automated builds and npm publishing. The pipeline builds standalone binaries for 7 platform/architecture combinations and publishes them as scoped npm packages.
 
 ### Workflows
 
@@ -1488,8 +1488,9 @@ impulse uses GitHub Actions for automated builds and npm publishing. The pipelin
 | macOS | ARM64 | `macos-latest` | Native | `@spenceriam/impulse-darwin-arm64` |
 | macOS | x64 | `macos-15-intel` | Native | `@spenceriam/impulse-darwin-x64` |
 | Windows | x64 | `windows-latest` | Native | `@spenceriam/impulse-windows-x64` |
+| Windows | ARM64 | `ubuntu-latest` | Cross-compile (`bun-windows-arm64`) | `@spenceriam/impulse-windows-arm64` |
 
-**Note:** Windows ARM64 is not currently supported. Bun doesn't have a cross-compile target for Windows ARM64 yet (`bun-windows-aarch64` returns "Unsupported compile target"). Will be added when Bun supports it.
+**Note:** Windows ARM64 is cross-compiled from Linux in CI (Bun `bun-windows-arm64` target). Native Windows ARM runners are not required.
 
 ### Build Process
 
@@ -1505,7 +1506,7 @@ impulse uses GitHub Actions for automated builds and npm publishing. The pipelin
 
 ### Publishing
 
-1. Platform packages published first (6 packages)
+1. Platform packages published first (7 packages)
 2. CLI wrapper package (`@spenceriam/impulse`) published last with `optionalDependencies` pointing to all platform packages
 3. Publish targets:
    - npm registry (`registry.npmjs.org`) for installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+  ### Added
+  - **Windows on ARM npm install** — `@spenceriam/impulse-windows-arm64` platform package for Snapdragon X and other Windows ARM64 devices; CI cross-compiles with Bun `bun-windows-arm64` and bundles `@vscode/ripgrep-win32-arm64`
+
 ## [1.6.0] - 2026-06-11
 
   **Type:** minor

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@spenceriam/impulse-linux-arm64": "1.2.2",
     "@spenceriam/impulse-darwin-x64": "1.2.2",
     "@spenceriam/impulse-darwin-arm64": "1.2.2",
-    "@spenceriam/impulse-windows-x64": "1.2.2"
+    "@spenceriam/impulse-windows-x64": "1.2.2",
+    "@spenceriam/impulse-windows-arm64": "1.2.2"
   }
 }

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -54,14 +54,14 @@ function findBinary() {
     "darwin-x64",
     "darwin-arm64",
     "windows-x64",
+    "windows-arm64",
   ];
   
   const combo = `${platform}-${arch}`;
   if (!supportedCombos.includes(combo)) {
     throw new Error(
       `Unsupported platform: ${platform}-${arch}\n` +
-      `impulse currently supports: ${supportedCombos.join(", ")}\n` +
-      `Windows ARM64 support is pending Bun's cross-compile target.`
+      `impulse currently supports: ${supportedCombos.join(", ")}`
     );
   }
 

--- a/scripts/publish-linux.ts
+++ b/scripts/publish-linux.ts
@@ -57,7 +57,8 @@ async function main() {
     "@spenceriam/impulse-linux-arm64": VERSION,
     "@spenceriam/impulse-darwin-x64": VERSION,
     "@spenceriam/impulse-darwin-arm64": VERSION,
-    "@spenceriam/impulse-windows-x64": VERSION
+    "@spenceriam/impulse-windows-x64": VERSION,
+    "@spenceriam/impulse-windows-arm64": VERSION
   };
   writeFileSync("packages/cli/package.json", JSON.stringify(cliPkg, null, 2));
   


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Windows on ARM (ARM64) as a supported npm install target so users on Snapdragon X and other Windows ARM64 devices can install impulse via `npm i -g @spenceriam/impulse`.

Closes #84

## Changes

- **Release CI** — new matrix job cross-compiles `bun-windows-arm64` from `ubuntu-latest`, bundles `@vscode/ripgrep-win32-arm64`, and publishes `@spenceriam/impulse-windows-arm64`
- **npm wrapper** — adds `@spenceriam/impulse-windows-arm64` to `optionalDependencies` (release workflow + `packages/cli/package.json` template)
- **postinstall** — recognizes `windows-arm64` as a supported platform combo (removes the "pending Bun support" error)
- **Docs** — CHANGELOG + AGENTS.md build matrix updated (7 platform packages)

## Background

Bun now supports the `bun-windows-arm64` compile target (v1.3.14+). The previous blocker (`bun-windows-aarch64` unsupported) is resolved; cross-compilation from Linux was verified locally.

## Testing

- `bun run typecheck` — pass
- `bun test` — 323 pass, 0 fail
- Local cross-compile: `bun build --compile --target=bun-windows-arm64 ./dist/index.js` succeeds

## Release note

Windows ARM64 binaries will ship on the next tagged release after merge. Existing installs on other platforms are unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

