### PR TITLE
fix(cli): postinstall platform-package import path (1.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-06-19
+
+  **Type:** patch
+  **Title:** Windows npm postinstall fix
+
+  ### Fixed
+  - **npm install on Windows** — `postinstall.mjs` imported `platform-package.mjs` from the wrong path (`../` instead of `./`), breaking global install on all platforms
+
 ## [1.6.1] - 2026-06-19
 
   **Type:** patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -37,11 +37,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.6.1",
-    "@spenceriam/impulse-linux-arm64": "1.6.1",
-    "@spenceriam/impulse-darwin-x64": "1.6.1",
-    "@spenceriam/impulse-darwin-arm64": "1.6.1",
-    "@spenceriam/impulse-windows-x64": "1.6.1",
-    "@spenceriam/impulse-win32-arm64": "1.6.1"
+    "@spenceriam/impulse-linux-x64": "1.6.2",
+    "@spenceriam/impulse-linux-arm64": "1.6.2",
+    "@spenceriam/impulse-darwin-x64": "1.6.2",
+    "@spenceriam/impulse-darwin-arm64": "1.6.2",
+    "@spenceriam/impulse-windows-x64": "1.6.2",
+    "@spenceriam/impulse-win32-arm64": "1.6.2"
   }
 }

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -5,7 +5,7 @@ import path from "path";
 import os from "os";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
-import { platformPackageName } from "../platform-package.mjs";
+import { platformPackageName } from "./platform-package.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

Global `npm i -g @spenceriam/impulse@latest` fails in postinstall:

```
Cannot find module '@spenceriam/platform-package.mjs'
imported from ...\@spenceriam\impulse\postinstall.mjs
```

## Cause

`postinstall.mjs` imported `../platform-package.mjs`, which resolves to the **parent** `@spenceriam/` scope — not inside the impulse package. Both files live at the package root; import should be `./platform-package.mjs`.

(`bin/impulse` correctly uses `../` because it lives under `bin/`.)

## Fix

- `postinstall.mjs` → `./platform-package.mjs`
- Bump **1.6.2** for npm publish

## After merge

Release on main should tag `v1.6.2` and publish. Then on Surface:

```powershell
npm i -g @spenceriam/impulse@latest
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc83ae6e-87b5-4547-aded-646dad5bdea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

