### PR TITLE
fix(update): do not relaunch standalone update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-06-22
+
+  **Type:** patch
+  **Title:** Standalone update exits after install
+
+  ### Fixed
+  - **#106** -- `impulse --update` now installs the latest version and exits instead of relaunching Impulse
+  - **#106** -- in-app `/update` keeps the relaunch-and-resume flow through hidden internal auto-update handling
+
 ## [1.8.0] - 2026-06-22
 
   **Type:** minor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -142,7 +142,7 @@ function relaunchImpulse() {
 function runUpdate({ relaunch }) {
   const current = currentInstalledVersion();
   const latest = latestNpmVersion();
-  if (!relaunch && compareSemver(latest, current) <= 0) {
+  if (compareSemver(latest, current) <= 0) {
     console.log(`Already on latest (v${current}).`);
     if (relaunch) {
       console.log("  Relaunching impulse...");

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -12,6 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const PACKAGE_NAME = "@spenceriam/impulse";
 const INTERNAL_AUTO_UPDATE_ENV = "IMPULSE_INTERNAL_AUTO_UPDATE";
+const UPDATE_PARENT_PID_ENV = "IMPULSE_UPDATE_PARENT_PID";
 
 function detectPlatformAndArch() {
   let platform;
@@ -127,6 +128,56 @@ function latestNpmVersion() {
   return result.stdout.trim();
 }
 
+function syncDelay(ms) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    // busy-wait for short parent-exit polling
+  }
+}
+
+function waitForParentExit() {
+  const raw = process.env[UPDATE_PARENT_PID_ENV];
+  if (!raw) return;
+  const parentPid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parentPid) || parentPid <= 1) return;
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(parentPid, 0);
+    } catch {
+      return;
+    }
+    syncDelay(100);
+  }
+}
+
+function installedVersionViaCommand() {
+  const result = spawnSync(process.platform === "win32" ? "impulse.cmd" : "impulse", ["--version"], {
+    encoding: "utf8",
+    shell: useShellForCommandShims(),
+  });
+  return result.stdout?.trim().match(/(\d+\.\d+\.\d+)/)?.[1];
+}
+
+function formatUpdateSuccessLines(latestVersion, installedVersion, relaunch) {
+  const lines = [];
+  if (installedVersion === latestVersion) {
+    lines.push(`  Update successful! impulse is now v${latestVersion}`);
+  } else if (installedVersion) {
+    lines.push(`  Update completed. Installed version: v${installedVersion}`);
+    lines.push(`  (Expected v${latestVersion} - you may need to restart your shell)`);
+  } else {
+    lines.push(`  Update completed! impulse should now be v${latestVersion}`);
+  }
+  if (relaunch) {
+    lines.push("  Relaunching impulse...");
+  } else {
+    lines.push("  Run `impulse` to start.");
+  }
+  return lines;
+}
+
 function relaunchImpulse() {
   const env = { ...process.env };
   delete env[INTERNAL_AUTO_UPDATE_ENV];
@@ -167,12 +218,10 @@ function runUpdate({ relaunch }) {
     return result.status ?? 1;
   }
 
+  const installedVersion = installedVersionViaCommand();
   console.log("\n--------------------------------------------------------");
-  console.log(`  Update successful! impulse is now v${latest}`);
-  if (relaunch) {
-    console.log("  Relaunching impulse...");
-  } else {
-    console.log("  Run `impulse` to start.");
+  for (const line of formatUpdateSuccessLines(latest, installedVersion, relaunch)) {
+    console.log(line);
   }
   console.log("--------------------------------------------------------\n");
 
@@ -195,6 +244,9 @@ if (hasStartupFlag("--update") || hasStartupFlag("--auto-update")) {
   try {
     const relaunch =
       hasStartupFlag("--auto-update") && process.env[INTERNAL_AUTO_UPDATE_ENV] === "1";
+    if (relaunch) {
+      waitForParentExit();
+    }
     process.exit(runUpdate({ relaunch }));
   } catch (error) {
     console.error(`Update failed: ${error.message}`);

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -128,6 +128,10 @@ function runUpdate({ relaunch }) {
   const latest = latestNpmVersion();
   if (compareSemver(latest, current) <= 0) {
     console.log(`Already on latest (v${current}).`);
+    if (relaunch) {
+      console.log("  Relaunching impulse...");
+      relaunchImpulse();
+    }
     return 0;
   }
 

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -89,6 +89,22 @@ function currentWrapperVersion() {
   return packageJson.version;
 }
 
+function currentInstalledVersion() {
+  try {
+    const binaryPath = findBinary();
+    const result = spawnSync(binaryPath, ["--version"], {
+      encoding: "utf8",
+    });
+    const version = result.stdout?.trim().match(/(\d+\.\d+\.\d+)/)?.[1];
+    if (version) {
+      return version;
+    }
+  } catch {
+    // fall back to wrapper package version
+  }
+  return currentWrapperVersion();
+}
+
 function compareSemver(a, b) {
   const left = String(a).split(".").map((part) => Number.parseInt(part, 10) || 0);
   const right = String(b).split(".").map((part) => Number.parseInt(part, 10) || 0);
@@ -124,9 +140,9 @@ function relaunchImpulse() {
 }
 
 function runUpdate({ relaunch }) {
-  const current = currentWrapperVersion();
+  const current = currentInstalledVersion();
   const latest = latestNpmVersion();
-  if (compareSemver(latest, current) <= 0) {
+  if (!relaunch && compareSemver(latest, current) <= 0) {
     console.log(`Already on latest (v${current}).`);
     if (relaunch) {
       console.log("  Relaunching impulse...");

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -185,7 +185,7 @@ function runUpdate({ relaunch }) {
 function hasStartupFlag(flag) {
   for (const arg of process.argv.slice(2)) {
     if (arg === "--") return false;
-    if (!arg.startsWith("-")) return false;
+    if (!arg.startsWith("-")) continue;
     if (arg === flag) return true;
   }
   return false;

--- a/packages/cli/bin/impulse
+++ b/packages/cli/bin/impulse
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { spawn } from "child_process";
-import { existsSync } from "fs";
+import { spawn, spawnSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
@@ -10,6 +10,8 @@ import os from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
+const PACKAGE_NAME = "@spenceriam/impulse";
+const INTERNAL_AUTO_UPDATE_ENV = "IMPULSE_INTERNAL_AUTO_UPDATE";
 
 function detectPlatformAndArch() {
   let platform;
@@ -71,6 +73,112 @@ function findBinary() {
       `Package ${packageName} may not be installed.\n` +
       `Try reinstalling: npm install -g @spenceriam/impulse`
     );
+  }
+}
+
+function npmCommand() {
+  return os.platform() === "win32" ? "npm.cmd" : "npm";
+}
+
+function useShellForCommandShims() {
+  return os.platform() === "win32";
+}
+
+function currentWrapperVersion() {
+  const packageJson = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
+  return packageJson.version;
+}
+
+function compareSemver(a, b) {
+  const left = String(a).split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const right = String(b).split(".").map((part) => Number.parseInt(part, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((left[i] ?? 0) > (right[i] ?? 0)) return 1;
+    if ((left[i] ?? 0) < (right[i] ?? 0)) return -1;
+  }
+  return 0;
+}
+
+function latestNpmVersion() {
+  const result = spawnSync(npmCommand(), ["view", PACKAGE_NAME, "version", "--silent"], {
+    encoding: "utf8",
+    shell: useShellForCommandShims(),
+  });
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || "").trim();
+    throw new Error(detail || `npm view failed with exit code ${result.status}`);
+  }
+  return result.stdout.trim();
+}
+
+function relaunchImpulse() {
+  const env = { ...process.env };
+  delete env[INTERNAL_AUTO_UPDATE_ENV];
+  const child = spawn(process.platform === "win32" ? "impulse.cmd" : "impulse", [], {
+    detached: true,
+    stdio: "ignore",
+    shell: useShellForCommandShims(),
+    env,
+  });
+  child.unref();
+}
+
+function runUpdate({ relaunch }) {
+  const current = currentWrapperVersion();
+  const latest = latestNpmVersion();
+  if (compareSemver(latest, current) <= 0) {
+    console.log(`Already on latest (v${current}).`);
+    return 0;
+  }
+
+  console.log(`Updating ${current} -> ${latest}...`);
+  console.log(`\nUpdating impulse to v${latest}...`);
+  console.log(`Running: npm install -g ${PACKAGE_NAME}\n`);
+
+  const result = spawnSync(npmCommand(), ["install", "-g", PACKAGE_NAME], {
+    stdio: "inherit",
+    shell: useShellForCommandShims(),
+  });
+  if (result.status !== 0) {
+    console.log("\n--------------------------------------------------------");
+    console.log(`  Update failed (exit code ${result.status ?? "unknown"})`);
+    console.log(`  Try running manually: npm install -g ${PACKAGE_NAME}`);
+    console.log("--------------------------------------------------------\n");
+    return result.status ?? 1;
+  }
+
+  console.log("\n--------------------------------------------------------");
+  console.log(`  Update successful! impulse is now v${latest}`);
+  if (relaunch) {
+    console.log("  Relaunching impulse...");
+  } else {
+    console.log("  Run `impulse` to start.");
+  }
+  console.log("--------------------------------------------------------\n");
+
+  if (relaunch) {
+    relaunchImpulse();
+  }
+  return 0;
+}
+
+function hasStartupFlag(flag) {
+  for (const arg of process.argv.slice(2)) {
+    if (arg === "--") return false;
+    if (!arg.startsWith("-")) return false;
+    if (arg === flag) return true;
+  }
+  return false;
+}
+
+if (hasStartupFlag("--update") || hasStartupFlag("--auto-update")) {
+  try {
+    const relaunch =
+      hasStartupFlag("--auto-update") && process.env[INTERNAL_AUTO_UPDATE_ENV] === "1";
+    process.exit(runUpdate({ relaunch }));
+  } catch (error) {
+    console.error(`Update failed: ${error.message}`);
+    process.exit(1);
   }
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "Provider-flexible terminal AI co-partner agent",
   "license": "MIT",
   "bin": {
@@ -37,11 +37,11 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@spenceriam/impulse-linux-x64": "1.7.0",
-    "@spenceriam/impulse-linux-arm64": "1.7.0",
-    "@spenceriam/impulse-darwin-x64": "1.7.0",
-    "@spenceriam/impulse-darwin-arm64": "1.7.0",
-    "@spenceriam/impulse-windows-x64": "1.7.0",
-    "@spenceriam/impulse-win32-arm64": "1.7.0"
+    "@spenceriam/impulse-linux-x64": "1.8.1",
+    "@spenceriam/impulse-linux-arm64": "1.8.1",
+    "@spenceriam/impulse-darwin-x64": "1.8.1",
+    "@spenceriam/impulse-darwin-arm64": "1.8.1",
+    "@spenceriam/impulse-windows-x64": "1.8.1",
+    "@spenceriam/impulse-win32-arm64": "1.8.1"
   }
 }

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -158,6 +158,7 @@ import {
   getCurrentVersion,
   impulseCommand,
   INTERNAL_AUTO_UPDATE_ENV,
+  UPDATE_PARENT_PID_ENV,
 } from "../util/update-check.js";
 import {
   PROVIDER_REASONING_STYLE,
@@ -3753,6 +3754,7 @@ export class ImpulseRenderer {
       env: {
         ...process.env,
         [INTERNAL_AUTO_UPDATE_ENV]: "1",
+        [UPDATE_PARENT_PID_ENV]: String(process.pid),
       },
     });
     try {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3746,9 +3746,6 @@ export class ImpulseRenderer {
     this.tui.requestRender();
     await SessionManager.flushCurrent();
     const session = SessionManager.getCurrentSession();
-    if (session?.id) {
-      writeUpdateResumeHint(session.id);
-    }
     const child = spawn(impulseCommand(), ["--auto-update"], {
       detached: true,
       stdio: "inherit",
@@ -3768,6 +3765,9 @@ export class ImpulseRenderer {
       this.addChatLine(clr.error(`Failed to start update: ${message}`));
       this.tui.requestRender();
       return;
+    }
+    if (session?.id) {
+      writeUpdateResumeHint(session.id);
     }
     clearActiveSessionMarker();
     this.tui.stop();

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3750,6 +3750,7 @@ export class ImpulseRenderer {
       writeUpdateResumeHint(session.id);
     }
     const child = spawn(impulseCommand(), ["--auto-update"], {
+      detached: true,
       stdio: "inherit",
       shell: process.platform === "win32",
       env: {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -23,6 +23,7 @@ import {
   type OverlayHandle,
 } from "@mariozechner/pi-tui";
 import type { EditorTheme } from "@mariozechner/pi-tui";
+import { spawn } from "child_process";
 import {
   PromptInput,
   resolveSubmitPayloadAfterPathAttach,
@@ -152,7 +153,12 @@ import {
   type ReasoningLevel,
   type ThinkingDisplay,
 } from "../util/config.js";
-import { checkForUpdate, performUpdate, getCurrentVersion } from "../util/update-check.js";
+import {
+  checkForUpdate,
+  getCurrentVersion,
+  impulseCommand,
+  INTERNAL_AUTO_UPDATE_ENV,
+} from "../util/update-check.js";
 import {
   PROVIDER_REASONING_STYLE,
   getLevelsForStyle,
@@ -3745,7 +3751,14 @@ export class ImpulseRenderer {
       writeUpdateResumeHint(session.id);
     }
     this.tui.stop();
-    performUpdate(update.latestVersion);
+    spawn(impulseCommand(), ["--auto-update"], {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+      env: {
+        ...process.env,
+        [INTERNAL_AUTO_UPDATE_ENV]: "1",
+      },
+    });
     process.exit(0);
   }
 

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3745,13 +3745,11 @@ export class ImpulseRenderer {
     this.addChatLine(clr.dim("Installing update and relaunching..."));
     this.tui.requestRender();
     await SessionManager.flushCurrent();
-    clearActiveSessionMarker();
     const session = SessionManager.getCurrentSession();
     if (session?.id) {
       writeUpdateResumeHint(session.id);
     }
-    this.tui.stop();
-    spawn(impulseCommand(), ["--auto-update"], {
+    const child = spawn(impulseCommand(), ["--auto-update"], {
       stdio: "inherit",
       shell: process.platform === "win32",
       env: {
@@ -3759,6 +3757,20 @@ export class ImpulseRenderer {
         [INTERNAL_AUTO_UPDATE_ENV]: "1",
       },
     });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("spawn", () => resolve());
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.addChatLine(clr.error(`Failed to start update: ${message}`));
+      this.tui.requestRender();
+      return;
+    }
+    clearActiveSessionMarker();
+    this.tui.stop();
+    child.unref();
     process.exit(0);
   }
 

--- a/src/cli/startup-flags.ts
+++ b/src/cli/startup-flags.ts
@@ -11,6 +11,7 @@ export const KNOWN_BOOLEAN_FLAGS = new Set([
   "--version",
   "-v",
   "--update",
+  "--auto-update",
   "--help",
   "-h",
   "--setup",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,19 @@ if (args.includes("--version") || args.includes("-v")) {
 
 // ─── --update ────────────────────────────────────────────────────────────────
 if (args.includes("--update") || args.includes("--auto-update")) {
-  const { checkForUpdate, performUpdate, getCurrentVersion, isInternalAutoUpdate } = await import(
-    "./util/update-check.js"
-  );
+  const {
+    checkForUpdate,
+    performUpdate,
+    getCurrentVersion,
+    isInternalAutoUpdate,
+    relaunchImpulse,
+  } = await import("./util/update-check.js");
   const update = await checkForUpdate();
   if (!update) {
     console.log(`Already on latest (v${getCurrentVersion()}).`);
+    if (isInternalAutoUpdate(args)) {
+      relaunchImpulse();
+    }
     process.exit(0);
   }
   console.log(`Updating ${update.currentVersion} -> ${update.latestVersion}...`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,8 @@ if (args.includes("--version") || args.includes("-v")) {
 }
 
 // ─── --update ────────────────────────────────────────────────────────────────
-if (args.includes("--update")) {
-  const { checkForUpdate, performUpdate, getCurrentVersion } = await import(
+if (args.includes("--update") || args.includes("--auto-update")) {
+  const { checkForUpdate, performUpdate, getCurrentVersion, isInternalAutoUpdate } = await import(
     "./util/update-check.js"
   );
   const update = await checkForUpdate();
@@ -59,8 +59,7 @@ if (args.includes("--update")) {
     process.exit(0);
   }
   console.log(`Updating ${update.currentVersion} -> ${update.latestVersion}...`);
-  performUpdate(update.latestVersion);
-  process.exit(0);
+  process.exit(performUpdate(update.latestVersion, { relaunch: isInternalAutoUpdate(args) }));
 }
 
 // ─── --help ──────────────────────────────────────────────────────────────────

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -154,6 +154,18 @@ export function isInternalAutoUpdate(argv: string[] = process.argv.slice(2), env
   return argv.includes("--auto-update") && env[INTERNAL_AUTO_UPDATE_ENV] === "1";
 }
 
+export function relaunchImpulse(): void {
+  const env = { ...process.env };
+  delete env[INTERNAL_AUTO_UPDATE_ENV];
+  const child = spawn(impulseCommand(), [], {
+    detached: true,
+    stdio: "ignore",
+    shell: useShellForCommandShims(),
+    env,
+  });
+  child.unref();
+}
+
 export function formatUpdateSuccessLines(latestVersion: string, installedVersion: string | undefined, relaunch: boolean): string[] {
   const lines: string[] = [];
   if (installedVersion === latestVersion) {
@@ -210,12 +222,7 @@ export function performUpdate(latestVersion: string, options: PerformUpdateOptio
     rawPrint("--------------------------------------------------------\n");
 
     if (relaunch) {
-      const child = spawn(impulseCommand(), [], {
-        detached: true,
-        stdio: "ignore",
-        shell: useShellForCommandShims(),
-      });
-      child.unref();
+      relaunchImpulse();
     }
     return 0;
   } else {

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -1,13 +1,6 @@
 /**
- * Update checker for impulse
- * Checks npm registry for newer versions and prompts user to update.
- * 
- * NEW APPROACH (v0.27.12):
- * - Check for updates on startup
- * - If update available, show notification with [Y] to update
- * - If user confirms, EXIT the app first (so binary can be replaced)
- * - Run npm install after exit
- * - Show result in terminal and prompt to restart
+ * Update checker for impulse.
+ * Checks npm registry for newer versions and supports explicit update modes.
  */
 
 import * as semver from "semver";
@@ -22,8 +15,15 @@ const PACKAGE_NAME = "@spenceriam/impulse";
 const CURRENT_VERSION = packageJson.version;
 const REGISTRY_URL = "https://registry.npmjs.org";
 
+export const INTERNAL_AUTO_UPDATE_ENV = "IMPULSE_INTERNAL_AUTO_UPDATE";
+
+export interface PerformUpdateOptions {
+  /** Relaunch impulse after a successful update. Defaults to false. */
+  relaunch?: boolean;
+}
+
 /**
- * Debug log helper - writes to stderr when --verbose is enabled
+ * Debug log helper - writes to stderr when --verbose is enabled.
  */
 function debugLog(message: string, data?: unknown): void {
   if (isDebugEnabled()) {
@@ -42,36 +42,33 @@ export interface UpdateInfo {
   updateCommand: string;
 }
 
-export type UpdateState = 
+export type UpdateState =
   | { status: "checking" }
   | { status: "available"; latestVersion: string; updateCommand: string }
   | { status: "none" };
 
 /**
- * Check npm registry for newer version
- * Non-blocking, fails silently on network errors
+ * Check npm registry for newer version.
+ * Non-blocking, fails silently on network errors.
  */
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
   debugLog("Starting update check", { currentVersion: CURRENT_VERSION, package: PACKAGE_NAME });
-  
+
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000); // 5s timeout
 
-    // URL-encode the scoped package name for npm registry
+    // URL-encode the scoped package name for npm registry.
     const encodedName = PACKAGE_NAME.replace("/", "%2F");
     const url = `${REGISTRY_URL}/${encodedName}/latest`;
     debugLog("Fetching from registry", { url });
-    
-    const response = await fetch(
-      url,
-      {
-        signal: controller.signal,
-        headers: {
-          Accept: "application/json",
-        },
-      }
-    );
+
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+      },
+    });
 
     clearTimeout(timeout);
 
@@ -89,14 +86,14 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
       return null;
     }
 
-    // Compare versions using semver
+    // Compare versions using semver.
     const isNewer = semver.gt(latestVersion, CURRENT_VERSION);
-    debugLog("Version comparison", { 
-      current: CURRENT_VERSION, 
-      latest: latestVersion, 
-      isNewer 
+    debugLog("Version comparison", {
+      current: CURRENT_VERSION,
+      latest: latestVersion,
+      isNewer,
     });
-    
+
     if (isNewer) {
       return {
         currentVersion: CURRENT_VERSION,
@@ -107,16 +104,16 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
 
     return null;
   } catch (error) {
-    // Silently fail on network errors - don't block the app
+    // Silently fail on network errors - don't block the app.
     debugLog("Update check failed", { error: error instanceof Error ? error.message : String(error) });
     return null;
   }
 }
 
 /**
- * Run update check and notify if update available
- * Called once on app startup
- * Does NOT auto-install - just notifies via Bus event
+ * Run update check and notify if update available.
+ * Called once on app startup.
+ * Does NOT auto-install - just notifies via Bus event.
  */
 export async function runUpdateCheck(): Promise<void> {
   debugLog("runUpdateCheck started");
@@ -127,82 +124,111 @@ export async function runUpdateCheck(): Promise<void> {
     return;
   }
 
-  debugLog("Update available", { 
-    from: update.currentVersion, 
+  debugLog("Update available", {
+    from: update.currentVersion,
     to: update.latestVersion,
-    command: update.updateCommand 
+    command: update.updateCommand,
   });
 
-  // Notify that update is available - UI will show prompt
-  Bus.publish(UpdateEvents.Available, { 
+  // Notify that update is available - UI will show prompt.
+  Bus.publish(UpdateEvents.Available, {
     currentVersion: update.currentVersion,
     latestVersion: update.latestVersion,
     updateCommand: update.updateCommand,
   });
 }
 
+export function npmCommand(): string {
+  return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+export function impulseCommand(): string {
+  return process.platform === "win32" ? "impulse.cmd" : "impulse";
+}
+
+function useShellForCommandShims(): boolean {
+  return process.platform === "win32";
+}
+
+export function isInternalAutoUpdate(argv: string[] = process.argv.slice(2), env = process.env): boolean {
+  return argv.includes("--auto-update") && env[INTERNAL_AUTO_UPDATE_ENV] === "1";
+}
+
+export function formatUpdateSuccessLines(latestVersion: string, installedVersion: string | undefined, relaunch: boolean): string[] {
+  const lines: string[] = [];
+  if (installedVersion === latestVersion) {
+    lines.push(`  Update successful! impulse is now v${latestVersion}`);
+  } else if (installedVersion) {
+    lines.push(`  Update completed. Installed version: v${installedVersion}`);
+    lines.push(`  (Expected v${latestVersion} - you may need to restart your shell)`);
+  } else {
+    lines.push(`  Update completed! impulse should now be v${latestVersion}`);
+  }
+  if (relaunch) {
+    lines.push("  Relaunching impulse...");
+  } else {
+    lines.push("  Run `impulse` to start.");
+  }
+  return lines;
+}
+
 /**
- * Perform the actual update after app has exited
- * This is called from index.tsx after renderer.destroy()
- * 
- * Runs npm install -g synchronously and prints result to terminal
+ * Perform the actual update after the app has exited.
+ * Runs npm install -g synchronously and prints result to terminal.
  */
-export function performUpdate(latestVersion: string): void {
-  // Helper function that writes directly to file descriptor 1 (stdout)
-  // This bypasses any Node.js/Bun buffering or stream interception
+export function performUpdate(latestVersion: string, options: PerformUpdateOptions = {}): number {
+  const relaunch = options.relaunch === true;
+
+  // Helper function that writes directly to file descriptor 1 (stdout).
+  // This bypasses any Node.js/Bun buffering or stream interception.
   const rawPrint = (msg: string) => {
     writeSync(1, msg + "\n");
   };
-  
+
   rawPrint(`\nUpdating impulse to v${latestVersion}...`);
   rawPrint(`Running: npm install -g ${PACKAGE_NAME}\n`);
 
-  const result = spawnSync("npm", ["install", "-g", PACKAGE_NAME], {
-    stdio: "inherit", // Show npm output directly
-    shell: true,
+  const result = spawnSync(npmCommand(), ["install", "-g", PACKAGE_NAME], {
+    stdio: "inherit", // Show npm output directly.
+    shell: useShellForCommandShims(),
   });
 
-  // After stdio: "inherit" returns, the terminal should be back to normal
-  // Use a no-op spawnSync to give the terminal time to settle
-  spawnSync("true", [], { shell: true });
-
   if (result.status === 0) {
-    // Verify the update worked
-    const versionCheck = spawnSync("impulse", ["--version"], {
+    // Verify the update worked.
+    const versionCheck = spawnSync(impulseCommand(), ["--version"], {
       encoding: "utf-8",
-      shell: true,
+      shell: useShellForCommandShims(),
     });
-    
+
     const installedVersion = versionCheck.stdout?.trim().match(/(\d+\.\d+\.\d+)/)?.[1];
-    
-    // Print success message using raw file descriptor write
-    rawPrint(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
-    if (installedVersion === latestVersion) {
-      rawPrint(`  Update successful! impulse is now v${latestVersion}`);
-    } else if (installedVersion) {
-      rawPrint(`  Update completed. Installed version: v${installedVersion}`);
-      rawPrint(`  (Expected v${latestVersion} - you may need to restart your shell)`);
-    } else {
-      rawPrint(`  Update completed! impulse should now be v${latestVersion}`);
+
+    // Print success message using raw file descriptor write.
+    rawPrint("\n--------------------------------------------------------");
+    for (const line of formatUpdateSuccessLines(latestVersion, installedVersion, relaunch)) {
+      rawPrint(line);
     }
-    rawPrint(`  Relaunching impulse...`);
-    rawPrint(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`);
-    const child = spawn("impulse", [], {
-      detached: true,
-      stdio: "ignore",
-      shell: true,
-    });
-    child.unref();
+    rawPrint("--------------------------------------------------------\n");
+
+    if (relaunch) {
+      const child = spawn(impulseCommand(), [], {
+        detached: true,
+        stdio: "ignore",
+        shell: useShellForCommandShims(),
+      });
+      child.unref();
+    }
+    return 0;
   } else {
-    rawPrint(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
-    rawPrint(`  Update failed (exit code ${result.status})`);
+    rawPrint("\n--------------------------------------------------------");
+    rawPrint(`  Update failed (exit code ${result.status ?? "unknown"})`);
     rawPrint(`  Try running manually: npm install -g ${PACKAGE_NAME}`);
-    rawPrint(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`);
+    rawPrint("--------------------------------------------------------\n");
+    return result.status ?? 1;
   }
 }
 
 /**
- * Get current version
+ * Get current version.
  */
 export function getCurrentVersion(): string {
   return CURRENT_VERSION;

--- a/src/util/update-check.ts
+++ b/src/util/update-check.ts
@@ -16,6 +16,7 @@ const CURRENT_VERSION = packageJson.version;
 const REGISTRY_URL = "https://registry.npmjs.org";
 
 export const INTERNAL_AUTO_UPDATE_ENV = "IMPULSE_INTERNAL_AUTO_UPDATE";
+export const UPDATE_PARENT_PID_ENV = "IMPULSE_UPDATE_PARENT_PID";
 
 export interface PerformUpdateOptions {
   /** Relaunch impulse after a successful update. Defaults to false. */

--- a/test/startup-flags.test.ts
+++ b/test/startup-flags.test.ts
@@ -13,6 +13,7 @@ describe("findUnknownFlag", () => {
   test("accepts known boolean flags", () => {
     expect(findUnknownFlag(["--version"])).toBeUndefined();
     expect(findUnknownFlag(["--update"])).toBeUndefined();
+    expect(findUnknownFlag(["--auto-update"])).toBeUndefined();
     expect(findUnknownFlag(["--aa"])).toBeUndefined();
     expect(findUnknownFlag(["--allow-all"])).toBeUndefined();
     expect(findUnknownFlag(["--resume"])).toBeUndefined();

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatUpdateSuccessLines,
+  INTERNAL_AUTO_UPDATE_ENV,
+  isInternalAutoUpdate,
+} from "../src/util/update-check.js";
+
+describe("update mode helpers", () => {
+  test("standalone update success message does not relaunch", () => {
+    const lines = formatUpdateSuccessLines("1.8.1", "1.8.1", false);
+    expect(lines.some((line) => line.includes("Relaunching impulse"))).toBe(false);
+    expect(lines).toContain("  Run `impulse` to start.");
+  });
+
+  test("internal auto-update success message relaunches", () => {
+    const lines = formatUpdateSuccessLines("1.8.1", "1.8.1", true);
+    expect(lines).toContain("  Relaunching impulse...");
+    expect(lines.some((line) => line.includes("Run `impulse`"))).toBe(false);
+  });
+
+  test("manual --auto-update is not internal without env marker", () => {
+    expect(isInternalAutoUpdate(["--auto-update"], {})).toBe(false);
+  });
+
+  test("--auto-update is internal only with env marker", () => {
+    expect(isInternalAutoUpdate(["--auto-update"], { [INTERNAL_AUTO_UPDATE_ENV]: "1" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problems

- `impulse --update` reused the same updater path as in-app `/update`, so standalone CLI updates relaunched Impulse after install.
- The relaunch behavior was implicit inside `performUpdate()`, making it easy for future callers to accidentally restart the app.
- On Windows, standalone updates could run through the compiled executable that npm was trying to replace.

## Fixed

- Made update relaunch behavior explicit: standalone `--update` installs and exits, while in-app `/update` uses hidden internal auto-update handling to relaunch and resume.
- Added hidden `--auto-update` flag recognition; manual use aliases to standalone update unless `IMPULSE_INTERNAL_AUTO_UPDATE=1` is present.
- Added npm wrapper-level update handling so Windows packaged installs can update without running through the compiled binary where possible.
- Bumped patch version to 1.8.1 and added focused update/startup flag coverage.

## Validation

- `npx tsc --noEmit`
- `node --check packages/cli/bin/impulse`
- `node --check packages/cli/postinstall.mjs`
- `node --check packages/cli/platform-package.mjs`
- `git diff --check`

Note: `bun test` was not run locally because Bun was not available on the PowerShell PATH.

Fixes #106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global install/update and process relaunch behavior across CLI wrapper and main binary; mistakes could break updates or unwanted restarts, though scope is narrow and covered by new tests.
> 
> **Overview**
> **Standalone `impulse --update`** now runs `npm install -g` and exits with a “run `impulse` to start” message instead of always relaunching the app. **In-app `/update`** keeps relaunch-and-resume by spawning a detached `impulse --auto-update` child with `IMPULSE_INTERNAL_AUTO_UPDATE=1` and `IMPULSE_UPDATE_PARENT_PID`, after flushing the session and writing the resume hint.
> 
> Relaunch is **explicit** via `performUpdate(..., { relaunch })` and `isInternalAutoUpdate()`; manual `--auto-update` without the env marker behaves like a standalone update. The **npm CLI wrapper** (`packages/cli/bin/impulse`) intercepts `--update` / `--auto-update` before the platform binary so global installs can update without executing the binary being replaced (notably on Windows). Patch release **1.8.1** with changelog and tests for success messaging and internal auto-update detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1be15d2e2fae00d4fda4fd8a1b45901117743f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->