### PR TITLE
chore: release v1.6.1 — publish Windows ARM64 npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,12 @@ jobs:
       - name: Publish CLI wrapper
         run: |
           cd packages/cli
-          npm publish --access public
+          VERSION="${{ steps.version.outputs.version }}"
+          if npm view "@spenceriam/impulse@${VERSION}" version >/dev/null 2>&1; then
+            echo "@spenceriam/impulse@${VERSION} already on npm — skipping wrapper publish"
+          else
+            npm publish --access public
+          fi
 
       - name: Setup Node.js for GitHub Packages
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-06-19
+
+  **Type:** patch
+  **Title:** Windows on ARM npm binary
+
   ### Added
   - **Windows on ARM npm install** — `@spenceriam/impulse-windows-arm64` platform package for Snapdragon X and other Windows ARM64 devices; CI cross-compiles with Bun `bun-windows-arm64` and bundles `@vscode/ripgrep-win32-arm64`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.2.2",
+  "version": "1.6.1",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -36,11 +36,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.2.2",
-    "@spenceriam/impulse-linux-arm64": "1.2.2",
-    "@spenceriam/impulse-darwin-x64": "1.2.2",
-    "@spenceriam/impulse-darwin-arm64": "1.2.2",
-    "@spenceriam/impulse-windows-x64": "1.2.2",
-    "@spenceriam/impulse-windows-arm64": "1.2.2"
+    "@spenceriam/impulse-linux-x64": "1.6.1",
+    "@spenceriam/impulse-linux-arm64": "1.6.1",
+    "@spenceriam/impulse-darwin-x64": "1.6.1",
+    "@spenceriam/impulse-darwin-arm64": "1.6.1",
+    "@spenceriam/impulse-windows-x64": "1.6.1",
+    "@spenceriam/impulse-windows-arm64": "1.6.1"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Merging #86 did **not** publish `@spenceriam/impulse-windows-arm64` to npm.

**Release on main** (run [27800499845](https://github.com/spenceriam/impulse/actions/runs/27800499845)) saw `package.json` still at `1.6.0`, found tag `v1.6.0` already exists (from the June 14 release at PR #79), and **skipped** creating a tag and dispatching **Release**. No Release workflow ran after the Windows ARM64 merge.

npm today:
- `@spenceriam/impulse@1.6.0` — no `windows-arm64` in `optionalDependencies`
- `@spenceriam/impulse-windows-arm64` — **404** (never published)

## Fix

- Bump to **1.6.1** so merge triggers `v1.6.1` tag + full Release (7 platform builds including `windows-arm64`)
- Move Windows ARM64 changelog entry from Unreleased → 1.6.1
- Skip wrapper `npm publish` when version already on registry (helps partial/manual releases)

## After merge

Watch **Release on main** → should create `v1.6.1` → dispatch **Release** → verify `build (ubuntu-latest, windows, arm64, bun-windows-arm64)` succeeds → confirm:

```bash
npm view @spenceriam/impulse-windows-arm64 version
npm view @spenceriam/impulse optionalDependencies
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

