### PR TITLE
feat: auto-detect Windows shells and harden state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-22
+
+  **Type:** minor
+  **Title:** Windows shell auto-detection and cross-platform hardening
+
+  ### Added
+  - **#104** — Windows command execution now auto-detects PowerShell, cmd.exe, and Git Bash so Impulse can follow the user's active shell where possible
+
+  ### Fixed
+  - **#104** — compound shell command permission checks now classify each unquoted command segment instead of allowing risky commands through safe-looking prefixes
+  - **#104** — PowerShell chaining checks are capability-aware, so PowerShell 5 still blocks `&&` / `||` while PowerShell 7 allows them
+  - **#105** — path containment checks now handle Windows different-drive paths and valid names like `..foo` consistently
+  - **#105** — GitHub CLI lookup now rejects directories named `gh` / `gh.exe`
+  - **#105** — `file_write` permission metadata uses the active session ID and basename handling uses Node path utilities
+  - **#105** — session and generic storage JSON writes now use crash-safe atomic writes with Windows rename retries
+
 ## [1.7.0] - 2026-06-22
 
   **Type:** minor

--- a/docs/cross-platform-shell.md
+++ b/docs/cross-platform-shell.md
@@ -16,6 +16,8 @@ impulse is designed to **"just work"** across all major operating systems withou
 ### Windows
 - **PowerShell 5.x** (Windows PowerShell) - Built into Windows 10/11
 - **PowerShell 7.x** (pwsh) - Cross-platform PowerShell
+- **cmd.exe** - Windows Command Prompt
+- **Git Bash** - POSIX shell installed with Git for Windows
 
 ### macOS
 - **bash** - Legacy default shell (macOS 10.14 and earlier)
@@ -36,7 +38,7 @@ On startup or when generating system prompts, impulse:
 
 1. Detects the operating system (`process.platform`)
 2. Queries the shell version:
-   - **Windows**: Attempts `pwsh --version`, falls back to `powershell.exe`
+   - **Windows**: Detects the active shell when possible (`pwsh`, `powershell.exe`, `cmd.exe`, Git Bash); falls back to `pwsh` if installed, then `powershell.exe`
    - **macOS/Linux**: Reads `$SHELL` for login-shell context and uses `bash -lc` for command execution
 3. Returns a `ShellEnvironment` object with:
    - Platform name
@@ -47,7 +49,7 @@ On startup or when generating system prompts, impulse:
 
 ### 2. POSIX-to-PowerShell Translation (`src/tools/posix-translation.ts`)
 
-When running commands on Windows, common POSIX patterns are automatically translated:
+When running commands on Windows through PowerShell, common POSIX patterns are automatically translated:
 
 | POSIX Command | PowerShell Equivalent |
 |---------------|----------------------|
@@ -63,7 +65,7 @@ When running commands on Windows, common POSIX patterns are automatically transl
 | `env` | `Get-ChildItem Env:` |
 | `touch file` | `New-Item -ItemType File -Force -Path file` |
 
-**Translation happens automatically for simple single commands** - AI models can write common POSIX commands and they'll work on Windows. Compound commands, pipelines, and redirects are left untouched because partial regex rewrites can change command behavior.
+**Translation happens automatically for simple single commands in PowerShell** - AI models can write common POSIX commands and they'll work in Windows PowerShell. Compound commands, pipelines, and redirects are left untouched because partial regex rewrites can change command behavior. Translation is not applied when the active Windows shell is cmd.exe or Git Bash.
 
 ### 3. Output Stream Handling (`src/tools/bash.ts`)
 
@@ -120,6 +122,8 @@ Different execution shells support different chaining operators:
 |-------|-----------------|----------------|---------------|
 | PowerShell 5.x | ❌ (use `;`) | ❌ (use `;`) | `;` |
 | PowerShell 7.x | `&&` | `\|\|` | `;` |
+| cmd.exe | `&&` | `\|\|` | `&` |
+| Git Bash | `&&` | `\|\|` | `;` |
 | macOS/Linux bash (`bash -lc`) | `&&` | `\|\|` | `;` |
 
 impulse provides `supportsChainedCommands` and `commandSeparator` in `ShellEnvironment` to guide command construction.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/cli/user-shell.ts
+++ b/src/cli/user-shell.ts
@@ -3,9 +3,16 @@
  */
 
 import { sanitizePath } from "../util/path.js";
-import { executePty, isPtyAvailable, initPty, type PtyHandle } from "../pty/index.js";
+import {
+  executePty,
+  isPtyAvailable,
+  initPty,
+  type PtyHandle,
+  type PtySpawnOptions,
+} from "../pty/index.js";
 import { needsInteractiveMode } from "../tools/bash.js";
 import { detectAndPublishBranchChange } from "../git/branch-detect.js";
