### PR TITLE
fix(release): publish Windows ARM64 as impulse-win32-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,14 @@ jobs:
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          if [ "${{ matrix.platform }}" = "windows" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
+            NPM_NAME="@spenceriam/impulse-win32-arm64"
+          else
+            NPM_NAME="@spenceriam/impulse-${{ matrix.platform }}-${{ matrix.arch }}"
+          fi
           cat > packages/${{ matrix.platform }}-${{ matrix.arch }}/package.json << EOF
           {
-            "name": "@spenceriam/impulse-${{ matrix.platform }}-${{ matrix.arch }}",
+            "name": "$NPM_NAME",
             "version": "$VERSION",
             "description": "IMPULSE binary for ${{ matrix.platform }}-${{ matrix.arch }}",
             "license": "MIT",
@@ -247,9 +252,9 @@ jobs:
           # later step so npm CDN propagation for early packages overlaps with
           # publishing the rest (avoids racing a per-package 404 right after publish).
           for platform_dir in artifacts/impulse-*/; do
-            platform_name=$(basename "$platform_dir")
-            pkg="@spenceriam/${platform_name}"
             cd "$platform_dir"
+            pkg=$(node -p "require('./package.json').name")
+            pkg_slug="${pkg#@spenceriam/}"
 
             if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
               echo "${pkg}@${VERSION} already on npm — skipping publish"
@@ -271,9 +276,10 @@ jobs:
           # only a genuine ghost publish (permanent 404) fails the job.
           fail=0
           for platform_dir in artifacts/impulse-*/; do
-            platform_name=$(basename "$platform_dir")
-            pkg="@spenceriam/${platform_name}"
-            tarball_url="https://registry.npmjs.org/@spenceriam/${platform_name}/-/${platform_name}-${VERSION}.tgz"
+            cd "$platform_dir"
+            pkg=$(node -p "require('./package.json').name")
+            pkg_slug="${pkg#@spenceriam/}"
+            tarball_url="https://registry.npmjs.org/@spenceriam/${pkg_slug}/-/${pkg_slug}-${VERSION}.tgz"
 
             echo "Verifying tarball: ${tarball_url}"
             ok=false
@@ -291,6 +297,7 @@ jobs:
             else
               echo "Tarball verified for ${pkg}@${VERSION}"
             fi
+            cd - >/dev/null
           done
 
           if [ "${fail}" != "0" ]; then
@@ -323,7 +330,7 @@ jobs:
             "homepage": "https://github.com/spenceriam/impulse#readme",
             "keywords": ["ai", "cli", "impulse", "terminal", "coding", "agent"],
             "author": "Spencer Francisco",
-            "files": ["bin/*", "postinstall.mjs"],
+            "files": ["bin/*", "postinstall.mjs", "platform-package.mjs"],
             "publishConfig": {
               "access": "public"
             },
@@ -333,7 +340,7 @@ jobs:
               "@spenceriam/impulse-darwin-x64": "$VERSION",
               "@spenceriam/impulse-darwin-arm64": "$VERSION",
               "@spenceriam/impulse-windows-x64": "$VERSION",
-              "@spenceriam/impulse-windows-arm64": "$VERSION"
+              "@spenceriam/impulse-win32-arm64": "$VERSION"
             }
           }
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1488,7 +1488,7 @@ impulse uses GitHub Actions for automated builds and npm publishing. The pipelin
 | macOS | ARM64 | `macos-latest` | Native | `@spenceriam/impulse-darwin-arm64` |
 | macOS | x64 | `macos-15-intel` | Native | `@spenceriam/impulse-darwin-x64` |
 | Windows | x64 | `windows-latest` | Native | `@spenceriam/impulse-windows-x64` |
-| Windows | ARM64 | `ubuntu-latest` | Cross-compile (`bun-windows-arm64`) | `@spenceriam/impulse-windows-arm64` |
+| Windows | ARM64 | `ubuntu-latest` | Cross-compile (`bun-windows-arm64`) | `@spenceriam/impulse-win32-arm64` |
 
 **Note:** Windows ARM64 is cross-compiled from Linux in CI (Bun `bun-windows-arm64` target). Native Windows ARM runners are not required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Title:** Windows on ARM npm binary
 
   ### Added
