### PR TITLE
fix(ci): download win32-arm64 ripgrep for Windows ARM64 cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,31 @@ jobs:
         run: |
           RG_PLATFORM="${{ matrix.platform == 'windows' && 'win32' || matrix.platform }}"
           RG_PKG="@vscode/ripgrep-${RG_PLATFORM}-${{ matrix.arch }}"
+          RG_PKG_SLUG="ripgrep-${RG_PLATFORM}-${{ matrix.arch }}"
+          OUT_DIR="packages/${{ matrix.platform }}-${{ matrix.arch }}/bin"
+          RG_VERSION=$(node -p "require('./node_modules/@vscode/ripgrep/package.json').version")
+          TARBALL_URL="https://registry.npmjs.org/@vscode/${RG_PKG_SLUG}/-/ripgrep-${RG_PLATFORM}-${{ matrix.arch }}-${RG_VERSION}.tgz"
+
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            cp "node_modules/${RG_PKG}/bin/rg.exe" "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg.exe"
+            SRC="node_modules/${RG_PKG}/bin/rg.exe"
+            DEST="${OUT_DIR}/rg.exe"
+            if [ -f "$SRC" ]; then
+              cp "$SRC" "$DEST"
+            else
+              echo "Downloading ${RG_PKG}@${RG_VERSION} (not installed for host OS)..."
+              curl -fsSL "$TARBALL_URL" | tar -xzf - -O package/bin/rg.exe > "$DEST"
+            fi
           else
-            cp "node_modules/${RG_PKG}/bin/rg" "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg"
-            chmod +x "packages/${{ matrix.platform }}-${{ matrix.arch }}/bin/rg"
+            SRC="node_modules/${RG_PKG}/bin/rg"
+            DEST="${OUT_DIR}/rg"
+            if [ -f "$SRC" ]; then
+              cp "$SRC" "$DEST"
+              chmod +x "$DEST"
+            else
+              echo "Downloading ${RG_PKG}@${RG_VERSION} (not installed for host OS)..."
+              curl -fsSL "$TARBALL_URL" | tar -xzf - -O package/bin/rg > "$DEST"
+              chmod +x "$DEST"
+            fi
           fi
 
       - name: Create platform package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ### Added
   - **Windows on ARM npm install** — `@spenceriam/impulse-windows-arm64` platform package for Snapdragon X and other Windows ARM64 devices; CI cross-compiles with Bun `bun-windows-arm64` and bundles `@vscode/ripgrep-win32-arm64`
 
+  ### Fixed
+  - **Release CI** — Windows ARM64 build downloads `ripgrep-win32-arm64` from npm when cross-compiling on Linux (optional dep is not installed for the host OS)
+
 ## [1.6.0] - 2026-06-11
 
   **Type:** minor


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Failure

Release run [27800742062](https://github.com/spenceriam/impulse/actions/runs/27800742062) failed on:

`build (ubuntu-latest, windows, arm64, bun-windows-arm64)` → **Bundle rg binary**

```
cp: cannot stat 'node_modules/@vscode/ripgrep-win32-arm64/bin/rg.exe': No such file or directory
```

6 other platform builds succeeded; **publish** and **github-release** were skipped.

## Root cause

Windows ARM64 is cross-compiled on `ubuntu-latest`. `bun install` only installs host optional deps (`ripgrep-linux-x64`), not `@vscode/ripgrep-win32-arm64`. `npm install` for that package also fails on Linux (`EBADPLATFORM`).

## Fix

In **Bundle rg binary**, if the target ripgrep package is missing from `node_modules`, download the matching `@vscode/ripgrep-*` tarball from the npm registry and extract `rg` / `rg.exe`.

## After merge

`v1.6.1` tag already exists but nothing was published to npm. Re-run **Release** workflow manually:

1. Actions → **Release** → **Run workflow**
2. Branch: `main`, version: `1.6.1`

No version bump needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