+import { detectWindowsCommandShell } from "../util/windows-shell.js";
 
 export interface ShellRunResult {
   command: string;
@@ -20,20 +27,39 @@ export interface ShellRunResult {
 
 export type ShellDataHandler = (chunk: string) => void;
 
-function buildCmd(command: string): string[] {
+interface BuiltShellCommand {
+  cmd: string[];
+  ptyOptions?: PtySpawnOptions;
+}
+
+async function buildCmd(command: string, interactive = false): Promise<BuiltShellCommand> {
   if (process.platform === "win32") {
-    return [
-      "powershell.exe",
+    const shell = await detectWindowsCommandShell();
+
+    if (shell.type === "cmd") {
+      const args = ["/d", "/s", "/c", command];
+      return { cmd: [shell.executable, ...args], ptyOptions: { shell: shell.executable, args } };
+    }
+
+    if (shell.type === "git-bash") {
+      const args = ["-lc", command];
+      return { cmd: [shell.executable, ...args], ptyOptions: { shell: shell.executable, args } };
+    }
+
+    const args = [
       "-NoLogo",
       "-NoProfile",
-      "-NonInteractive",
+      ...(interactive ? [] : ["-NonInteractive"]),
       "-ExecutionPolicy",
       "Bypass",
       "-Command",
       command,
     ];
+    return { cmd: [shell.executable, ...args], ptyOptions: { shell: shell.executable, args } };
   }
-  return ["bash", "-lc", command];
+
+  const args = ["-lc", command];
+  return { cmd: ["bash", ...args], ptyOptions: { shell: "bash", args } };
 }
 
 let activeAbort: AbortController | null = null;
@@ -84,6 +110,7 @@ export async function runUserShellCommand(options: {
   const cwd = options.cwd ? sanitizePath(options.cwd) : process.cwd();
   const start = Date.now();
   const interactive = options.forceInteractive ?? needsInteractiveMode(command);
+  const builtCommand = await buildCmd(command, interactive);
 
   abortUserShell();
   activeAbort = new AbortController();
@@ -109,7 +136,8 @@ export async function runUserShellCommand(options: {
       },
       signal,
       cols,
-      rows
+      rows,
+      builtCommand.ptyOptions
     );
     activePty = handle;
     let result: ShellRunResult;
@@ -152,7 +180,7 @@ export async function runUserShellCommand(options: {
 
   const usePipedInteractive = interactive && !isPtyAvailable();
   const proc = Bun.spawn({
-    cmd: buildCmd(command),
+    cmd: builtCommand.cmd,
     cwd,
     env: process.env,
     stdin: usePipedInteractive ? "pipe" : "ignore",

--- a/src/git/gh-cli.ts
+++ b/src/git/gh-cli.ts
@@ -25,10 +25,23 @@ function executableCandidates(name: string, env: NodeJS.ProcessEnv = process.env
     .map((e) => `${name}${e.toLowerCase()}`);
 }
 
+function isExecutableFile(filePath: string): boolean {
+  try {
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) return false;
+    if (process.platform !== "win32") {
+      fs.accessSync(filePath, fs.constants.X_OK);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function resolveGhCliPath(env: NodeJS.ProcessEnv = process.env): string | null {
   const override = env["GH_CLI_PATH"]?.trim();
   if (override) {
-    return fs.existsSync(override) ? override : null;
+    return isExecutableFile(override) ? override : null;
   }
 
   const pathValue = env["PATH"] ?? "";
@@ -36,7 +49,7 @@ export function resolveGhCliPath(env: NodeJS.ProcessEnv = process.env): string |
   for (const dir of dirs) {
     for (const candidate of executableCandidates("gh", env)) {
       const fullPath = path.join(dir, candidate);
-      if (fs.existsSync(fullPath)) {
+      if (isExecutableFile(fullPath)) {
         return fullPath;
       }
     }

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -2,9 +2,9 @@ import { Storage } from "../storage";
 import { Bus, SessionEvents } from "../bus";
 import { Global } from "../global";
 import crypto from "crypto";
-import fs from "fs/promises";
 import path from "path";
 import type { OptionalPatch } from "../util/omit-undefined.js";
+import { writeJsonAtomic } from "../util/atomic-write.js";
 
 /**
  * Generate a project ID from a directory path.
@@ -158,12 +158,7 @@ class SessionStoreImpl {
   /** Write temp file then rename — avoids torn reads on crash mid-write. */
   private async atomicWriteSession(session: Session): Promise<void> {
     const target = this.sessionFilePath(session.id, session.projectID);
-    const dir = path.dirname(target);
-    const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
-
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(tmp, JSON.stringify(session, null, 2), "utf-8");
-    await fs.rename(tmp, target);
+    await writeJsonAtomic(target, session);
   }
 
   async create(session: Omit<Session, "created_at" | "updated_at">): Promise<Session> {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,6 +1,7 @@
 import { Global } from "../global";
 import fs from "fs/promises";
 import path from "path";
+import { writeJsonAtomic } from "../util/atomic-write.js";
 
 class NotFoundErrorImpl extends Error {
   constructor(message: string) {
@@ -62,10 +63,7 @@ export namespace Storage {
 
   export async function write<T>(key: string[], content: T): Promise<void> {
     const target = keyToPath(key);
-    const dir = path.dirname(target);
-
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(target, JSON.stringify(content, null, 2), "utf-8");
+    await writeJsonAtomic(target, content);
   }
 
   export async function update<T>(

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -150,13 +150,16 @@ function updateSessionCwd(sessionName: string | null, cwd: string, command: stri
 }
 
 const WINDOWS_COMMAND_ENV_VAR = "IMPULSE_COMMAND";
-const WINDOWS_POWERSHELL_WRAPPER = `
+export const WINDOWS_POWERSHELL_WRAPPER = `
 $ErrorActionPreference = 'Continue'
+$ProgressPreference = 'SilentlyContinue'
 $impulseCommand = [Environment]::GetEnvironmentVariable('${WINDOWS_COMMAND_ENV_VAR}', 'Process')
 $impulseExitCode = 0
 
 try {
-  $global:LASTEXITCODE = 0
+  # Start with no native exit code so we can tell whether a native executable ran.
+  # A native process sets LASTEXITCODE to an int (even 0); pure PowerShell leaves it $null.
+  $global:LASTEXITCODE = $null
   $impulseErrorCount = $Error.Count
   $impulseOutput = & ([scriptblock]::Create($impulseCommand)) *>&1
   $impulseSuccess = $?
@@ -166,9 +169,12 @@ try {
     $impulseOutput | Out-String -Width 4096 | Write-Output
   }
 
-  if ($impulseNativeExit -is [int] -and $impulseNativeExit -ne 0) {
+  if ($impulseNativeExit -is [int]) {
+    # A native executable ran: trust its exit code exactly. Native stderr (e.g. tool
+    # banners on PowerShell 5.x) inflates \$Error but must not be treated as failure.
     $impulseExitCode = [int]$impulseNativeExit
   } elseif (-not $impulseSuccess -or $Error.Count -gt $impulseErrorCount) {
+    # Pure PowerShell command: fall back to success/error-record signals.
     $impulseExitCode = 1
   }
 } catch {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { resolve, relative, isAbsolute } from "path";
 import path from "path";
 import { statSync } from "fs";
 import { resolveToolPath } from "./resolve-tool-path.js";
@@ -14,18 +13,19 @@ import {
   type PtyHandle,
 } from "../pty";
 import { zCommandString, zFilePath } from "./schemas/branded";
-import { detectPowerShellVersion, translatePosixToPowerShell } from "./posix-translation";
-import { detectShellEnvironment } from "../util/shell-env";
+import { analyzePowerShellChaining, translatePosixToPowerShell } from "./posix-translation";
 import { detectAndPublishBranchChange } from "../git/branch-detect";
 import { SessionManager } from "../session/manager";
 import { capBashOutputLines } from "../util/tool-output-cap.js";
+import { isWithinBase } from "../util/path.js";
+import { detectWindowsCommandShell } from "../util/windows-shell.js";
 
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
-On Windows this uses PowerShell. On macOS/Linux this uses bash.
+On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
 Required: command, description. Optional: workdir, timeout, interactive, session.
 See docs/tools/bash.md for safety rules and usage details.`;
 
@@ -45,6 +45,7 @@ interface SpawnOptions {
   cmd: string[];
   cwd?: string;
   env?: Record<string, string | undefined>;
+  shellKind?: "powershell" | "cmd" | "bash";
 }
 
 interface ShellSessionState {
@@ -349,7 +350,61 @@ export function needsInteractiveMode(command: string): boolean {
 /**
  * Classify a command as safe, high-risk, or unknown.
  */
-export function classifyCommand(command: string): "safe" | "high_risk" | "unknown" {
+function splitCommandForPermission(command: string): {
+  segments: string[];
+  hasRedirect: boolean;
+} {
+  const segments: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let hasRedirect = false;
+
+  const pushSegment = () => {
+    const trimmed = current.trim();
+    if (trimmed) segments.push(trimmed);
+    current = "";
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]!;
+
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ">" || ch === "<") {
+      hasRedirect = true;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ";" || ch === "\n" || ch === "\r") {
+      pushSegment();
+      continue;
+    }
+
+    if (ch === "&" || ch === "|") {
+      pushSegment();
+      if (command[i + 1] === ch) i++;
+      continue;
+    }
+
+    current += ch;
+  }
+
+  pushSegment();
+  return { segments: segments.length > 0 ? segments : [command.trim()].filter(Boolean), hasRedirect };
+}
+
+function classifySingleCommand(command: string): "safe" | "high_risk" | "unknown" {
   const trimmed = command.trim();
 
   for (const pattern of HIGH_RISK_PATTERNS) {
@@ -367,17 +422,28 @@ export function classifyCommand(command: string): "safe" | "high_risk" | "unknow
   return "unknown";
 }
 
+export function classifyCommand(command: string): "safe" | "high_risk" | "unknown" {
+  const { segments, hasRedirect } = splitCommandForPermission(command);
+  if (hasRedirect) return "unknown";
+
+  let sawUnknown = false;
+  for (const segment of segments) {
+    const classification = classifySingleCommand(segment);
+    if (classification === "high_risk") return "high_risk";
+    if (classification === "unknown") sawUnknown = true;
+  }
+
+  return sawUnknown ? "unknown" : "safe";
+}
+
 /**
  * Check if a path is within the current working directory
  */
 function isWithinCwd(targetPath: string, cwd: string): boolean {
-  const absoluteTarget = isAbsolute(targetPath)
-    ? targetPath
-    : resolve(cwd, targetPath);
-  const relativePath = relative(cwd, absoluteTarget);
-
-  // If relative path starts with "..", it's outside cwd
-  return relativePath !== ".." && !relativePath.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`);
+  const absoluteTarget = path.isAbsolute(targetPath)
+    ? path.resolve(targetPath)
+    : path.resolve(cwd, targetPath);
+  return isWithinBase(cwd, absoluteTarget);
 }
 
 function tokenizeCommand(command: string): string[] {
@@ -446,9 +512,9 @@ function quotePowerShellString(value: string): string {
 
 function normalizeWindowsCommand(command: string, shellType: "powershell5" | "powershell7"): string {
   const trimmed = command.trim();
-  const chaining = detectPowerShellVersion(trimmed);
+  const chaining = analyzePowerShellChaining(trimmed, shellType);
 
-  if (shellType === "powershell5" && chaining.hasChainingOperator && chaining.recommendation) {
+  if (!chaining.isSupported && chaining.recommendation) {
     return `Write-Error ${quotePowerShellString(chaining.recommendation)}; exit 1`;
   }
 
@@ -474,19 +540,35 @@ async function getSpawnOptions(
   };
 
   if (process.platform === "win32") {
-    const shellEnv = await detectShellEnvironment();
-    const commandShellType = shellEnv.commandShellType === "powershell7" ? "powershell7" : "powershell5";
-    const executable = commandShellType === "powershell7" ? "pwsh" : "powershell.exe";
+    const shell = await detectWindowsCommandShell();
+
+    if (shell.type === "cmd") {
+      return {
+        ...common,
+        shellKind: "cmd",
+        cmd: [shell.executable, "/d", "/s", "/c", input.command],
+      };
+    }
+
+    if (shell.type === "git-bash") {
+      return {
+        ...common,
+        shellKind: "bash",
+        cmd: [shell.executable, "-lc", input.command],
+      };
+    }
+
     const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
 
     return {
       ...common,
+      shellKind: "powershell",
       env: {
         ...process.env,
-        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, commandShellType),
+        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, shell.type),
       },
       cmd: [
-        executable,
+        shell.executable,
         "-NoLogo",
         "-NoProfile",
         ...interactiveArgs,
@@ -500,6 +582,7 @@ async function getSpawnOptions(
 
   return {
     ...common,
+    shellKind: "bash",
     cmd: ["bash", "-lc", input.command],
   };
 }
@@ -728,9 +811,9 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
   
   // Cross-platform output handling
-  // - Windows: Merge captured stdout and stderr after PowerShell execution
-  // - macOS/Linux: Merge stdout and stderr, preserve both streams
-  const shell = process.platform === "win32" ? "powershell" : "bash";
+  // - Windows PowerShell wrapper merges streams before output
+  // - bash/cmd: Merge stdout and stderr, preserve both streams
+  const shell = spawnOptions.shellKind ?? (process.platform === "win32" ? "powershell" : "bash");
   let combinedOutput: string;
   
   if (shell === "powershell") {

--- a/src/tools/file-edit.ts
+++ b/src/tools/file-edit.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { readFile, writeFile } from "fs/promises";
-import { resolve, relative, isAbsolute } from "path";
+import { basename } from "path";
 import { createPatch } from "diff";
 import {
   capCompactDiffResult,
@@ -16,6 +16,7 @@ import { SessionManager } from "../session/manager";
 import { Bus } from "../bus";
 import { FileEvents } from "../format/events";
 import { zCodeEdit, zFilePath } from "./schemas/branded";
+import { isWithinBase } from "../util/path.js";
 import {
   applyReplacement,
   buildOldStringNotFoundError,
@@ -43,14 +44,7 @@ type EditInput = z.infer<typeof EditSchema>;
  * Check if a path is within the current working directory
  */
 function isWithinCwd(targetPath: string): boolean {
-  const cwd = process.cwd();
-  const absoluteTarget = isAbsolute(targetPath) 
-    ? targetPath 
-    : resolve(cwd, targetPath);
-  const relativePath = relative(cwd, absoluteTarget);
-  
-  // If relative path starts with "..", it's outside cwd
-  return !relativePath.startsWith("..");
+  return isWithinBase(process.cwd(), targetPath);
 }
 
 export const fileEdit: Tool<EditInput> = Tool.define(
@@ -71,7 +65,7 @@ export const fileEdit: Tool<EditInput> = Tool.define(
       }
       
       const outsideCwd = !isWithinCwd(safePath);
-      const fileName = safePath.split(/[/\\]/).pop() ?? safePath;
+      const fileName = basename(safePath);
       await askPermission({
         sessionID: SessionManager.getCurrentSessionID() ?? "unknown",
         permission: "edit",

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
 import { mkdir, stat, writeFile, readFile, chmod, access } from "fs/promises";
-import { resolve, relative, isAbsolute, basename, dirname } from "path";
+import { basename, dirname } from "path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
 import { resolveToolPath } from "./resolve-tool-path.js";
@@ -16,6 +16,8 @@ import {
 import { Bus } from "../bus";
 import { FileEvents } from "../format/events";
 import { zFilePath } from "./schemas/branded";
+import { isWithinBase } from "../util/path.js";
+import { SessionManager } from "../session/manager";
 
 const DESCRIPTION = `Write a file to disk (create or overwrite).
 
@@ -42,14 +44,7 @@ async function fileExists(filePath: string): Promise<boolean> {
  * Check if a path is within the current working directory
  */
 function isWithinCwd(targetPath: string): boolean {
-  const cwd = process.cwd();
-  const absoluteTarget = isAbsolute(targetPath) 
-    ? targetPath 
-    : resolve(cwd, targetPath);
-  const relativePath = relative(cwd, absoluteTarget);
-  
-  // If relative path starts with "..", it's outside cwd
-  return !relativePath.startsWith("..");
+  return isWithinBase(process.cwd(), targetPath);
 }
 
 export const fileWrite: Tool<WriteInput> = Tool.define(
@@ -86,9 +81,9 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
           : outsideCwd
             ? `Overwrite file outside cwd: ${safePath}`
             : `Overwrite file: ${safePath}`;
-        const fileName = safePath.split(/[/\\]/).pop() ?? safePath;
+        const fileName = basename(safePath);
         await askPermission({
-          sessionID: "current",
+          sessionID: SessionManager.getCurrentSessionID() ?? "unknown",
           permission: permissionType,
           patterns: [safePath],
           message,

--- a/src/tools/posix-translation.ts
+++ b/src/tools/posix-translation.ts
@@ -235,21 +235,44 @@ export function translatePosixToPowerShell(command: string): {
  * 
  * PowerShell 7+ supports these, but Windows PowerShell 5.x does not.
  */
-export function detectPowerShellVersion(command: string): {
+export function analyzePowerShellChaining(
+  command: string,
+  shellType: "powershell5" | "powershell7"
+): {
   hasChainingOperator: boolean;
+  isSupported: boolean;
   recommendation?: string;
 } {
   if (hasUnquotedChainingOperator(command)) {
+    const isSupported = shellType === "powershell7";
     return {
       hasChainingOperator: true,
-      recommendation:
-        "Command uses && or || operators which require PowerShell 7+. " +
-        "On Windows PowerShell 5.x, use ; to chain commands unconditionally.",
+      isSupported,
+      ...(isSupported
+        ? {}
+        : {
+            recommendation:
+              "Command uses && or || operators which require PowerShell 7+. " +
+              "On Windows PowerShell 5.x, use ; to chain commands unconditionally.",
+          }),
     };
   }
 
   return {
     hasChainingOperator: false,
+    isSupported: true,
+  };
+}
+
+/** @deprecated Use analyzePowerShellChaining(command, shellType). */
+export function detectPowerShellVersion(command: string): {
+  hasChainingOperator: boolean;
+  recommendation?: string;
+} {
+  const analysis = analyzePowerShellChaining(command, "powershell5");
+  return {
+    hasChainingOperator: analysis.hasChainingOperator,
+    ...(analysis.recommendation ? { recommendation: analysis.recommendation } : {}),
   };
 }
 

--- a/src/tools/resolve-tool-path.ts
+++ b/src/tools/resolve-tool-path.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { sanitizePath, SecurityError } from "../util/path.js";
+import { isWithinBase, sanitizePath, SecurityError } from "../util/path.js";
 import { isAllowAllBypass, ask as askPermission } from "../permission/index.js";
 import { SessionManager } from "../session/manager.js";
 
@@ -14,10 +14,7 @@ export class OutsideCwdError extends Error {
 }
 
 function isOutsideCwd(targetPath: string, cwd: string): boolean {
-  const absoluteTarget = path.resolve(targetPath);
-  const absoluteCwd = path.resolve(cwd);
-  const relativePath = path.relative(absoluteCwd, absoluteTarget);
-  return relativePath.startsWith("..") || path.isAbsolute(relativePath);
+  return !isWithinBase(cwd, targetPath);
 }
 
 /**

--- a/src/util/atomic-write.ts
+++ b/src/util/atomic-write.ts
@@ -1,0 +1,101 @@
+import { randomBytes } from "crypto";
+import fs from "fs/promises";
+import path from "path";
+
+const writeChains = new Map<string, Promise<void>>();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fsyncDirectory(dir: string): Promise<void> {
+  if (process.platform === "win32") return;
+
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(dir, "r");
+    await handle.sync();
+  } catch {
+    // Directory fsync is not available on every filesystem/platform.
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+async function renameWithRetry(tmp: string, target: string): Promise<void> {
+  const retryable = new Set(["EBUSY", "EACCES", "EPERM"]);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 6; attempt++) {
+    try {
+      await fs.rename(tmp, target);
+      return;
+    } catch (error) {
+      lastError = error;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (process.platform !== "win32" || !code || !retryable.has(code)) {
+        throw error;
+      }
+      await sleep(25 * (attempt + 1));
+    }
+  }
+
+  throw lastError;
+}
+
+async function writeFileAtomicUnchained(
+  targetPath: string,
+  content: string | Buffer,
+  options?: { mode?: number }
+): Promise<void> {
+  const target = path.resolve(targetPath);
+  const dir = path.dirname(target);
+  const base = path.basename(target);
+  const suffix = `${process.pid}.${Date.now()}.${randomBytes(6).toString("hex")}`;
+  const tmp = path.join(dir, `.${base}.${suffix}.tmp`);
+
+  await fs.mkdir(dir, { recursive: true });
+
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(tmp, "wx", options?.mode);
+    await handle.writeFile(content);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+
+    await renameWithRetry(tmp, target);
+    await fsyncDirectory(dir);
+  } catch (error) {
+    await handle?.close().catch(() => {});
+    await fs.unlink(tmp).catch(() => {});
+    throw error;
+  }
+}
+
+export async function writeFileAtomic(
+  targetPath: string,
+  content: string | Buffer,
+  options?: { mode?: number }
+): Promise<void> {
+  const target = path.resolve(targetPath);
+  const previous = writeChains.get(target) ?? Promise.resolve();
+  const next = previous
+    .catch(() => {
+      // Keep the chain alive after a previous failed write.
+    })
+    .then(() => writeFileAtomicUnchained(target, content, options));
+
+  writeChains.set(target, next);
+  try {
+    await next;
+  } finally {
+    if (writeChains.get(target) === next) {
+      writeChains.delete(target);
+    }
+  }
+}
+
+export async function writeJsonAtomic(targetPath: string, value: unknown): Promise<void> {
+  await writeFileAtomic(targetPath, JSON.stringify(value, null, 2), { mode: 0o600 });
+}

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -9,9 +9,20 @@ class SecurityError extends Error {
   }
 }
 
-function isWithinBase(baseDir: string, targetPath: string): boolean {
-  const relative = path.relative(baseDir, targetPath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+type PathModule = Pick<typeof path, "isAbsolute" | "relative" | "resolve" | "sep">;
+
+function isParentRelativePath(relativePath: string, pathModule: PathModule = path): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${pathModule.sep}`);
+}
+
+function isWithinBase(baseDir: string, targetPath: string, pathModule: PathModule = path): boolean {
+  const normalizedBase = pathModule.resolve(baseDir);
+  const normalizedTarget = pathModule.resolve(targetPath);
+  const relative = pathModule.relative(normalizedBase, normalizedTarget);
+  return (
+    relative === "" ||
+    (!isParentRelativePath(relative, pathModule) && !pathModule.isAbsolute(relative))
+  );
 }
 
 function realpathOrResolved(targetPath: string): string {

--- a/src/util/shell-env.ts
+++ b/src/util/shell-env.ts
@@ -15,10 +15,10 @@ export interface ShellEnvironment {
   /** User's configured login shell, detected from the host environment. */
   shell: string;
   shellVersion?: string;
-  shellType: "powershell5" | "powershell7" | "bash" | "zsh" | "fish" | "sh" | "unknown";
+  shellType: WindowsCommandShellType | "bash" | "zsh" | "fish" | "sh" | "unknown";
   /** Shell actually used by the bash tool for command execution. */
   commandShell: string;
-  commandShellType: "powershell5" | "powershell7" | "bash";
+  commandShellType: WindowsCommandShellType | "bash";
   supportsChainedCommands: boolean;
   commandSeparator: string; // ; or && depending on shell
   recommendations: string[];
@@ -66,62 +66,6 @@ async function readStdoutAndDrainStderr(
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
   }
-}
-
-/**
- * Detect PowerShell version on Windows
- */
-async function detectPowerShellVersion(): Promise<{ version: string; isPwsh7: boolean }> {
-  if (process.platform !== "win32") {
-    return { version: "N/A", isPwsh7: false };
-  }
-
-  try {
-    // Try to detect PowerShell 7 (pwsh)
-    const pwsh7Check = Bun.spawn({
-      cmd: ["pwsh", "-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"],
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const pwsh7Result = await readStdoutAndDrainStderr(pwsh7Check);
-    const pwsh7Output = pwsh7Result.stdout;
-
-    if (pwsh7Check.exitCode === 0 && pwsh7Output.trim()) {
-      return { version: pwsh7Output.trim(), isPwsh7: true };
-    }
-  } catch {
-    // pwsh not available, fall back to Windows PowerShell
-  }
-
-  try {
-    // Fall back to Windows PowerShell 5.x
-    const ps5Check = Bun.spawn({
-      cmd: [
-        "powershell.exe",
-        "-NoProfile",
-        "-Command",
-        "$PSVersionTable.PSVersion.ToString()",
-      ],
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const ps5Result = await readStdoutAndDrainStderr(ps5Check);
-    const ps5Output = ps5Result.stdout;
-
-    if (ps5Result.timedOut) {
-      return { version: "Unknown", isPwsh7: false };
-    }
-
-    if (ps5Check.exitCode === 0 && ps5Output.trim()) {
-      return { version: ps5Output.trim(), isPwsh7: false };
-    }
-  } catch {
-    // Could not detect
-  }
-
-  return { version: "Unknown", isPwsh7: false };
 }
 
 /**
@@ -242,11 +186,11 @@ async function detectShellEnvironmentUncached(): Promise<ShellEnvironment> {
 
   // ===== Windows Platform =====
   if (process.platform === "win32") {
-    const { version, isPwsh7 } = await detectPowerShellVersion();
-    const shellType = isPwsh7 ? "powershell7" : "powershell5";
-    const shell = isPwsh7 ? "PowerShell 7.x (pwsh)" : "Windows PowerShell 5.x";
+    const detected = await detectWindowsCommandShell();
+    const shellType = detected.type;
+    const shell = detected.displayName;
 
-    if (!isPwsh7) {
+    if (shellType === "powershell5") {
       recommendations.push(
         "PowerShell 5.x detected: Use ; instead of && to chain commands"
       );
@@ -255,20 +199,26 @@ async function detectShellEnvironmentUncached(): Promise<ShellEnvironment> {
       );
       tips.push("Commands return objects by default - pipe through | Out-String for text");
       tips.push("Use *>&1 to merge all output streams");
-    } else {
+    } else if (shellType === "powershell7") {
       tips.push("PowerShell 7+ supports && and || operators");
       tips.push("Commands still return objects - use | Out-String when needed");
+    } else if (shellType === "cmd") {
+      tips.push("cmd.exe supports && and || operators");
+      tips.push("Use Windows command syntax for shell commands");
+    } else {
+      tips.push("Git Bash supports POSIX shell syntax with && and || operators");
+      tips.push("Use bash/POSIX syntax for shell commands");
     }
 
     return {
       platform,
       shell,
-      shellVersion: version,
+      ...(detected.version ? { shellVersion: detected.version } : {}),
       shellType,
       commandShell: shell,
       commandShellType: shellType,
-      supportsChainedCommands: isPwsh7,
-      commandSeparator: isPwsh7 ? "&&" : ";",
+      supportsChainedCommands: detected.supportsChainedCommands,
+      commandSeparator: detected.commandSeparator,
       recommendations,
       tips,
     };
@@ -426,6 +376,18 @@ export function generateShellContext(env: ShellEnvironment): string {
       parts.push("- POSIX commands are auto-translated to PowerShell equivalents");
       break;
 
+    case "cmd":
+      parts.push("- Use Windows cmd.exe syntax");
+      parts.push("- Supports && (and), || (or), and & (unconditional) operators");
+      parts.push("- POSIX-to-PowerShell translation is not applied in cmd.exe");
+      break;
+
+    case "git-bash":
+      parts.push("- Use bash/POSIX syntax");
+      parts.push("- Supports && (and), || (or), and ; (unconditional) operators");
+      parts.push("- POSIX-to-PowerShell translation is not applied in Git Bash");
+      break;
+
     case "bash":
       parts.push("- Use && to chain commands (runs next only if previous succeeds)");
       parts.push("- Use || for OR logic (runs next only if previous fails)");
@@ -442,3 +404,4 @@ export function generateShellContext(env: ShellEnvironment): string {
 
   return parts.join("\n");
 }
+import { detectWindowsCommandShell, type WindowsCommandShellType } from "./windows-shell.js";

--- a/src/util/windows-shell.ts
+++ b/src/util/windows-shell.ts
@@ -1,0 +1,292 @@
+import fs from "fs";
+import path from "path";
+
+export type WindowsCommandShellType = "powershell5" | "powershell7" | "cmd" | "git-bash";
+
+export interface WindowsCommandShell {
+  type: WindowsCommandShellType;
+  executable: string;
+  displayName: string;
+  version?: string;
+  supportsChainedCommands: boolean;
+  commandSeparator: "&&" | ";";
+}
+
+export interface WindowsProcessInfo {
+  name?: string;
+  executablePath?: string;
+}
+
+const DETECTION_TIMEOUT_MS = 1500;
+
+function streamToText(
+  stream: ReadableStream<Uint8Array> | number | null | undefined
+): Promise<string> {
+  return stream instanceof ReadableStream
+    ? new Response(stream).text().catch(() => "")
+    : Promise.resolve("");
+}
+
+async function readStdoutAndDrainStderr(
+  proc: ReturnType<typeof Bun.spawn>,
+  timeoutMs = DETECTION_TIMEOUT_MS
+): Promise<{ stdout: string; timedOut: boolean }> {
+  const stdoutPromise = streamToText(proc.stdout);
+  const stderrPromise = streamToText(proc.stderr);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => {
+      try {
+        proc.kill();
+      } catch {
+        // Process may have already exited.
+      }
+      resolve("timeout");
+    }, timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([
+      Promise.all([stdoutPromise, stderrPromise, proc.exited]).then(([stdout]) => stdout),
+      timeoutPromise,
+    ]);
+
+    return result === "timeout"
+      ? { stdout: "", timedOut: true }
+      : { stdout: result, timedOut: false };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+function isFile(candidate: string | undefined): candidate is string {
+  if (!candidate) return false;
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathCandidates(name: string, env: NodeJS.ProcessEnv = process.env): string[] {
+  const pathValue = env["PATH"] ?? "";
+  return pathValue
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((dir) => path.join(dir, name));
+}
+
+function firstExistingFile(candidates: string[]): string | null {
+  return candidates.find((candidate) => isFile(candidate)) ?? null;
+}
+
+function findOnPath(name: string, env: NodeJS.ProcessEnv = process.env): string | null {
+  return firstExistingFile(pathCandidates(name, env));
+}
+
+function shellDisplayName(type: WindowsCommandShellType, version?: string): string {
+  switch (type) {
+    case "powershell7":
+      return version ? `PowerShell ${version} (pwsh)` : "PowerShell 7.x (pwsh)";
+    case "powershell5":
+      return version ? `Windows PowerShell ${version}` : "Windows PowerShell 5.x";
+    case "cmd":
+      return "Windows Command Prompt (cmd.exe)";
+    case "git-bash":
+      return "Git Bash";
+  }
+}
+
+function makeShell(
+  type: WindowsCommandShellType,
+  executable: string,
+  version?: string
+): WindowsCommandShell {
+  const supportsChainedCommands = type !== "powershell5";
+  return {
+    type,
+    executable,
+    displayName: shellDisplayName(type, version),
+    ...(version ? { version } : {}),
+    supportsChainedCommands,
+    commandSeparator: supportsChainedCommands ? "&&" : ";",
+  };
+}
+
+export function classifyWindowsShellExecutable(
+  executablePathOrName: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): WindowsCommandShellType | null {
+  const raw = executablePathOrName?.trim();
+  if (!raw) return null;
+
+  const normalized = raw.replaceAll("\\", "/").toLowerCase();
+  const base = path.basename(normalized);
+
+  if (base === "pwsh.exe" || base === "pwsh") return "powershell7";
+  if (base === "powershell.exe" || base === "powershell") return "powershell5";
+  if (base === "cmd.exe" || base === "cmd") return "cmd";
+  if (base === "bash.exe" || base === "bash") {
+    if (env["MSYSTEM"] || env["MINGW_PREFIX"] || normalized.includes("/git/")) {
+      return "git-bash";
+    }
+  }
+
+  return null;
+}
+
+export function resolveWindowsShellFromSignals(input: {
+  env?: NodeJS.ProcessEnv;
+  processTree?: WindowsProcessInfo[];
+  pwshPath?: string | null;
+  powershellPath?: string | null;
+}): WindowsCommandShell | null {
+  const env = input.env ?? process.env;
+
+  const shellEnv = env["SHELL"];
+  const shellEnvType = classifyWindowsShellExecutable(shellEnv, env);
+  if (shellEnvType === "git-bash" && shellEnv) {
+    return makeShell("git-bash", shellEnv);
+  }
+
+  if (env["MSYSTEM"] || env["MINGW_PREFIX"]) {
+    const bashPath = firstExistingFile([
+      shellEnv ?? "",
+      findOnPath("bash.exe", env) ?? "",
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    ]);
+    if (bashPath) return makeShell("git-bash", bashPath);
+  }
+
+  for (const proc of input.processTree ?? []) {
+    const type =
+      classifyWindowsShellExecutable(proc.executablePath, env) ??
+      classifyWindowsShellExecutable(proc.name, env);
+    if (!type) continue;
+    const executable = proc.executablePath && isFile(proc.executablePath)
+      ? proc.executablePath
+      : type === "powershell7"
+        ? input.pwshPath ?? "pwsh"
+        : type === "powershell5"
+          ? input.powershellPath ?? "powershell.exe"
+          : type === "cmd"
+            ? env["COMSPEC"] ?? "cmd.exe"
+            : shellEnv ?? findOnPath("bash.exe", env) ?? "bash.exe";
+    return makeShell(type, executable);
+  }
+
+  if (input.pwshPath) return makeShell("powershell7", input.pwshPath);
+  return makeShell("powershell5", input.powershellPath ?? "powershell.exe");
+}
+
+async function detectPowerShellExecutable(
+  executable: string,
+  type: "powershell5" | "powershell7"
+): Promise<WindowsCommandShell | null> {
+  try {
+    const proc = Bun.spawn({
+      cmd: [executable, "-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const result = await readStdoutAndDrainStderr(proc);
+    const version = result.stdout.trim();
+    if (!result.timedOut && proc.exitCode === 0 && version) {
+      return makeShell(type, executable, version);
+    }
+  } catch {
+    // Shell not available.
+  }
+
+  return null;
+}
+
+async function detectPowerShellFallback(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{
+  pwsh: WindowsCommandShell | null;
+  powershell: WindowsCommandShell;
+}> {
+  const pwshPath = findOnPath("pwsh.exe", env) ?? findOnPath("pwsh", env) ?? "pwsh";
+  const pwsh = await detectPowerShellExecutable(pwshPath, "powershell7");
+  const psPath = env["SystemRoot"]
+    ? path.join(env["SystemRoot"], "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    : "powershell.exe";
+  const powershell =
+    (await detectPowerShellExecutable(psPath, "powershell5")) ??
+    makeShell("powershell5", psPath);
+
+  return { pwsh, powershell };
+}
+
+async function detectWindowsProcessTree(): Promise<WindowsProcessInfo[]> {
+  const script = `
+$pidToCheck = ${process.ppid}
+for ($i = 0; $i -lt 8 -and $pidToCheck -gt 0; $i++) {
+  $p = Get-CimInstance Win32_Process -Filter "ProcessId = $pidToCheck" -ErrorAction SilentlyContinue
+  if ($null -eq $p) { break }
+  "$($p.Name)|$($p.ExecutablePath)"
+  $pidToCheck = [int]$p.ParentProcessId
+}
+`.trim();
+
+  try {
+    const proc = Bun.spawn({
+      cmd: ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const result = await readStdoutAndDrainStderr(proc);
+    if (result.timedOut || proc.exitCode !== 0) return [];
+
+    return result.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [name, executablePath] = line.split("|", 2);
+        return {
+          ...(name ? { name } : {}),
+          ...(executablePath ? { executablePath } : {}),
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+let cachedWindowsShell: Promise<WindowsCommandShell> | undefined;
+
+export async function detectWindowsCommandShell(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<WindowsCommandShell> {
+  if (process.platform !== "win32") {
+    return makeShell("powershell5", "powershell.exe");
+  }
+
+  cachedWindowsShell ??= (async () => {
+    const [fallback, processTree] = await Promise.all([
+      detectPowerShellFallback(env),
+      detectWindowsProcessTree(),
+    ]);
+    const resolved = resolveWindowsShellFromSignals({
+      env,
+      processTree,
+      pwshPath: fallback.pwsh?.executable ?? null,
+      powershellPath: fallback.powershell.executable,
+    });
+
+    if (!resolved) return fallback.pwsh ?? fallback.powershell;
+    if (resolved.type === "powershell7") return fallback.pwsh ?? resolved;
+    if (resolved.type === "powershell5") return fallback.powershell;
+    return resolved;
+  })();
+
+  return cachedWindowsShell;
+}
+
+export function clearWindowsShellCache(): void {
+  cachedWindowsShell = undefined;
+}

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { writeFileAtomic, writeJsonAtomic } from "../src/util/atomic-write.js";
+
+describe("atomic writes", () => {
+  test("writes valid JSON", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-atomic-"));
+    try {
+      const file = path.join(dir, "state.json");
+      await writeJsonAtomic(file, { ok: true });
+      await expect(fs.readFile(file, "utf-8").then(JSON.parse)).resolves.toEqual({ ok: true });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes concurrent writes to the same target", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-atomic-concurrent-"));
+    try {
+      const file = path.join(dir, "state.json");
+      await Promise.all([
+        writeJsonAtomic(file, { value: 1 }),
+        writeJsonAtomic(file, { value: 2 }),
+        writeJsonAtomic(file, { value: 3 }),
+      ]);
+      const parsed = JSON.parse(await fs.readFile(file, "utf-8")) as { value: number };
+      expect([1, 2, 3]).toContain(parsed.value);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans up temp files after failure", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-atomic-fail-"));
+    try {
+      const targetDir = path.join(dir, "state.json");
+      await fs.mkdir(targetDir);
+      await expect(writeFileAtomic(targetDir, "content")).rejects.toThrow();
+      const entries = await fs.readdir(dir);
+      expect(entries.filter((entry) => entry.includes(".tmp"))).toEqual([]);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/bash-permission.test.ts
+++ b/test/bash-permission.test.ts
@@ -10,4 +10,19 @@ describe("bash permission policy", () => {
   test("safe read-only commands within cwd do not require approval", () => {
     expect(needsPermission("ls -la").needed).toBe(false);
   });
+
+  test("compound commands classify each segment", () => {
+    expect(needsPermission("git status && git diff -- src").needed).toBe(false);
+    expect(needsPermission("echo ok; rm -rf build").needed).toBe(true);
+    expect(needsPermission("echo ok && mystery-cli --foo").needed).toBe(true);
+  });
+
+  test("quoted operators do not make a command compound", () => {
+    expect(needsPermission('echo "a && b"').needed).toBe(false);
+    expect(needsPermission("Select-String 'a || b' file.txt").needed).toBe(false);
+  });
+
+  test("redirection requires approval", () => {
+    expect(needsPermission("echo data > file.txt").needed).toBe(true);
+  });
 });

--- a/test/gh-cli.test.ts
+++ b/test/gh-cli.test.ts
@@ -10,6 +10,7 @@ describe("resolveGhCliPath", () => {
     try {
       const fakeGh = path.join(dir, process.platform === "win32" ? "gh.exe" : "gh");
       fs.writeFileSync(fakeGh, "");
+      if (process.platform !== "win32") fs.chmodSync(fakeGh, 0o755);
       expect(resolveGhCliPath({ GH_CLI_PATH: fakeGh, PATH: "" })).toBe(fakeGh);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -20,13 +21,34 @@ describe("resolveGhCliPath", () => {
     expect(resolveGhCliPath({ GH_CLI_PATH: path.join(os.tmpdir(), "missing-gh"), PATH: "" })).toBeNull();
   });
 
+  test("returns null when GH_CLI_PATH points to a directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-gh-dir-"));
+    try {
+      expect(resolveGhCliPath({ GH_CLI_PATH: dir, PATH: "" })).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("finds gh on PATH without invoking the shell", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-gh-path-"));
     try {
       const name = process.platform === "win32" ? "gh.exe" : "gh";
       const fakeGh = path.join(dir, name);
       fs.writeFileSync(fakeGh, "");
+      if (process.platform !== "win32") fs.chmodSync(fakeGh, 0o755);
       expect(resolveGhCliPath({ PATH: dir, PATHEXT: ".EXE;.CMD" })).toBe(fakeGh);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores gh candidates that are directories", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-gh-path-dir-"));
+    try {
+      const name = process.platform === "win32" ? "gh.exe" : "gh";
+      fs.mkdirSync(path.join(dir, name));
+      expect(resolveGhCliPath({ PATH: dir, PATHEXT: ".EXE;.CMD" })).toBeNull();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/path-containment.test.ts
+++ b/test/path-containment.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import path from "path";
+import { isWithinBase } from "../src/util/path.js";
+
+describe("isWithinBase", () => {
+  test("handles POSIX containment", () => {
+    const p = path.posix;
+    expect(isWithinBase("/repo", "/repo/src/index.ts", p)).toBe(true);
+    expect(isWithinBase("/repo", "/repo", p)).toBe(true);
+    expect(isWithinBase("/repo", "/outside", p)).toBe(false);
+    expect(isWithinBase("/repo", "/repo/../../outside", p)).toBe(false);
+    expect(isWithinBase("/repo", "/repo2", p)).toBe(false);
+    expect(isWithinBase("/repo", "/repo/..foo", p)).toBe(true);
+  });
+
+  test("handles Windows containment", () => {
+    const p = path.win32;
+    expect(isWithinBase("C:\\repo", "C:\\repo\\src\\index.ts", p)).toBe(true);
+    expect(isWithinBase("C:\\repo", "C:\\outside", p)).toBe(false);
+    expect(isWithinBase("C:\\repo", "C:\\repo\\..\\..\\outside", p)).toBe(false);
+    expect(isWithinBase("C:\\repo", "C:\\repo2", p)).toBe(false);
+    expect(isWithinBase("C:\\repo", "D:\\outside", p)).toBe(false);
+    expect(isWithinBase("C:\\repo", "C:\\repo\\..foo", p)).toBe(true);
+  });
+});

--- a/test/posix-translation.test.ts
+++ b/test/posix-translation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { detectPowerShellVersion, translatePosixToPowerShell } from "../src/tools/posix-translation.js";
+import { analyzePowerShellChaining, translatePosixToPowerShell } from "../src/tools/posix-translation.js";
 
 describe("translatePosixToPowerShell", () => {
   test("leaves ls unchanged because PowerShell already has an ls alias", () => {
@@ -94,8 +94,15 @@ describe("translatePosixToPowerShell", () => {
   });
 
   test("detects only unquoted PowerShell chaining operators", () => {
-    expect(detectPowerShellVersion("echo a && echo b").hasChainingOperator).toBe(true);
-    expect(detectPowerShellVersion('git commit -m "fix: a && b"').hasChainingOperator).toBe(false);
-    expect(detectPowerShellVersion("Select-String 'a || b' file.txt").hasChainingOperator).toBe(false);
+    expect(analyzePowerShellChaining("echo a && echo b", "powershell5")).toMatchObject({
+      hasChainingOperator: true,
+      isSupported: false,
+    });
+    expect(analyzePowerShellChaining("echo a && echo b", "powershell7")).toMatchObject({
+      hasChainingOperator: true,
+      isSupported: true,
+    });
+    expect(analyzePowerShellChaining('git commit -m "fix: a && b"', "powershell5").hasChainingOperator).toBe(false);
+    expect(analyzePowerShellChaining("Select-String 'a || b' file.txt", "powershell5").hasChainingOperator).toBe(false);
   });
 });

--- a/test/storage-atomic.test.ts
+++ b/test/storage-atomic.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { Storage } from "../src/storage/index.js";
+
+describe("Storage.write", () => {
+  test("persists JSON through generic storage", async () => {
+    const key = ["test-storage-atomic", `${process.pid}-${Date.now()}`];
+    try {
+      await Storage.write(key, { ok: true });
+      await expect(Storage.read(key)).resolves.toEqual({ ok: true });
+    } finally {
+      await Storage.remove(key);
+    }
+  });
+});

--- a/test/windows-powershell-wrapper.test.ts
+++ b/test/windows-powershell-wrapper.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { WINDOWS_POWERSHELL_WRAPPER } from "../src/tools/bash.js";
+
+const isWindows = process.platform === "win32";
+const describeWindows = isWindows ? describe : describe.skip;
+
+function runWrapper(command: string): number {
+  const encoded = Buffer.from(WINDOWS_POWERSHELL_WRAPPER, "utf16le").toString("base64");
+  const result = spawnSync(
+    "powershell.exe",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+      encoded,
+    ],
+    {
+      env: { ...process.env, IMPULSE_COMMAND: command },
+      encoding: "utf-8",
+      windowsHide: true,
+    }
+  );
+  return result.status ?? -1;
+}
+
+describeWindows("Windows PowerShell wrapper exit-code fidelity", () => {
+  test("native command exiting 0 with stderr output reports success", () => {
+    expect(runWrapper('cmd /c "echo banner 1>&2 & exit 0"')).toBe(0);
+  });
+
+  test("native command propagates a non-zero exit code", () => {
+    expect(runWrapper('cmd /c "exit 3"')).toBe(3);
+  });
+
+  test("successful pure PowerShell command reports success", () => {
+    expect(runWrapper("Get-Date | Out-Null")).toBe(0);
+  });
+
+  test("pure PowerShell Write-Error reports failure", () => {
+    expect(runWrapper("Write-Error 'boom'")).toBe(1);
+  });
+
+  test("pure PowerShell cmdlet failure reports failure", () => {
+    expect(runWrapper("Get-Item 'C:\\does-not-exist-xyz-impulse'")).toBe(1);
+  });
+});

--- a/test/windows-shell.test.ts
+++ b/test/windows-shell.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWindowsShellFromSignals } from "../src/util/windows-shell.js";
+
+describe("resolveWindowsShellFromSignals", () => {
+  test("detects PowerShell 7 from process tree", () => {
+    const shell = resolveWindowsShellFromSignals({
+      processTree: [{ name: "pwsh.exe", executablePath: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" }],
+      pwshPath: "pwsh",
+      powershellPath: "powershell.exe",
+    });
+
+    expect(shell?.type).toBe("powershell7");
+    expect(shell?.supportsChainedCommands).toBe(true);
+  });
+
+  test("detects Windows PowerShell from process tree", () => {
+    const shell = resolveWindowsShellFromSignals({
+      processTree: [{ name: "powershell.exe" }],
+      pwshPath: "pwsh",
+      powershellPath: "powershell.exe",
+    });
+
+    expect(shell?.type).toBe("powershell5");
+    expect(shell?.supportsChainedCommands).toBe(false);
+  });
+
+  test("detects cmd from process tree", () => {
+    const shell = resolveWindowsShellFromSignals({
+      env: { COMSPEC: "C:\\Windows\\System32\\cmd.exe" },
+      processTree: [{ name: "cmd.exe" }],
+      pwshPath: "pwsh",
+      powershellPath: "powershell.exe",
+    });
+
+    expect(shell?.type).toBe("cmd");
+    expect(shell?.executable).toBe("C:\\Windows\\System32\\cmd.exe");
+  });
+
+  test("detects Git Bash from environment", () => {
+    const shell = resolveWindowsShellFromSignals({
+      env: {
+        SHELL: "C:\\Program Files\\Git\\bin\\bash.exe",
+        MSYSTEM: "MINGW64",
+      },
+      pwshPath: "pwsh",
+      powershellPath: "powershell.exe",
+    });
+
+    expect(shell?.type).toBe("git-bash");
+  });
+
+  test("falls back to PowerShell 7 then Windows PowerShell", () => {
+    expect(
+      resolveWindowsShellFromSignals({
+        pwshPath: "pwsh",
+        powershellPath: "powershell.exe",
+      })?.type
+    ).toBe("powershell7");
+
+    expect(
+      resolveWindowsShellFromSignals({
+        pwshPath: null,
+        powershellPath: "powershell.exe",
+      })?.type
+    ).toBe("powershell5");
+  });
+});


### PR DESCRIPTION
﻿## Problems

- Windows command execution was PowerShell-only, which hamstrung users running Impulse from cmd.exe or Git Bash.
- PowerShell chaining analysis was named like version detection and was not explicit about shell capabilities.
- Compound shell permission checks could allow risky segments through safe-looking command prefixes.
- Path containment, GitHub CLI lookup, file permission metadata, and state writes had cross-platform correctness gaps.

## Changed

- Added Windows shell auto-detection for PowerShell 7, Windows PowerShell 5, cmd.exe, and Git Bash, and reused it for both agent `bash` tool calls and user `!` shell commands.
- Hardened shell permission classification by checking each unquoted command segment and making PowerShell chaining capability-aware.
- Centralized cwd containment checks, hardened `gh` executable lookup, and fixed `file_write` permission session metadata and basename handling.
- Added crash-safe atomic JSON writes for session and generic storage state with Windows rename retries.
- Updated cross-platform shell docs, regression coverage, and bumped minor version to 1.8.0.

Fixes #104
Fixes #105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch shell execution, permission gating, and path containment on Windows—security-sensitive behavior—with broad test coverage but real platform variance risk.
> 
> **Overview**
> **Windows command execution** now picks the active shell (PowerShell 7/5, **cmd.exe**, **Git Bash**) via a new `windows-shell` detector (env, parent process tree, PATH fallbacks) and uses it for both the agent **`bash`** tool and user **`!`** shell, including PTY spawn options. POSIX→PowerShell translation and chaining rules apply only when PowerShell is the execution shell; **PowerShell 5** still blocks `&&`/`||` while **7+** allows them. The PowerShell wrapper exit-code logic is tightened so native stderr does not falsely fail runs.
> 
> **Permission and path safety** improve compound commands by classifying each unquoted segment (quoted `&&`/`||` ignored; redirects force approval) and centralizing cwd checks on **`isWithinBase`** (Windows cross-drive and `..foo`-style names). **`gh`** resolution requires real executables, not directories; **`file_write`** permissions use the real session ID and **`basename`**.
> 
> **Persistence** routes session and generic storage JSON through **`writeJsonAtomic`** (temp file, fsync, rename with Windows retries, per-target write chaining). Version bumps to **1.8.0** with docs/changelog and expanded tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084dc265273833810614d1079bcf0b7f51b8ee49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->