-  - **Windows on ARM npm install** — `@spenceriam/impulse-windows-arm64` platform package for Snapdragon X and other Windows ARM64 devices; CI cross-compiles with Bun `bun-windows-arm64` and bundles `@vscode/ripgrep-win32-arm64`
+  - **Windows on ARM npm install** — `@spenceriam/impulse-win32-arm64` platform package for Snapdragon X and other Windows ARM64 devices; CI cross-compiles with Bun `bun-windows-arm64` and bundles `@vscode/ripgrep-win32-arm64`
 
   ### Fixed
   - **Release CI** — Windows ARM64 build downloads `ripgrep-win32-arm64` from npm when cross-compiling on Linux (optional dep is not installed for the host OS)
+  - **Windows ARM64 npm name** — publish as `@spenceriam/impulse-win32-arm64` (`impulse-windows-arm64` was unpublished on npm and cannot be reclaimed; 409 on publish)
 
 ## [1.6.0] - 2026-06-11
 

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import { platformPackageName } from "../platform-package.mjs";
 import os from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -45,7 +46,7 @@ function detectPlatformAndArch() {
 
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch();
-  const packageName = `@spenceriam/impulse-${platform}-${arch}`;
+  const packageName = platformPackageName(platform, arch);
   const binaryName = platform === "windows" ? "impulse.exe" : "impulse";
 
   try {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,8 @@
   "author": "Spencer Francisco",
   "files": [
     "bin/*",
-    "postinstall.mjs"
+    "postinstall.mjs",
+    "platform-package.mjs"
   ],
   "publishConfig": {
     "access": "public"
@@ -41,6 +42,6 @@
     "@spenceriam/impulse-darwin-x64": "1.6.1",
     "@spenceriam/impulse-darwin-arm64": "1.6.1",
     "@spenceriam/impulse-windows-x64": "1.6.1",
-    "@spenceriam/impulse-windows-arm64": "1.6.1"
+    "@spenceriam/impulse-win32-arm64": "1.6.1"
   }
 }

--- a/packages/cli/platform-package.mjs
+++ b/packages/cli/platform-package.mjs
@@ -1,0 +1,10 @@
+/**
+ * npm platform package names. Windows ARM64 uses win32-arm64 because
+ * @spenceriam/impulse-windows-arm64 was unpublished and cannot be reclaimed.
+ */
+export function platformPackageName(platform, arch) {
+  if (platform === "windows" && arch === "arm64") {
+    return "@spenceriam/impulse-win32-arm64";
+  }
+  return `@spenceriam/impulse-${platform}-${arch}`;
+}

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -5,6 +5,7 @@ import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import { platformPackageName } from "../platform-package.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -44,7 +45,7 @@ function detectPlatformAndArch() {
 
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch();
-  const packageName = `@spenceriam/impulse-${platform}-${arch}`;
+  const packageName = platformPackageName(platform, arch);
   const binaryName = platform === "windows" ? "impulse.exe" : "impulse";
 
   // Check for unsupported platform/arch combinations

--- a/scripts/publish-linux.ts
+++ b/scripts/publish-linux.ts
@@ -58,7 +58,7 @@ async function main() {
     "@spenceriam/impulse-darwin-x64": VERSION,
     "@spenceriam/impulse-darwin-arm64": VERSION,
     "@spenceriam/impulse-windows-x64": VERSION,
-    "@spenceriam/impulse-windows-arm64": VERSION
+    "@spenceriam/impulse-win32-arm64": VERSION
   };
   writeFileSync("packages/cli/package.json", JSON.stringify(cliPkg, null, 2));
   


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Failure

Release [27800878038](https://github.com/spenceriam/impulse/actions/runs/27800878038): all **7 builds passed**, but **publish** failed on:

```
npm error 409 Conflict - PUT @spenceriam/impulse-windows-arm64
```

## Root cause

`@spenceriam/impulse-windows-arm64` was **unpublished on npm** (2026-02-25). That name is permanently blocked.

Five platform packages at **1.6.1** were published; `windows-x64` and the wrapper were never reached.

## Fix

Publish Windows ARM64 as **`@spenceriam/impulse-win32-arm64`**.

## After merge

Re-run **Release**: branch `main`, version **`1.6.1`**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

