### PR TITLE
fix: Windows reliability and render stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-06-22
+
+  **Type:** patch
+  **Title:** Windows reliability and render stability
+
+  ### Fixed
+  - **#91** — `file_write` now uses the same outside-cwd path policy as `file_edit`, so Windows absolute paths can be granted instead of rejected before permission handling
+  - **#92** — `github_issue` detects GitHub CLI through explicit binary lookup and argument-based execution instead of shell-specific `gh ... 2>&1` commands
+  - **#93** — active-turn bottom anchoring is released on normal turn completion, error, and context cutoff so long tool-heavy turns do not leave stale frozen spacer state
+
 ## [1.6.2] - 2026-06-19
 
   **Type:** patch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.0",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.6.0",
+      "version": "1.6.3",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -37,11 +37,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.6.2",
-    "@spenceriam/impulse-linux-arm64": "1.6.2",
-    "@spenceriam/impulse-darwin-x64": "1.6.2",
-    "@spenceriam/impulse-darwin-arm64": "1.6.2",
-    "@spenceriam/impulse-windows-x64": "1.6.2",
-    "@spenceriam/impulse-win32-arm64": "1.6.2"
+    "@spenceriam/impulse-linux-x64": "1.6.3",
+    "@spenceriam/impulse-linux-arm64": "1.6.3",
+    "@spenceriam/impulse-darwin-x64": "1.6.3",
+    "@spenceriam/impulse-darwin-arm64": "1.6.3",
+    "@spenceriam/impulse-windows-x64": "1.6.3",
+    "@spenceriam/impulse-win32-arm64": "1.6.3"
   }
 }

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -2648,6 +2648,7 @@ export class ImpulseRenderer {
         this.lastBandWasTool = false;
         this.turnShowsImpulseHeader = false;
         this.isRunning = false;
+        this.releaseTurnAnchor();
         this.tui.setFocus(this.promptInput);
         this.tui.requestRender();
         if (this.goalLoopActive()) {
@@ -2662,6 +2663,7 @@ export class ImpulseRenderer {
         this.syncContextBar({ isRunning: false });
         this.addChatLine(`${clr.error("Error:")} ${err.message}`);
         this.isRunning = false;
+        this.releaseTurnAnchor();
         this.tui.setFocus(this.promptInput);
         this.tui.requestRender();
         this.drainTurnQueue();
@@ -2680,6 +2682,7 @@ export class ImpulseRenderer {
           `Context limit reached: ${tokens} / ${this.contextWindow} tokens (${pct}%). Use /compact or /new to continue.`
         );
         this.isRunning = false;
+        this.releaseTurnAnchor();
         this.tui.setFocus(this.promptInput);
         this.tui.requestRender();
         this.drainTurnQueue();

--- a/src/git/gh-cli.ts
+++ b/src/git/gh-cli.ts
@@ -1,4 +1,6 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
 
 export interface GhCliStatus {
   installed: boolean;
@@ -11,17 +13,58 @@ let cachedStatus: GhCliStatus | null = null;
 
 const CACHE_MS = 60_000;
 
-function runQuiet(command: string, timeoutMs = 3000): { ok: boolean; stdout: string } {
+function executableCandidates(name: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  if (process.platform !== "win32") return [name];
+  const ext = path.extname(name);
+  if (ext) return [name];
+  const pathext = env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD";
+  return pathext
+    .split(";")
+    .map((e) => e.trim())
+    .filter(Boolean)
+    .map((e) => `${name}${e.toLowerCase()}`);
+}
+
+export function resolveGhCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const override = env["GH_CLI_PATH"]?.trim();
+  if (override) {
+    return fs.existsSync(override) ? override : null;
+  }
+
+  const pathValue = env["PATH"] ?? "";
+  const dirs = pathValue.split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const candidate of executableCandidates("gh", env)) {
+      const fullPath = path.join(dir, candidate);
+      if (fs.existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function runQuiet(
+  executable: string,
+  args: string[],
+  timeoutMs = 3000
+): { ok: boolean; stdout: string } {
   try {
-    const stdout = execSync(command, {
+    const stdout = execFileSync(executable, args, {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: timeoutMs,
       encoding: "utf-8",
+      windowsHide: true,
     });
     return { ok: true, stdout: stdout.toString().trim() };
   } catch (err: unknown) {
-    const e = err as { stdout?: Buffer; stderr?: Buffer };
-    const stdout = (e.stdout?.toString() ?? e.stderr?.toString() ?? "").trim();
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string };
+    const out =
+      typeof e.stdout === "string" ? e.stdout : e.stdout?.toString();
+    const errOut =
+      typeof e.stderr === "string" ? e.stderr : e.stderr?.toString();
+    const stdout = [out, errOut].filter(Boolean).join("\n").trim();
     return { ok: false, stdout };
   }
 }
@@ -35,14 +78,21 @@ export function probeGhCli(force = false): GhCliStatus {
     return cachedStatus;
   }
 
-  const version = runQuiet("gh --version", 2000);
+  const ghPath = resolveGhCliPath();
+  if (!ghPath) {
+    cachedStatus = { installed: false, authenticated: false };
+    cachedAt = now;
+    return cachedStatus;
+  }
+
+  const version = runQuiet(ghPath, ["--version"], 2000);
   if (!version.ok) {
     cachedStatus = { installed: false, authenticated: false };
     cachedAt = now;
     return cachedStatus;
   }
 
-  const auth = runQuiet("gh auth status -h github.com 2>&1", 4000);
+  const auth = runQuiet(ghPath, ["auth", "status", "-h", "github.com"], 4000);
   if (!auth.ok) {
     cachedStatus = { installed: true, authenticated: false };
     cachedAt = now;

--- a/src/git/gh-cli.ts
+++ b/src/git/gh-cli.ts
@@ -17,7 +17,7 @@ function executableCandidates(name: string, env: NodeJS.ProcessEnv = process.env
   if (process.platform !== "win32") return [name];
   const ext = path.extname(name);
   if (ext) return [name];
-  const pathext = env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD";
+  const pathext = env["PATHEXT"]?.trim() || ".COM;.EXE;.BAT;.CMD";
   return pathext
     .split(";")
     .map((e) => e.trim())

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { mkdir, stat, writeFile, readFile, chmod, access } from "fs/promises";
-import { resolve, relative, isAbsolute, basename } from "path";
-import { sanitizePath } from "../util/path";
+import { resolve, relative, isAbsolute, basename, dirname } from "path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
+import { resolveToolPath } from "./resolve-tool-path.js";
 import { createPatch } from "diff";
 import {
   capCompactDiffResult,
@@ -58,7 +58,7 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
   WriteSchema,
   async (input: WriteInput): Promise<ToolResult> => {
     try {
-      const safePath = sanitizePath(input.filePath);
+      const safePath = await resolveToolPath(input.filePath, "file_write");
       
       // Check mode-based path restrictions (PLAN -> docs/ or PRD.md)
       const modeError = validateWritePath(safePath);
@@ -69,7 +69,7 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
         };
       }
       
-      const dir = safePath.substring(0, safePath.lastIndexOf("/"));
+      const dir = dirname(safePath);
       
       // Determine if this is a new file or overwrite
       const isNewFile = !(await fileExists(safePath));
@@ -107,7 +107,7 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
         });
       }
 
-      if (dir && dir.length > 0) {
+      if (dir && dir !== safePath) {
         await mkdir(dir, { recursive: true });
       }
 

--- a/src/tools/github-issue.ts
+++ b/src/tools/github-issue.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { probeGhCli } from "../git/gh-cli.js";
+import { probeGhCli, resolveGhCliPath } from "../git/gh-cli.js";
 import {
   issueUrlForNumber,
   parseGitHubOwnerRepo,
@@ -199,9 +199,21 @@ export const githubIssueTool: Tool<GithubIssueInput> = Tool.define(
       };
     }
 
+    const ghPath = resolveGhCliPath();
+    if (!ghPath) {
+      return {
+        success: false,
+        output: [
+          "GitHub CLI (gh) is not installed.",
+          `Canonical issue URL: ${canonicalUrl}`,
+          "Install gh (https://cli.github.com/) or use web_fetch on that URL.",
+        ].join("\n"),
+      };
+    }
+
     const fields = "title,body,state,url,labels,comments";
     const proc = Bun.spawn(
-      ["gh", "issue", "view", String(number), "-R", fullName, "--json", fields],
+      [ghPath, "issue", "view", String(number), "-R", fullName, "--json", fields],
       { stdout: "pipe", stderr: "pipe", cwd: process.cwd() }
     );
 

--- a/test/bottom-anchor-spacer.test.ts
+++ b/test/bottom-anchor-spacer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { BottomAnchorSpacer } from "../src/cli/components/bottom-anchor-spacer.js";
+
+describe("BottomAnchorSpacer", () => {
+  test("uses frozen turn-anchor lines until the active turn releases them", () => {
+    let rows = 20;
+    let contentHeight = 8;
+    let frozen: number | null = null;
+    const tui = { terminal: { get rows() { return rows; } } };
+    const spacer = new BottomAnchorSpacer(
+      tui as never,
+      () => contentHeight,
+      () => frozen
+    );
+
+    expect(spacer.render(80).length).toBe(12);
+
+    frozen = 12;
+    contentHeight = 30;
+    spacer.invalidate();
+    expect(spacer.render(80).length).toBe(12);
+
+    frozen = null;
+    spacer.invalidate();
+    expect(spacer.render(80).length).toBe(0);
+
+    rows = 40;
+    contentHeight = 30;
+    spacer.invalidate();
+    expect(spacer.render(80).length).toBe(10);
+  });
+});

--- a/test/file-write-path.test.ts
+++ b/test/file-write-path.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Tool } from "../src/tools/registry.js";
+import { setAllowAllBypass } from "../src/permission/index.js";
+import "../src/tools/init.js";
+
+describe("file_write path handling", () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    setAllowAllBypass(false);
+    await Promise.all(
+      createdDirs.splice(0).map((dir) =>
+        fs.rm(dir, { recursive: true, force: true })
+      )
+    );
+  });
+
+  test("writes absolute paths outside cwd when allow-all grants outside-cwd access", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-file-write-"));
+    createdDirs.push(dir);
+    const filePath = path.join(dir, "nested", "config.json");
+
+    setAllowAllBypass(true);
+    const result = await Tool.execute("file_write", {
+      filePath,
+      content: "{\"ok\":true}\n",
+    });
+
+    expect(result.success).toBe(true);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("{\"ok\":true}\n");
+  });
+});

--- a/test/gh-cli.test.ts
+++ b/test/gh-cli.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { resolveGhCliPath } from "../src/git/gh-cli.js";
+
+describe("resolveGhCliPath", () => {
+  test("uses GH_CLI_PATH override when it exists", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-gh-"));
+    try {
+      const fakeGh = path.join(dir, process.platform === "win32" ? "gh.exe" : "gh");
+      fs.writeFileSync(fakeGh, "");
+      expect(resolveGhCliPath({ GH_CLI_PATH: fakeGh, PATH: "" })).toBe(fakeGh);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null for missing GH_CLI_PATH override", () => {
+    expect(resolveGhCliPath({ GH_CLI_PATH: path.join(os.tmpdir(), "missing-gh"), PATH: "" })).toBeNull();
+  });
+
+  test("finds gh on PATH without invoking the shell", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-gh-path-"));
+    try {
+      const name = process.platform === "win32" ? "gh.exe" : "gh";
+      const fakeGh = path.join(dir, name);
+      fs.writeFileSync(fakeGh, "");
+      expect(resolveGhCliPath({ PATH: dir, PATHEXT: ".EXE;.CMD" })).toBe(fakeGh);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
﻿## Problems

- #91 — Windows absolute paths could be rejected by file write/edit flows.
- #92 — `github_issue` could fail to detect `gh` on Windows.
- #93 — long tool-heavy turns could briefly flicker or jump in the terminal.

## Fixed

- Unified Windows path handling for file write/edit.
- Hardened `gh` detection without shell-specific command strings.
- Stabilized bottom-anchor state after active turns finish or fail.
- Bumped patch version to 1.6.3.


Fixes #91, #92, #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bugfixes in tools, gh probing, and UI anchor lifecycle with new unit tests; no auth or data-model changes.
> 
> **Overview**
> **Release 1.6.3** — Windows path handling, GitHub CLI detection, and terminal scroll stability.
> 
> **`file_write`** now resolves paths through **`resolveToolPath`** (same policy as **`file_edit`**) instead of **`sanitizePath`**, so Windows absolute paths outside the cwd can reach permission/allow-all logic instead of failing early. Parent directories use **`dirname`**, with a small **`mkdir`** guard fix.
> 
> **`github_issue` / `probeGhCli`** no longer run shell strings like `gh ... 2>&1`. **`resolveGhCliPath`** walks **`PATH`** (including Windows **`PATHEXT`** / **`gh.exe`**) or **`GH_CLI_PATH`**, then **`execFileSync`** / **`Bun.spawn`** with explicit argv.
> 
> **Renderer** calls **`releaseTurnAnchor()`** on normal turn completion, errors, and context hard cutoff so frozen bottom-anchor spacer state does not linger after long tool-heavy turns.
> 
> Version and platform optional deps bumped to **1.6.3**; changelog and tests cover path write, **`gh`** resolution, and **`BottomAnchorSpacer`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8deaf74dd02793c2290dc460e07b2fdfb8d8143a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->