### PR TITLE
fix: fail-closed goal judge, atomic writes, bash timeout default, clear sessions on /new

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0",
+        "typescript": "^5.9.3",
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "bun": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/diff": "^8.0.0",
     "@types/node": "^22.10.0",
     "@types/semver": "^7.7.1",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.3"
   },
   "bin": {
     "impulse": "dist/index.js"

--- a/src/agent/goal-loop.ts
+++ b/src/agent/goal-loop.ts
@@ -5,7 +5,7 @@
 import { getProviderManager } from "../api/manager.js";
 import type { GoalState } from "../session/goal-state.js";
 
-export type GoalJudgeVerdict = "done" | "continue";
+export type GoalJudgeVerdict = "done" | "continue" | "judge_unavailable";
 
 export interface GoalJudgeResult {
   verdict: GoalJudgeVerdict;
@@ -18,7 +18,6 @@ DONE: <brief reason>
 or
 CONTINUE: <brief reason>`;
 
-/** Fail-open: continue on any judge error. */
 export async function judgeGoal(
   goal: GoalState,
   lastAssistantText: string,
@@ -26,7 +25,7 @@ export async function judgeGoal(
 ): Promise<GoalJudgeResult> {
   const model = judgeModel?.trim();
   if (!model) {
-    return { verdict: "continue", reason: "no judge model configured" };
+    return { verdict: "judge_unavailable", reason: "no judge model configured" };
   }
 
   try {
@@ -58,7 +57,7 @@ export async function judgeGoal(
     return { verdict: "continue", reason: "judge inconclusive" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { verdict: "continue", reason: `judge error (fail-open): ${msg}` };
+    return { verdict: "judge_unavailable", reason: `judge error: ${msg}` };
   }
 }
 

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -219,7 +219,7 @@ import {
   formatSessionStatsBlock,
 } from "../session/session-stats.js";
 import { writeUpdateResumeHint } from "../util/update-resume-hint.js";
-import { abortCurrentBashExecution } from "../tools/bash.js";
+import { abortCurrentBashExecution, clearShellSessions } from "../tools/bash.js";
 import { rejectQuestion, resolveQuestion, type Question } from "../tools/question.js";
 import { setCurrentMode } from "../tools/mode-state.js";
 import {
@@ -1253,6 +1253,21 @@ export class ImpulseRenderer {
       };
       await this.persistGoalState();
       void this.emitStatusEvent(`Goal achieved: ${result.reason}`);
+      this.drainTurnQueue();
+      return;
+    }
+
+    if (result.verdict === "judge_unavailable") {
+      this.goalState = {
+        ...activeGoal,
+        status: "paused_judge_unavailable",
+        lastJudgeReason: result.reason,
+      };
+      await this.persistGoalState();
+      this.syncGoalContextBar();
+      void this.emitStatusEvent(
+        "Goal paused — judge model unavailable. Run /goal resume after restoring it."
+      );
       this.drainTurnQueue();
       return;
     }
@@ -2723,7 +2738,9 @@ export class ImpulseRenderer {
     const label =
       this.goalState?.status === "active"
         ? this.goalState.text
-        : undefined;
+        : this.goalState?.status === "paused_judge_unavailable"
+          ? "[goal paused — judge unavailable]"
+          : undefined;
     this.syncContextBar({ goalLabel: label });
   }
 
@@ -3053,6 +3070,7 @@ export class ImpulseRenderer {
     if (arg) {
       this.addChatLine(clr.dim("Optional session name is not documented; starting a new session."));
     }
+    clearShellSessions();
     await SessionManager.createNew(arg || undefined);
     const newCfg = await loadConfig();
     if (newCfg.defaultModel?.trim()) {
@@ -4394,14 +4412,18 @@ export class ImpulseRenderer {
     }
     if (sub === "resume") {
       if (this.goalState) {
+        const wasJudgePause = this.goalState.status === "paused_judge_unavailable";
         this.goalState = {
           ...this.goalState,
           status: "active",
-          turnsUsed: 0,
+          // Preserve turnsUsed for judge pauses — no work-turn was consumed
+          ...(wasJudgePause ? {} : { turnsUsed: 0 }),
         };
         await this.persistGoalState();
         this.syncGoalContextBar();
-        void this.emitStatusEvent("Goal resumed — turn counter reset");
+        void this.emitStatusEvent(
+          wasJudgePause ? "Goal resumed" : "Goal resumed — turn counter reset"
+        );
       }
       this.tui.requestRender();
       return;

--- a/src/session/goal-state.ts
+++ b/src/session/goal-state.ts
@@ -4,7 +4,7 @@
 
 export interface GoalState {
   text: string;
-  status: "active" | "paused" | "done";
+  status: "active" | "paused" | "paused_judge_unavailable" | "done";
   turnsUsed: number;
   maxTurns: number;
   lastJudgeReason?: string;
@@ -26,7 +26,12 @@ export function parseGoalState(raw: unknown): GoalState | undefined {
   const g = raw as Record<string, unknown>;
   if (typeof g["text"] !== "string" || !g["text"].trim()) return undefined;
   const status = g["status"];
-  if (status !== "active" && status !== "paused" && status !== "done") return undefined;
+  if (
+    status !== "active" &&
+    status !== "paused" &&
+    status !== "paused_judge_unavailable" &&
+    status !== "done"
+  ) return undefined;
   return {
     text: g["text"].trim(),
     status,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -27,6 +27,8 @@ const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
 Required: command, description. Optional: workdir, timeout, interactive, session.
+Default timeout is 120s. Pass a higher value for known long-running operations (builds, installs).
+Pass timeout: 0 to run without a time limit (e.g. dev servers meant to stay alive).
 See docs/tools/bash.md for safety rules and usage details.`;
 
 const BashSchema = z.object({
@@ -54,6 +56,11 @@ interface ShellSessionState {
 
 const shellSessions = new Map<string, ShellSessionState>();
 const sessionChains = new Map<string, Promise<unknown>>();
+
+export function clearShellSessions(): void {
+  shellSessions.clear();
+  sessionChains.clear();
+}
 
 function isValidSessionCwd(cwd: string): boolean {
   try {
@@ -796,7 +803,8 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const stderrPromise = proc.stderr ? new Response(proc.stderr).text() : Promise.resolve("");
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutMs = input.timeout;
+  // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
+  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,14 @@ import { detectWindowsCommandShell } from "../util/windows-shell.js";
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
+/**
+ * Resolve the effective timeout for a bash/PTY invocation.
+ * `timeout: 0` means no limit (undefined); omitted falls back to the 120s default.
+ */
+export function resolveBashTimeoutMs(timeout?: number): number | undefined {
+  return timeout === 0 ? undefined : (timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+}
+
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
@@ -712,25 +720,28 @@ async function executeWithPty(
     activePtyHandles.set(toolCallId, handle);
     Bus.emit(PtyEvents.Started, { toolCallId, pid: handle.pid });
     
-    const timeoutMs = input.timeout ?? DEFAULT_BASH_TIMEOUT_MS;
+    const timeoutMs = resolveBashTimeoutMs(input.timeout);
     let timedOut = false;
     const result = await new Promise<{ output: string; exitCode: number; pid?: number }>((resolve) => {
-      const timer = setTimeout(() => {
-        timedOut = true;
-        try {
-          handle.kill();
-        } catch {
-          /* ignore */
-        }
-        resolve({
-          output: lastOutput,
-          exitCode: -1,
-          pid: handle.pid,
-        });
-      }, timeoutMs);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            handle.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve({
+            output: lastOutput,
+            exitCode: -1,
+            pid: handle.pid,
+          });
+        }, timeoutMs);
+      }
 
       void handle.result.then((ptyResult) => {
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         if (!timedOut) resolve(ptyResult);
       });
     });
@@ -804,7 +815,7 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
-  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+  const timeoutMs = resolveBashTimeoutMs(input.timeout);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/file-edit.ts
+++ b/src/tools/file-edit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename } from "path";
 import { createPatch } from "diff";
 import {
@@ -82,6 +83,10 @@ export const fileEdit: Tool<EditInput> = Tool.define(
       });
 
       const content = await readFile(safePath, "utf-8");
+      let existingMode: number | undefined;
+      try {
+        existingMode = (await stat(safePath)).mode;
+      } catch { /* preserve no mode if stat fails */ }
 
       const resolved = resolveEditMatch(
         content,
@@ -156,7 +161,11 @@ export const fileEdit: Tool<EditInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, newContent, "utf-8");
+      await writeFileAtomic(
+        safePath,
+        newContent,
+        existingMode !== undefined ? { mode: existingMode } : undefined
+      );
 
       // Emit file edited event for formatters
       Bus.publish(FileEvents.Edited, { 

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { mkdir, stat, writeFile, readFile, chmod, access } from "fs/promises";
+import { mkdir, stat, readFile, access } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename, dirname } from "path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
@@ -128,11 +129,11 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, input.content, "utf-8");
-
-      if (existingPermissions !== undefined) {
-        await chmod(safePath, existingPermissions);
-      }
+      await writeFileAtomic(
+        safePath,
+        input.content,
+        existingPermissions !== undefined ? { mode: existingPermissions } : undefined
+      );
 
       // Count logical content lines written. Empty files have 0 lines.
       const linesWritten = input.content.length === 0 ? 0 : input.content.split("\n").length;

--- a/test/bash-timeout-resolution.test.ts
+++ b/test/bash-timeout-resolution.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBashTimeoutMs } from "../src/tools/bash.js";
+
+describe("resolveBashTimeoutMs", () => {
+  test("timeout: 0 means no limit", () => {
+    expect(resolveBashTimeoutMs(0)).toBeUndefined();
+  });
+
+  test("omitted timeout falls back to the 120s default", () => {
+    expect(resolveBashTimeoutMs(undefined)).toBe(120_000);
+  });
+
+  test("an explicit timeout passes through unchanged", () => {
+    expect(resolveBashTimeoutMs(5000)).toBe(5000);
+  });
+});


### PR DESCRIPTION
## Summary

First branch in a stacked sequence implementing issues #113-#118 (a prior planning session broke the work into 6 branches; this PR is a review pass + bugfix pass on top of the original implementation, not a rewrite). This branch covers:

- **#114 (pt 1)** — fail-closed goal judge: a third verdict (`judge_unavailable`) is returned when the judge model is missing or the API call throws, instead of silently continuing. The renderer pauses the goal loop without consuming a turn and `/goal resume` preserves `turnsUsed` for judge-unavailable pauses.
- **#118 item 1** — default 120s bash/PTY timeout when the model omits `timeout`; `timeout: 0` opts out (for dev servers).
- **#118 item 4** — atomic file writes for `file_write`/`file_edit` (existing `writeFileAtomic` wired in, preserving chmod).
- **#118 item 8a** — `/new` clears shell session state.

## Review findings fixed in this pass

- **Bug:** the PTY execution path ignored `timeout: 0` — it only mapped to "no limit" on the non-interactive spawn path, so an interactive long-runner was still killed after 120s. Extracted a shared `resolveBashTimeoutMs()` used on both paths.
- Bumped `typescript` to `^5.9.3` to match what's actually resolved in `node_modules` (the `^5.7.0` range was stale).
- Added `test/bash-timeout-resolution.test.ts` covering the timeout resolution helper (no prior test coverage existed for this path).

## Validation

- `bun run typecheck` — clean.
- `bun test test/bash-timeout-resolution.test.ts` — 3/3 pass.
- Manual: confirmed a hung command times out at 120s and `timeout: 0` runs unbounded on both the spawn and PTY paths.

## Notes for reviewer

- This is the first of 6 stacked branches (`fix/loop-safety-114-118` → `feat/shell-tooling-primitives-115-118` → `feat/wsl-routing-115` → `feat/plan-goal-pipeline-113-114` → `feat/skills-management-117` → `feat/background-commands-116`), each already pushed and containing everything from the branches before it. Please merge in that order with a **merge commit** (not squash) — squashing would break the later branches' diffs against `main`.
- During review I found two pre-existing, unrelated environment issues (not caused by this stack): (1) the full `bun test` suite hangs on this machine because some test invokes the real permission-`ask()` flow with no UI attached — flagged separately for investigation; (2) two `test/windows-shell.test.ts` cases are sensitive to being run from a Git-Bash-launched shell — also flagged separately. Neither blocks this PR.
- Contributes to #114 and #118; those issues are fully closed once the later branches in this stack (`feat/shell-tooling-primitives-115-118` for #118, `feat/plan-goal-pipeline-113-114` for #114) merge.