### PR TITLE
feat: co-partner workflow and diagnostics enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-22
+
+  **Type:** minor
+  **Title:** Co-partner preferences, diagnostics, validation, and workflow foundations
+
+  ### Added
+  - **#101** — profile communication preferences now compile into explicit co-partner behavior instructions in the system prompt
+  - **#94** — `doctor` tool for lightweight provider/model configuration diagnostics
+  - **#98** — `project_validate` tool detects likely project validation commands
+  - **#96** — `semantic_search` tool provides local-first concept search over project files
+  - **#99** — `bash` supports opt-in named shell sessions that preserve cwd between calls
+  - **#97** — `task` accepts explicit bounded parent context for subagents
+  - **#100** — session sync protocol foundation for future GUI/runtime boundaries
+  - **#85** — fallback global installer script under `scripts/install.mjs`
+
 ## [1.6.3] - 2026-06-22
 
   **Type:** patch

--- a/docs/tools/doctor.md
+++ b/docs/tools/doctor.md
@@ -1,0 +1,18 @@
+# doctor
+
+Run lightweight Impulse configuration diagnostics.
+
+## Use when
+
+- Checking whether provider/model setup looks valid.
+- Debugging first-run or provider configuration problems.
+- Preparing a concise environment summary for the user.
+
+## Parameters
+
+- `includeEnv` optional boolean — include provider environment variable presence.
+
+## Notes
+
+- This does not make network calls.
+- Use provider setup or `/model` when diagnostics show missing model/provider configuration.

--- a/docs/tools/project-validate.md
+++ b/docs/tools/project-validate.md
@@ -1,0 +1,17 @@
+# project_validate
+
+Detect project validation commands.
+
+## Use when
+
+- You need to know the likely typecheck/test/build/lint commands.
+- You want to avoid rediscovering project verification commands.
+
+## Parameters
+
+- `cwd` optional string — directory to inspect; defaults to the current working directory.
+
+## Notes
+
+- This is read-only. It lists commands; use `bash` to run one.
+- Detection currently reads `package.json` scripts and chooses Bun when `bun.lock`/`bun.lockb` is present.

--- a/docs/tools/semantic-search.md
+++ b/docs/tools/semantic-search.md
@@ -1,0 +1,18 @@
+# semantic_search
+
+Search project files by concept using local lexical ranking.
+
+## Use when
+
+- Exact `grep` terms are not obvious.
+- You need candidate files/snippets for a concept before verifying with `file_read` or `grep`.
+
+## Parameters
+
+- `query` required string — concept or terms to search for.
+- `maxResults` optional number — maximum results, capped at 20.
+
+## Notes
+
+- Local-first; no remote embedding calls.
+- Results are ranked hints. Verify important findings with `file_read` or `grep`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -37,11 +37,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.6.3",
-    "@spenceriam/impulse-linux-arm64": "1.6.3",
-    "@spenceriam/impulse-darwin-x64": "1.6.3",
-    "@spenceriam/impulse-darwin-arm64": "1.6.3",
-    "@spenceriam/impulse-windows-x64": "1.6.3",
-    "@spenceriam/impulse-win32-arm64": "1.6.3"
+    "@spenceriam/impulse-linux-x64": "1.7.0",
+    "@spenceriam/impulse-linux-arm64": "1.7.0",
+    "@spenceriam/impulse-darwin-x64": "1.7.0",
+    "@spenceriam/impulse-darwin-arm64": "1.7.0",
+    "@spenceriam/impulse-windows-x64": "1.7.0",
+    "@spenceriam/impulse-win32-arm64": "1.7.0"
   }
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Fallback global installer for impulse.
+ *
+ * Primary install remains:
+ *   npm i -g @spenceriam/impulse
+ *
+ * This script exists for users who need a one-file fallback path. It keeps the
+ * logic intentionally small and delegates the actual package install to npm.
+ */
+
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+
+const SUPPORTED = new Set([
+  "linux:x64",
+  "linux:arm64",
+  "darwin:x64",
+  "darwin:arm64",
+  "win32:x64",
+  "win32:arm64",
+]);
+
+const combo = `${os.platform()}:${os.arch()}`;
+if (!SUPPORTED.has(combo)) {
+  console.error(`Unsupported platform: ${combo}`);
+  console.error("Supported: linux/darwin/win32 on x64/arm64");
+  process.exit(1);
+}
+
+const npmCmd = os.platform() === "win32" ? "npm.cmd" : "npm";
+const args = ["i", "-g", "@spenceriam/impulse@latest"];
+
+console.log(`Installing impulse for ${combo} via npm...`);
+console.log(`${npmCmd} ${args.join(" ")}`);
+
+const result = spawnSync(npmCmd, args, { stdio: "inherit" });
+process.exit(result.status ?? 1);

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -64,7 +64,8 @@ import {
 import {
   applySafetyMargin,
   estimateRequestTokens,
-  resolveFooterContextTokens,
+  resolveFooterContextUsage,
+  type FooterContextTokenSource,
 } from "../session/token-estimate.js";
 import { setAgentTurnActive } from "../session/turn-active.js";
 import {
@@ -167,6 +168,7 @@ export interface LoopEvents {
     contextPct: number;
     tokensPerSecond: number;
     durationMs: number;
+    contextTokenSource: FooterContextTokenSource;
     /** Prompt tokens served from provider cache this turn (when reported). */
     cacheReadTokens?: number;
     /** DEBUG mode: leftover [IMPULSE_DEBUG] markers in edited files. */
@@ -1325,10 +1327,11 @@ export class AgentLoop {
         buildChatMessages(finalMessages, lastSystemPrompt),
         toolDefs
       );
-      const contextTokens = resolveFooterContextTokens({
+      const contextUsage = resolveFooterContextUsage({
         promptTokens: latestPromptTokens,
         estimatedTokens: estimatedContextTokens,
       });
+      const contextTokens = contextUsage.tokens;
       const debugInstrumentationNudge =
         mode === "DEBUG"
           ? buildDebugInstrumentationNudge([...debugEditedFiles])
@@ -1340,6 +1343,7 @@ export class AgentLoop {
         contextPct: Math.min(1, contextTokens / getContextWindow()),
         tokensPerSecond,
         durationMs,
+        contextTokenSource: contextUsage.source,
         ...(latestCacheReadTokens > 0 ? { cacheReadTokens: latestCacheReadTokens } : {}),
         ...(debugInstrumentationNudge
           ? { debugInstrumentationNudge }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -865,10 +865,16 @@ export class AgentLoop {
           }
 
           const specs: TaskCallSpec[] = toRun.map((item) => {
+            const rawPrompt = String(item.args["prompt"] ?? "");
+            const parentContext =
+              typeof item.args["context"] === "string" ? item.args["context"].trim() : "";
+            const prompt = parentContext
+              ? `Parent context:\n${parentContext}\n\nTask:\n${rawPrompt}`
+              : rawPrompt;
             const spec: TaskCallSpec = {
               toolCallId: item.tc.id,
               subagentType: item.args["subagent_type"] as TaskCallSpec["subagentType"],
-              prompt: String(item.args["prompt"] ?? ""),
+              prompt,
               description: String(item.args["description"] ?? ""),
             };
             const thoroughness = item.args["thoroughness"] as

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -9,7 +9,12 @@ import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { isAllowAllBypass } from "../permission/index.js";
-import { isExperimentalAdvisorEnabled, load as loadConfig, type Config } from "../util/config.js";
+import {
+  isExperimentalAdvisorEnabled,
+  load as loadConfig,
+  type Config,
+  type UserProfile,
+} from "../util/config.js";
 import { detectShellEnvironment, generateShellContext } from "../util/shell-env.js";
 import { loadInstructions } from "../util/instructions.js";
 
@@ -30,6 +35,65 @@ export function invalidatePromptCache(): void {
   lastTurnPromptKey = undefined;
   lastTurnPrompt = undefined;
   void import("../harness/session-cache.js").then((m) => m.clearPinnedSystemPrompt());
+}
+
+export function formatUserCollaborationProfile(profile?: UserProfile): string | null {
+  if (!profile) return null;
+
+  const lines: string[] = ["## User collaboration profile", ""];
+  if (profile.name?.trim()) {
+    lines.push(`Name: ${profile.name.trim()}`);
+  }
+
+  const preference = profile.responsePreference?.trim() || "balanced";
+  const normalized = preference.toLowerCase();
+  const presets: Record<string, string[]> = {
+    balanced: [
+      "Style: balanced",
+      "- Be concise, but include important reasoning and tradeoffs.",
+      "- Proceed with safe implementation work when the request is clear.",
+      "- Ask before broad, destructive, or ambiguous changes.",
+      "- After meaningful code changes, run standard validation when practical.",
+    ],
+    concise: [
+      "Style: fast + concise",
+      "- Lead with the answer or action taken.",
+      "- Avoid long explanations unless the user asks for detail.",
+      "- Keep summaries short after tool-heavy work.",
+    ],
+    detailed: [
+      "Style: thorough",
+      "- Explain reasoning, assumptions, and tradeoffs.",
+      "- Prefer explicit verification steps for code changes.",
+      "- Summarize what changed and what remains.",
+    ],
+    casual: [
+      "Style: casual",
+      "- Use a natural, relaxed tone.",
+      "- Stay precise about code, commands, and risks.",
+      "- Avoid unnecessary formality.",
+    ],
+    technical: [
+      "Style: technical",
+      "- Use precise implementation language.",
+      "- Mention relevant files, functions, and tradeoffs when useful.",
+      "- Avoid oversimplifying engineering details.",
+    ],
+  };
+
+  const preset = presets[normalized];
+  if (preset) {
+    lines.push(...preset);
+  } else {
+    lines.push("Style: custom");
+    lines.push(`- User-described preference: ${preference}`);
+  }
+
+  if (profile.customInstructions?.trim()) {
+    lines.push("", "Custom instructions:", profile.customInstructions.trim());
+  }
+
+  return lines.join("\n");
 }
 
 function getPromptsDir(): string {
@@ -440,14 +504,9 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     );
   }
 
-  // Add user profile context if available
-  if (cfg.userProfile?.name) {
-    parts.push(`## User Profile\n\nThe user's name is ${cfg.userProfile.name}.`);
-  }
-  if (cfg.userProfile?.customInstructions?.trim()) {
-    parts.push(
-      `## User preferences\n\n${cfg.userProfile.customInstructions.trim()}`
-    );
+  const collaborationProfile = formatUserCollaborationProfile(cfg.userProfile);
+  if (collaborationProfile) {
+    parts.push(collaborationProfile);
   }
 
   // Add advisor mode directive if experimental advisor is enabled

--- a/src/cli/components/settings-overlay.ts
+++ b/src/cli/components/settings-overlay.ts
@@ -19,7 +19,7 @@ import {
   OVERLAY_SELECT_FG,
 } from "./overlay-theme.js";
 
-const COMM_STYLES = ["concise", "detailed", "casual", "technical"] as const;
+const COMM_STYLES = ["balanced", "concise", "detailed", "casual", "technical"] as const;
 const THINKING_CYCLE: ThinkingDisplay[] = ["off", "summary", "full"];
 const REASONING_CYCLE: ReasoningLevel[] = ["off", "low", "medium", "high"];
 const BOTTOM_BAR_CYCLE: BottomBarVisual[] = ["full", "reduced", "minimal", "off"];
@@ -125,7 +125,7 @@ export class SettingsOverlay implements Component {
     {
       key: "responsePreference",
       label: "Communication style",
-      hint: "concise / detailed / casual / technical",
+      hint: "balanced / concise / detailed / casual / technical",
       kind: "cycle",
     },
     {
@@ -314,7 +314,7 @@ export class SettingsOverlay implements Component {
       case "responsePreference": {
         const styles = COMM_STYLES as readonly string[];
         const idx = styles.indexOf(this.values.responsePreference);
-        const next = styles[(idx + 1) % styles.length] ?? "concise";
+        const next = styles[(idx + 1) % styles.length] ?? "balanced";
         this.values.responsePreference = next;
         break;
       }

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3757,7 +3757,7 @@ export class ImpulseRenderer {
 
   private syncDisplaySettingsFromConfig(config: Config): void {
     this.thinkingDisplay = config.thinkingDisplay ?? "summary";
-    this.responsePreference = config.userProfile?.responsePreference?.trim() || "concise";
+    this.responsePreference = config.userProfile?.responsePreference?.trim() || "balanced";
     this.compactToolOutputEnabled = config.compactToolOutput ?? true;
     this.contextBar?.update({ bottomBarVisual: config.bottomBarVisual ?? "full" });
     this.applyThinkingDisplayMode();
@@ -4510,7 +4510,7 @@ export class ImpulseRenderer {
     const initialValues: SettingsValues = {
       thinkingDisplay: config.thinkingDisplay ?? "summary",
       reasoningLevel: config.reasoningLevel ?? "medium",
-      responsePreference: config.userProfile?.responsePreference?.trim() || "concise",
+      responsePreference: config.userProfile?.responsePreference?.trim() || "balanced",
       statsOnExit: config.statsOnExit ?? false,
       showSubagentThinking: config.showSubagentThinking,
       useSubagentModel: config.useSubagentModel,
@@ -4543,7 +4543,7 @@ export class ImpulseRenderer {
         config.subagentModel = values.subagentModel;
       }
       if (!config.userProfile) {
-        config.userProfile = { name: "", responsePreference: "concise", customInstructions: "" };
+        config.userProfile = { name: "", responsePreference: "balanced", customInstructions: "" };
       }
       config.userProfile.responsePreference = values.responsePreference;
       await saveConfig(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,11 +513,12 @@ export async function runOnboarding(): Promise<void> {
   console.log(`
   How should Impulse respond to you?
 
-    1. Concise    \x1b[90m(short, direct answers)\x1b[0m
-    2. Detailed   \x1b[90m(thorough explanations)\x1b[0m
-    3. Casual     \x1b[90m(relaxed, friendly tone)\x1b[0m
-    4. Technical   \x1b[90m(precise, code-focused)\x1b[0m
-    5. Other       \x1b[90m(describe your preference)\x1b[0m
+    1. Balanced   \x1b[90m(practical default; brief reasoning)\x1b[0m
+    2. Concise    \x1b[90m(short, direct answers)\x1b[0m
+    3. Detailed   \x1b[90m(thorough explanations)\x1b[0m
+    4. Casual     \x1b[90m(relaxed, friendly tone)\x1b[0m
+    5. Technical  \x1b[90m(precise, code-focused)\x1b[0m
+    6. Other      \x1b[90m(describe your preference)\x1b[0m
 `);
 
   const prefChoice = await ask("  Choice [1]: ");
@@ -525,21 +526,25 @@ export async function runOnboarding(): Promise<void> {
 
   switch (prefChoice) {
     case "2":
-      responsePreference = "detailed";
+      responsePreference = "concise";
       break;
     case "3":
-      responsePreference = "casual";
+      responsePreference = "detailed";
       break;
     case "4":
-      responsePreference = "technical";
+      responsePreference = "casual";
       break;
     case "5": {
+      responsePreference = "technical";
+      break;
+    }
+    case "6": {
       const custom = await ask("  Describe your preferred style: ");
-      responsePreference = custom || "concise";
+      responsePreference = custom || "balanced";
       break;
     }
     default:
-      responsePreference = "concise";
+      responsePreference = "balanced";
   }
 
   console.log(`
@@ -556,7 +561,7 @@ export async function runOnboarding(): Promise<void> {
       hasSeenWelcome: true,
       userProfile: {
         name: "",
-        responsePreference: "concise",
+        responsePreference: "balanced",
         customInstructions: "",
       },
     })

--- a/src/session/sync-protocol.ts
+++ b/src/session/sync-protocol.ts
@@ -1,0 +1,43 @@
+/**
+ * Local-first session sync protocol foundation.
+ *
+ * This does not implement remote sync. It defines stable envelope shapes future
+ * GUI panes or transports can use without embedding a terminal renderer.
+ */
+
+export type SyncEventType =
+  | "session.snapshot"
+  | "session.message.appended"
+  | "session.status.changed"
+  | "session.closed";
+
+export interface SyncEvent<TPayload = unknown> {
+  id: string;
+  type: SyncEventType;
+  sessionID: string;
+  projectID: string;
+  createdAt: string;
+  payload: TPayload;
+}
+
+export interface SyncPeer {
+  id: string;
+  kind: "cli" | "gui" | "worker" | "remote";
+  connectedAt: string;
+}
+
+export function createSyncEvent<TPayload>(input: {
+  type: SyncEventType;
+  sessionID: string;
+  projectID: string;
+  payload: TPayload;
+}): SyncEvent<TPayload> {
+  return {
+    id: `sync_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+    type: input.type,
+    sessionID: input.sessionID,
+    projectID: input.projectID,
+    createdAt: new Date().toISOString(),
+    payload: input.payload,
+  };
+}

--- a/src/session/token-estimate.ts
+++ b/src/session/token-estimate.ts
@@ -49,8 +49,17 @@ export function resolveFooterContextTokens(opts: {
   promptTokens: number | undefined;
   estimatedTokens: number;
 }): number {
+  return resolveFooterContextUsage(opts).tokens;
+}
+
+export type FooterContextTokenSource = "provider" | "estimate";
+
+export function resolveFooterContextUsage(opts: {
+  promptTokens: number | undefined;
+  estimatedTokens: number;
+}): { tokens: number; source: FooterContextTokenSource } {
   if (opts.promptTokens !== undefined && opts.promptTokens > 0) {
-    return opts.promptTokens;
+    return { tokens: opts.promptTokens, source: "provider" };
   }
-  return opts.estimatedTokens;
+  return { tokens: opts.estimatedTokens, source: "estimate" };
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { resolve, relative, isAbsolute } from "path";
 import path from "path";
+import { statSync } from "fs";
 import { resolveToolPath } from "./resolve-tool-path.js";
 import { ask as askPermission } from "../permission";
 import { Bus } from "../bus";
@@ -85,25 +86,32 @@ function parseCdTarget(command: string): string | null {
   const trimmed = command.trim();
   const cleanTarget = (raw: string): string => raw.trim().replace(/^['"]|['"]$/g, "");
 
+  // Leading cd before a chain operator (e.g. `cd dir && npm test`).
+  // Check chained forms before lone forms so the target does not greedily
+  // capture the rest of the command.
+  const chainedMatch =
+    trimmed.match(/^(?:cd|Set-Location)\s+(.+?)\s*(?:&&|\|\||;|\|)\s*/i) ??
+    trimmed.match(/^Push-Location\s+(.+?)\s*(?:&&|\|\||;|\|)\s*/i);
+  if (chainedMatch?.[1]) return cleanTarget(chainedMatch[1]);
+
   const loneMatch =
     trimmed.match(/^(?:cd|Set-Location)\s+(.+)$/i) ??
     trimmed.match(/^Push-Location\s+(.+)$/i);
   if (loneMatch?.[1]) return cleanTarget(loneMatch[1]);
 
-  // Leading cd before a chain operator (e.g. `cd dir && npm test`).
-  const chainedMatch =
-    trimmed.match(/^(?:cd|Set-Location)\s+(.+?)\s*(?:&&|\|\||;|\|)\s+/i) ??
-    trimmed.match(/^Push-Location\s+(.+?)\s*(?:&&|\|\||;|\|)\s+/i);
-  if (chainedMatch?.[1]) return cleanTarget(chainedMatch[1]);
-
   return null;
 }
 
-function updateSessionCwd(sessionName: string | null, cwd: string, command: string, success: boolean): void {
-  if (!sessionName || !success) return;
+function updateSessionCwd(sessionName: string | null, cwd: string, command: string): void {
+  if (!sessionName) return;
   const rawTarget = parseCdTarget(command);
   if (!rawTarget) return;
   const next = path.resolve(cwd, rawTarget);
+  try {
+    if (!statSync(next).isDirectory()) return;
+  } catch {
+    return;
+  }
   shellSessions.set(sessionName, { cwd: next });
 }
 
@@ -814,8 +822,8 @@ export const bashTool: Tool<BashInput> = Tool.define(
         result = await executeWithSpawn(input, cwd);
       }
 
+      updateSessionCwd(sessionName, cwd, input.command);
       if (result.success) {
-        updateSessionCwd(sessionName, cwd, input.command, true);
         detectAndPublishBranchChange(input.command, cwd);
       }
       if (sessionName) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -123,8 +123,8 @@ function parseCdTarget(command: string): string | null {
   // Check chained forms before lone forms so the target does not greedily
   // capture the rest of the command.
   const chainedMatch =
-    trimmed.match(/^(?:cd|Set-Location)\s+(.+?)\s*(?:&&|\|\||;|\|)\s*/i) ??
-    trimmed.match(/^Push-Location\s+(.+?)\s*(?:&&|\|\||;|\|)\s*/i);
+    trimmed.match(/^(?:cd|Set-Location)\s+(.+?)\s*(?:&&|\|\||;)\s*/i) ??
+    trimmed.match(/^Push-Location\s+(.+?)\s*(?:&&|\|\||;)\s*/i);
   if (chainedMatch?.[1]) return cleanTarget(chainedMatch[1]);
 
   const loneMatch =

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -55,7 +55,11 @@ const shellSessions = new Map<string, ShellSessionState>();
 function normalizeSessionName(name?: string): string | null {
   const trimmed = name?.trim();
   if (!trimmed) return null;
-  return trimmed.replace(/[^\w.-]/g, "_").slice(0, 60);
+  // Hex-encode disallowed chars so distinct names (e.g. foo@bar vs foo_bar) stay unique.
+  const encoded = trimmed.replace(/[^\w.-]/g, (ch) =>
+    `_x${ch.charCodeAt(0).toString(16).padStart(2, "0")}_`
+  );
+  return encoded.slice(0, 60);
 }
 
 function resolveSessionCwd(sessionName: string | null, fallbackCwd: string, reset?: boolean): string {
@@ -67,14 +71,28 @@ function resolveSessionCwd(sessionName: string | null, fallbackCwd: string, rese
   return fallbackCwd;
 }
 
-function updateSessionCwd(sessionName: string | null, cwd: string, command: string, success: boolean): void {
-  if (!sessionName || !success) return;
+function parseCdTarget(command: string): string | null {
   const trimmed = command.trim();
-  const match =
+  const cleanTarget = (raw: string): string => raw.trim().replace(/^['"]|['"]$/g, "");
+
+  const loneMatch =
     trimmed.match(/^(?:cd|Set-Location)\s+(.+)$/i) ??
     trimmed.match(/^Push-Location\s+(.+)$/i);
-  if (!match?.[1]) return;
-  const rawTarget = match[1].trim().replace(/^['"]|['"]$/g, "");
+  if (loneMatch?.[1]) return cleanTarget(loneMatch[1]);
+
+  // Leading cd before a chain operator (e.g. `cd dir && npm test`).
+  const chainedMatch =
+    trimmed.match(/^(?:cd|Set-Location)\s+(.+?)\s*(?:&&|\|\||;|\|)\s+/i) ??
+    trimmed.match(/^Push-Location\s+(.+?)\s*(?:&&|\|\||;|\|)\s+/i);
+  if (chainedMatch?.[1]) return cleanTarget(chainedMatch[1]);
+
+  return null;
+}
+
+function updateSessionCwd(sessionName: string | null, cwd: string, command: string, success: boolean): void {
+  if (!sessionName || !success) return;
+  const rawTarget = parseCdTarget(command);
+  if (!rawTarget) return;
   const next = path.resolve(cwd, rawTarget);
   shellSessions.set(sessionName, { cwd: next });
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -62,11 +62,21 @@ function normalizeSessionName(name?: string): string | null {
   return encoded.slice(0, 60);
 }
 
-function resolveSessionCwd(sessionName: string | null, fallbackCwd: string, reset?: boolean): string {
+function resolveSessionCwd(
+  sessionName: string | null,
+  fallbackCwd: string,
+  options?: { reset?: boolean; workdirProvided?: boolean }
+): string {
   if (!sessionName) return fallbackCwd;
-  if (reset) shellSessions.delete(sessionName);
+  if (options?.reset) shellSessions.delete(sessionName);
   const existing = shellSessions.get(sessionName);
-  if (existing) return existing.cwd;
+  if (existing) {
+    if (options?.workdirProvided) {
+      shellSessions.set(sessionName, { cwd: fallbackCwd });
+      return fallbackCwd;
+    }
+    return existing.cwd;
+  }
   shellSessions.set(sessionName, { cwd: fallbackCwd });
   return fallbackCwd;
 }
@@ -755,9 +765,18 @@ export const bashTool: Tool<BashInput> = Tool.define(
   BashSchema,
   async (input: BashInput): Promise<ToolResult> => {
     try {
+      const baseCwd = input.workdir
+        ? await resolveToolPath(input.workdir, "bash")
+        : process.cwd();
+      const sessionName = normalizeSessionName(input.session);
+      const cwd = resolveSessionCwd(sessionName, baseCwd, {
+        workdirProvided: !!input.workdir,
+        ...(input.resetSession ? { reset: true } : {}),
+      });
+
       // Check if permission is needed
-      const permCheck = needsPermission(input.command, input.workdir);
-      
+      const permCheck = needsPermission(input.command, cwd);
+
       if (permCheck.needed) {
         await askPermission({
           sessionID: SessionManager.getCurrentSessionID() ?? "unknown",
@@ -775,15 +794,9 @@ export const bashTool: Tool<BashInput> = Tool.define(
           },
         });
       }
-      
+
       // Determine if we should use interactive mode
       const shouldUseInteractive = input.interactive ?? needsInteractiveMode(input.command);
-      
-      const baseCwd = input.workdir
-        ? await resolveToolPath(input.workdir, "bash")
-        : process.cwd();
-      const sessionName = normalizeSessionName(input.session);
-      const cwd = resolveSessionCwd(sessionName, baseCwd, input.resetSession);
       let result: ToolResult;
 
       // Use PTY if interactive mode is requested AND PTY is available

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -52,6 +52,35 @@ interface ShellSessionState {
 }
 
 const shellSessions = new Map<string, ShellSessionState>();
+const sessionChains = new Map<string, Promise<unknown>>();
+
+function isValidSessionCwd(cwd: string): boolean {
+  try {
+    return statSync(cwd).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function withSessionLock<T>(
+  sessionName: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous = sessionChains.get(sessionName) ?? Promise.resolve();
+  const run = previous
+    .catch(() => {
+      /* keep chain alive after prior failure */
+    })
+    .then(() => fn());
+  sessionChains.set(sessionName, run);
+  try {
+    return await run;
+  } finally {
+    if (sessionChains.get(sessionName) === run) {
+      sessionChains.delete(sessionName);
+    }
+  }
+}
 
 function normalizeSessionName(name?: string): string | null {
   const trimmed = name?.trim();
@@ -76,7 +105,11 @@ function resolveSessionCwd(
       shellSessions.set(sessionName, { cwd: fallbackCwd });
       return fallbackCwd;
     }
-    return existing.cwd;
+    if (isValidSessionCwd(existing.cwd)) {
+      return existing.cwd;
+    }
+    shellSessions.set(sessionName, { cwd: fallbackCwd });
+    return fallbackCwd;
   }
   shellSessions.set(sessionName, { cwd: fallbackCwd });
   return fallbackCwd;
@@ -772,11 +805,12 @@ export const bashTool: Tool<BashInput> = Tool.define(
   DESCRIPTION,
   BashSchema,
   async (input: BashInput): Promise<ToolResult> => {
-    try {
+    const sessionName = normalizeSessionName(input.session);
+
+    const runBash = async (): Promise<ToolResult> => {
       const baseCwd = input.workdir
         ? await resolveToolPath(input.workdir, "bash")
         : process.cwd();
-      const sessionName = normalizeSessionName(input.session);
       const cwd = resolveSessionCwd(sessionName, baseCwd, {
         workdirProvided: !!input.workdir,
         ...(input.resetSession ? { reset: true } : {}),
@@ -834,7 +868,12 @@ export const bashTool: Tool<BashInput> = Tool.define(
         };
       }
       return result;
-      
+    };
+
+    try {
+      return sessionName
+        ? await withSessionLock(sessionName, runBash)
+        : await runBash();
     } catch (error) {
       if (error instanceof Error) {
         let output = error.message;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { resolve, relative, isAbsolute } from "path";
+import path from "path";
 import { resolveToolPath } from "./resolve-tool-path.js";
 import { ask as askPermission } from "../permission";
 import { Bus } from "../bus";
@@ -24,7 +25,7 @@ const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this uses PowerShell. On macOS/Linux this uses bash.
-Required: command, description. Optional: workdir, timeout, interactive.
+Required: command, description. Optional: workdir, timeout, interactive, session.
 See docs/tools/bash.md for safety rules and usage details.`;
 
 const BashSchema = z.object({
@@ -33,6 +34,8 @@ const BashSchema = z.object({
   workdir: zFilePath().optional(),
   timeout: z.number().optional(),
   interactive: z.boolean().optional(),
+  session: z.string().optional().describe("Optional named shell session; preserves cwd between bash calls"),
+  resetSession: z.boolean().optional().describe("Reset the named shell session before running"),
 });
 
 type BashInput = z.infer<typeof BashSchema>;
@@ -41,6 +44,39 @@ interface SpawnOptions {
   cmd: string[];
   cwd?: string;
   env?: Record<string, string | undefined>;
+}
+
+interface ShellSessionState {
+  cwd: string;
+}
+
+const shellSessions = new Map<string, ShellSessionState>();
+
+function normalizeSessionName(name?: string): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.replace(/[^\w.-]/g, "_").slice(0, 60);
+}
+
+function resolveSessionCwd(sessionName: string | null, fallbackCwd: string, reset?: boolean): string {
+  if (!sessionName) return fallbackCwd;
+  if (reset) shellSessions.delete(sessionName);
+  const existing = shellSessions.get(sessionName);
+  if (existing) return existing.cwd;
+  shellSessions.set(sessionName, { cwd: fallbackCwd });
+  return fallbackCwd;
+}
+
+function updateSessionCwd(sessionName: string | null, cwd: string, command: string, success: boolean): void {
+  if (!sessionName || !success) return;
+  const trimmed = command.trim();
+  const match =
+    trimmed.match(/^(?:cd|Set-Location)\s+(.+)$/i) ??
+    trimmed.match(/^Push-Location\s+(.+)$/i);
+  if (!match?.[1]) return;
+  const rawTarget = match[1].trim().replace(/^['"]|['"]$/g, "");
+  const next = path.resolve(cwd, rawTarget);
+  shellSessions.set(sessionName, { cwd: next });
 }
 
 const WINDOWS_COMMAND_ENV_VAR = "IMPULSE_COMMAND";
@@ -725,9 +761,11 @@ export const bashTool: Tool<BashInput> = Tool.define(
       // Determine if we should use interactive mode
       const shouldUseInteractive = input.interactive ?? needsInteractiveMode(input.command);
       
-      const cwd = input.workdir
+      const baseCwd = input.workdir
         ? await resolveToolPath(input.workdir, "bash")
         : process.cwd();
+      const sessionName = normalizeSessionName(input.session);
+      const cwd = resolveSessionCwd(sessionName, baseCwd, input.resetSession);
       let result: ToolResult;
 
       // Use PTY if interactive mode is requested AND PTY is available
@@ -746,7 +784,15 @@ export const bashTool: Tool<BashInput> = Tool.define(
       }
 
       if (result.success) {
+        updateSessionCwd(sessionName, cwd, input.command, true);
         detectAndPublishBranchChange(input.command, cwd);
+      }
+      if (sessionName) {
+        result.metadata = {
+          ...(result.metadata ?? {}),
+          session: sessionName,
+          sessionCwd: shellSessions.get(sessionName)?.cwd ?? cwd,
+        };
       }
       return result;
       

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import { load as loadConfig, isModelConfigured } from "../util/config.js";
+
+const DESCRIPTION = `Run lightweight Impulse configuration diagnostics.
+
+Checks provider/model configuration without making network calls.`;
+
+const DoctorSchema = z.object({
+  includeEnv: z.boolean().optional().describe("Include provider environment variable hints"),
+});
+
+type DoctorInput = z.infer<typeof DoctorSchema>;
+
+const PROVIDER_ENV_VARS: Record<string, string[]> = {
+  "z.ai": ["ZAI_API_KEY", "GLM_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  gemini: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"],
+  nous: ["NOUS_API_KEY"],
+  ollama: ["OLLAMA_API_KEY"],
+};
+
+export const doctorTool: Tool<DoctorInput> = Tool.define(
+  "doctor",
+  DESCRIPTION,
+  DoctorSchema,
+  async (input: DoctorInput): Promise<ToolResult> => {
+    const config = await loadConfig();
+    const providers = config.providers as Record<string, { apiKey?: string; baseUrl?: string; type?: string } | undefined>;
+    const configured = Object.entries(providers)
+      .filter(([, value]) => Boolean(value?.apiKey || value?.baseUrl))
+      .map(([key, value]) => {
+        const bits = [
+          value?.apiKey ? "apiKey" : null,
+          value?.baseUrl ? `baseUrl=${value.baseUrl}` : null,
+          value?.type ? `type=${value.type}` : null,
+        ].filter(Boolean);
+        return `- ${key}: ${bits.join(", ") || "present"}`;
+      });
+
+    const lines = [
+      "Impulse diagnostics",
+      "",
+      `Default provider: ${config.defaultProvider || "(not set)"}`,
+      `Default model: ${config.defaultModel || "(not set)"}`,
+      `Model configured: ${isModelConfigured(config) ? "yes" : "no"}`,
+      `Reasoning level: ${config.reasoningLevel}`,
+      `Max output tokens: ${config.maxOutputTokens}`,
+      "",
+      configured.length > 0
+        ? `Configured providers:\n${configured.join("\n")}`
+        : "Configured providers: none",
+    ];
+
+    if (input.includeEnv) {
+      const envLines = Object.entries(PROVIDER_ENV_VARS).map(([provider, keys]) => {
+        const present = keys.filter((key) => Boolean(process.env[key]));
+        return `- ${provider}: ${present.length > 0 ? present.join(", ") : "(none)"}`;
+      });
+      lines.push("", `Provider env vars:\n${envLines.join("\n")}`);
+    }
+
+    const warnings: string[] = [];
+    if (!isModelConfigured(config)) {
+      warnings.push("Run /model or --setup to choose a provider and model.");
+    }
+    if (!providers[config.defaultProvider]?.apiKey && !providers[config.defaultProvider]?.baseUrl) {
+      warnings.push(`Default provider "${config.defaultProvider}" is not configured in config providers.`);
+    }
+    if (warnings.length > 0) {
+      lines.push("", `Warnings:\n${warnings.map((w) => `- ${w}`).join("\n")}`);
+    }
+
+    return {
+      success: warnings.length === 0,
+      output: lines.join("\n"),
+      metadata: {
+        defaultProvider: config.defaultProvider,
+        defaultModel: config.defaultModel,
+        configuredProviders: configured.length,
+        warnings,
+      },
+    };
+  }
+);

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -67,7 +67,13 @@ export const doctorTool: Tool<DoctorInput> = Tool.define(
     if (!isModelConfigured(config)) {
       warnings.push("Run /model or --setup to choose a provider and model.");
     }
-    if (!providers[config.defaultProvider]?.apiKey && !providers[config.defaultProvider]?.baseUrl) {
+    const defaultProviderCfg = providers[config.defaultProvider];
+    const defaultProviderConfigured =
+      Boolean(defaultProviderCfg?.apiKey || defaultProviderCfg?.baseUrl) ||
+      (config.defaultProvider === "ollama" &&
+        (isModelConfigured(config) ||
+          Boolean(process.env["OLLAMA_API_KEY"] || process.env["OLLAMA_BASE_URL"])));
+    if (!defaultProviderConfigured) {
       warnings.push(`Default provider "${config.defaultProvider}" is not configured in config providers.`);
     }
     if (warnings.length > 0) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,3 +13,6 @@ export type { Question, QuestionOption, QuestionToolInput, QuestionToolOutput } 
 export { setHeader } from "./set-header";
 export { setMode } from "./set-mode";
 export { toolDocsTool } from "./tool-docs";
+export { doctorTool } from "./doctor";
+export { projectValidateTool } from "./project-validate";
+export { semanticSearchTool } from "./semantic-search";

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -42,6 +42,9 @@ import "./install-skill";
 
 // GitHub
 import "./github-issue";
+import "./doctor";
+import "./project-validate";
+import "./semantic-search";
 
 // Re-export registry for convenience
 export { Tool } from "./registry";

--- a/src/tools/project-validate.ts
+++ b/src/tools/project-validate.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import { detectValidationCommands } from "../util/project-validation.js";
+
+const DESCRIPTION = `Detect project validation commands.
+
+Lists likely typecheck/test/build/lint commands for the current project.`;
+
+const ProjectValidateSchema = z.object({
+  cwd: z.string().optional().describe("Directory to inspect; defaults to current working directory"),
+});
+
+type ProjectValidateInput = z.infer<typeof ProjectValidateSchema>;
+
+export const projectValidateTool: Tool<ProjectValidateInput> = Tool.define(
+  "project_validate",
+  DESCRIPTION,
+  ProjectValidateSchema,
+  async (input: ProjectValidateInput): Promise<ToolResult> => {
+    const cwd = input.cwd?.trim() || process.cwd();
+    const commands = detectValidationCommands(cwd);
+    if (commands.length === 0) {
+      return {
+        success: true,
+        output: `No standard validation commands detected in ${cwd}.`,
+        metadata: { cwd, commands: [] },
+      };
+    }
+
+    return {
+      success: true,
+      output: [
+        `Validation commands for ${cwd}:`,
+        ...commands.map((cmd) => `- ${cmd.name}: ${cmd.command} (${cmd.source})`),
+      ].join("\n"),
+      metadata: { cwd, commands },
+    };
+  }
+);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -45,6 +45,9 @@ const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   plan_revision: "utility",
   install_skill: "utility",
   github_issue: "read_only",
+  doctor: "read_only",
+  project_validate: "read_only",
+  semantic_search: "read_only",
   
   // Write tools (restricted in PLAN)
   file_write: "write",

--- a/src/tools/semantic-search.ts
+++ b/src/tools/semantic-search.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { Tool, ToolResult } from "./registry";
+import fs from "fs";
+import path from "path";
+
+const DESCRIPTION = `Search project files by concept using local lexical ranking.
+
+This is a local-first semantic search foundation: it ranks files/snippets by query terms and returns verifiable file paths.`;
+
+const SemanticSearchSchema = z.object({
+  query: z.string().min(1).describe("Concept or terms to search for"),
+  maxResults: z.number().int().positive().max(20).optional(),
+});
+
+type SemanticSearchInput = z.infer<typeof SemanticSearchSchema>;
+
+const SKIP_DIRS = new Set([".git", "node_modules", "dist", ".next", "coverage"]);
+const TEXT_EXTS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".json", ".md", ".yml", ".yaml", ".txt", ".css",
+]);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(path.join(dir, entry.name), out);
+    } else if (entry.isFile() && TEXT_EXTS.has(path.extname(entry.name))) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+function terms(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/[^a-z0-9_/-]+/i)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2);
+}
+
+function scoreFile(filePath: string, content: string, queryTerms: string[]): number {
+  const haystack = `${filePath}\n${content}`.toLowerCase();
+  return queryTerms.reduce((score, term) => {
+    const matches = haystack.split(term).length - 1;
+    return score + matches;
+  }, 0);
+}
+
+function snippet(content: string, queryTerms: string): string {
+  const lines = content.split(/\r?\n/);
+  const lowerTerms = terms(queryTerms);
+  const index = lines.findIndex((line) =>
+    lowerTerms.some((term) => line.toLowerCase().includes(term))
+  );
+  const start = Math.max(0, index < 0 ? 0 : index - 1);
+  return lines.slice(start, start + 3).join("\n").slice(0, 600);
+}
+
+export const semanticSearchTool: Tool<SemanticSearchInput> = Tool.define(
+  "semantic_search",
+  DESCRIPTION,
+  SemanticSearchSchema,
+  async (input: SemanticSearchInput): Promise<ToolResult> => {
+    const cwd = process.cwd();
+    const queryTerms = terms(input.query);
+    const maxResults = input.maxResults ?? 8;
+    const results = walk(cwd)
+      .map((file) => {
+        try {
+          const content = fs.readFileSync(file, "utf-8");
+          return {
+            file: path.relative(cwd, file),
+            score: scoreFile(file, content, queryTerms),
+            snippet: snippet(content, input.query),
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter((item): item is { file: string; score: number; snippet: string } =>
+        Boolean(item && item.score > 0)
+      )
+      .sort((a, b) => b.score - a.score || a.file.localeCompare(b.file))
+      .slice(0, maxResults);
+
+    if (results.length === 0) {
+      return {
+        success: true,
+        output: `No semantic_search results for "${input.query}".`,
+        metadata: { query: input.query, results: [] },
+      };
+    }
+
+    const output = results
+      .map((r) => `- ${r.file} (score ${r.score})\n${r.snippet}`)
+      .join("\n\n");
+    return {
+      success: true,
+      output: `semantic_search results for "${input.query}":\n\n${output}`,
+      metadata: { query: input.query, results },
+    };
+  }
+);

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -6,7 +6,7 @@ import { getCurrentMode } from "./mode-state";
 
 const DESCRIPTION = `Launch a subagent for delegated work.
 
-Required: prompt, description, subagent_type. Optional: thoroughness (explore only).
+Required: prompt, description, subagent_type. Optional: thoroughness (explore only), context.
 Multiple task calls in one turn run in parallel (up to 8 concurrent; additional tasks queue).
 See docs/tools/task.md for guidance and examples.`;
 
@@ -15,6 +15,7 @@ const TaskSchema = z.object({
   description: z.string(),
   subagent_type: z.enum(["explore", "general"]),
   thoroughness: z.enum(["quick", "medium", "thorough"]).optional(),
+  context: z.string().optional().describe("Bounded parent-session context to pass to the subagent"),
 });
 
 type TaskInput = z.infer<typeof TaskSchema>;
@@ -43,9 +44,13 @@ export const taskTool: Tool<TaskInput> = Tool.define(
         };
       }
 
+      const prompt = input.context?.trim()
+        ? `Parent context:\n${input.context.trim()}\n\nTask:\n${input.prompt}`
+        : input.prompt;
+
       const run = await executeSubagent(
         input.subagent_type,
-        input.prompt,
+        prompt,
         input.description,
         input.thoroughness,
         { parentToolCallId: "standalone-task" }
@@ -53,7 +58,7 @@ export const taskTool: Tool<TaskInput> = Tool.define(
 
       const spec: Pick<TaskCallSpec, "subagentType" | "prompt" | "description" | "thoroughness"> = {
         subagentType: input.subagent_type,
-        prompt: input.prompt,
+        prompt,
         description: input.description,
       };
       if (input.thoroughness !== undefined) {

--- a/src/tools/tool-docs.ts
+++ b/src/tools/tool-docs.ts
@@ -34,6 +34,9 @@ const TOOL_DOCS_MAP: Record<string, string> = {
   install_skill: "install-skill.md",
   github_issue: "github-issue.md",
   tool_docs: "tool-docs.md",
+  doctor: "doctor.md",
+  project_validate: "project-validate.md",
+  semantic_search: "semantic-search.md",
 };
 
 function getToolDocsDir(): string {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -102,7 +102,7 @@ const ConfigSchema = z.object({
     /** User's display name */
     name: z.string().default(""),
     /** Response style preference */
-    responsePreference: z.string().default("concise"),
+    responsePreference: z.string().default("balanced"),
     /** Custom instructions injected into every system prompt */
     customInstructions: z.string().default(""),
   }).optional(),

--- a/src/util/project-validation.ts
+++ b/src/util/project-validation.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import path from "path";
+
+export interface ValidationCommand {
+  name: string;
+  command: string;
+  source: string;
+}
+
+function readPackageScripts(cwd: string): Record<string, string> {
+  const packageJson = path.join(cwd, "package.json");
+  if (!fs.existsSync(packageJson)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packageJson, "utf-8")) as {
+      scripts?: Record<string, string>;
+    };
+    return parsed.scripts ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function packageManager(cwd: string): "bun" | "npm" {
+  if (fs.existsSync(path.join(cwd, "bun.lock")) || fs.existsSync(path.join(cwd, "bun.lockb"))) {
+    return "bun";
+  }
+  return "npm";
+}
+
+export function detectValidationCommands(cwd = process.cwd()): ValidationCommand[] {
+  const scripts = readPackageScripts(cwd);
+  const pm = packageManager(cwd);
+  const prefix = pm === "bun" ? "bun run" : "npm run";
+  const preferred = ["typecheck", "test", "build", "lint"];
+  const commands: ValidationCommand[] = [];
+
+  for (const name of preferred) {
+    if (scripts[name]) {
+      commands.push({
+        name,
+        command: `${prefix} ${name}`,
+        source: "package.json",
+      });
+    }
+  }
+
+  return commands;
+}

--- a/test/bash-session-cwd.test.ts
+++ b/test/bash-session-cwd.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import path from "path";
+import { bashTool } from "../src/tools/bash.js";
+
+const root = path.join(process.cwd(), `.tmp-bash-session-${Date.now()}`);
+const child = path.join(root, "child");
+const other = path.join(root, "other");
+
+async function run(
+  command: string,
+  session: string,
+  options: { resetSession?: boolean; workdir?: string | null } = {}
+) {
+  return bashTool.handler({
+    command,
+    description: "test bash session cwd tracking",
+    ...(options.workdir === null ? {} : { workdir: options.workdir ?? root }),
+    session,
+    timeout: 10_000,
+    ...(options.resetSession ? { resetSession: true } : {}),
+  });
+}
+
+describe("bash named session cwd tracking", () => {
+  beforeAll(() => {
+    mkdirSync(child, { recursive: true });
+    mkdirSync(other, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("chained cd parses only the directory target and updates cwd on later command failure", async () => {
+    const result = await run("cd child; exit 7", "session-failed-chain", { resetSession: true });
+
+    expect(result.success).toBe(false);
+    expect(result.metadata?.sessionCwd).toBe(child);
+  });
+
+  test("chained cd updates cwd on successful command", async () => {
+    const result = await run("cd child; echo ok", "session-successful-chain", { resetSession: true });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.sessionCwd).toBe(child);
+  });
+
+  test("missing cd target does not update stored cwd", async () => {
+    const session = "session-missing-target";
+    await run("cd other", session, { resetSession: true });
+
+    const result = await run("cd missing-dir; echo after", session, { workdir: null });
+
+    expect(result.metadata?.sessionCwd).toBe(other);
+  });
+
+  test("lone cd still updates cwd", async () => {
+    const result = await run("cd child", "session-lone-cd", { resetSession: true });
+
+    expect(result.success).toBe(true);
+    expect(result.metadata?.sessionCwd).toBe(child);
+  });
+
+  test("distinct named sessions keep separate cwd state", async () => {
+    const first = await run("cd child", "session-one", { resetSession: true });
+    const second = await run("cd other", "session-two", { resetSession: true });
+
+    expect(first.metadata?.sessionCwd).toBe(child);
+    expect(second.metadata?.sessionCwd).toBe(other);
+  });
+});

--- a/test/context-accounting.test.ts
+++ b/test/context-accounting.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFooterContextUsage } from "../src/session/token-estimate.js";
+
+describe("resolveFooterContextUsage", () => {
+  test("prefers provider prompt tokens", () => {
+    expect(resolveFooterContextUsage({ promptTokens: 123, estimatedTokens: 999 })).toEqual({
+      tokens: 123,
+      source: "provider",
+    });
+  });
+
+  test("falls back to estimates", () => {
+    expect(resolveFooterContextUsage({ promptTokens: undefined, estimatedTokens: 999 })).toEqual({
+      tokens: 999,
+      source: "estimate",
+    });
+  });
+});

--- a/test/profile-preferences.test.ts
+++ b/test/profile-preferences.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatUserCollaborationProfile } from "../src/agent/prompts.js";
+
+describe("formatUserCollaborationProfile", () => {
+  test("compiles balanced preference into behavioral instructions", () => {
+    const block = formatUserCollaborationProfile({
+      name: "Spencer",
+      responsePreference: "balanced",
+      customInstructions: "",
+    });
+
+    expect(block).toContain("Name: Spencer");
+    expect(block).toContain("Style: balanced");
+    expect(block).toContain("Proceed with safe implementation work");
+  });
+
+  test("keeps custom instructions in the profile block", () => {
+    const block = formatUserCollaborationProfile({
+      name: "",
+      responsePreference: "technical",
+      customInstructions: "Prefer exact file names.",
+    });
+
+    expect(block).toContain("Style: technical");
+    expect(block).toContain("Prefer exact file names.");
+  });
+});

--- a/test/project-validation.test.ts
+++ b/test/project-validation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { detectValidationCommands } from "../src/util/project-validation.js";
+
+describe("detectValidationCommands", () => {
+  test("detects package validation scripts and prefers bun when bun.lock is present", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-validation-"));
+    try {
+      fs.writeFileSync(
+        path.join(dir, "package.json"),
+        JSON.stringify({
+          scripts: {
+            typecheck: "tsc --noEmit",
+            test: "bun test",
+            build: "bun run scripts/build.ts",
+          },
+        })
+      );
+      fs.writeFileSync(path.join(dir, "bun.lock"), "");
+
+      expect(detectValidationCommands(dir).map((c) => c.command)).toEqual([
+        "bun run typecheck",
+        "bun run test",
+        "bun run build",
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sync-protocol.test.ts
+++ b/test/sync-protocol.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { createSyncEvent } from "../src/session/sync-protocol.js";
+
+describe("createSyncEvent", () => {
+  test("creates a sync event envelope", () => {
+    const event = createSyncEvent({
+      type: "session.status.changed",
+      sessionID: "sess_1",
+      projectID: "proj_1",
+      payload: { status: "idle" },
+    });
+
+    expect(event.id).toStartWith("sync_");
+    expect(event.sessionID).toBe("sess_1");
+    expect(event.payload).toEqual({ status: "idle" });
+  });
+});


### PR DESCRIPTION
﻿## Problems

- The profile/preferences system did not strongly drive agent behavior.
- Provider/model setup lacked a clear health diagnostic path.
- Long-session workflow, validation, subagent context, shell state, search, installer, and future GUI foundations needed first-class implementation.

## Changed

- Added co-partner profile behavior presets.
- Added provider diagnostics and improved context accounting.
- Added project validation, subagent context sharing, persistent shell-session support, semantic search foundation, remote-sync foundation, and global installer support.
- Bumped minor version to 1.7.0.

Fixes #85
Fixes #94
Fixes #95
Fixes #96
Fixes #97
Fixes #98
Fixes #99
Fixes #100
Fixes #101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds in-process bash session state and changes system-prompt composition and subagent inputs; new tools are read-only but bash session cwd heuristics could mis-track edge-case shell usage.
> 
> **Overview**
> **Release 1.7.0** adds workflow and diagnostics capabilities and tightens how user preferences shape agent behavior.
> 
> **Co-partner profile** — `formatUserCollaborationProfile` turns `userProfile` (name, `responsePreference`, custom instructions) into explicit system-prompt behavior blocks with presets (**balanced** is the new default across config, onboarding, and `/settings`). Communication style options now include **balanced** alongside concise/detailed/casual/technical.
> 
> **New read-only tools** — `doctor` (local config/provider diagnostics, optional env hints), `project_validate` (detect typecheck/test/build/lint from `package.json`, Bun vs npm), and `semantic_search` (local lexical file ranking, no embeddings). Each is registered, documented under `docs/tools/`, and wired into `tool_docs`.
> 
> **Agent workflow** — `task` accepts optional **`context`**; the agent loop and standalone `task` handler prepend bounded parent context to subagent prompts. **`bash`** supports optional named **`session`** / **`resetSession`**, serializes per-session runs, and tracks cwd across calls (including chained `cd` parsing). Turn-end footer accounting uses **`resolveFooterContextUsage`** so **`onTurnEnd`** reports whether context tokens came from the provider or an estimate.
> 
> **Foundations** — `src/session/sync-protocol.ts` defines stable sync event envelopes for future GUI/runtime peers. **`scripts/install.mjs`** is a small platform-gated fallback that runs `npm i -g @spenceriam/impulse@latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf566d3ea93cd70a9d94126518f8b210df57749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->