### PR TITLE
feat: WSL command routing + preferredShell config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0",
+        "typescript": "^5.9.3",
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "bun": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/diff": "^8.0.0",
     "@types/node": "^22.10.0",
     "@types/semver": "^7.7.1",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.3"
   },
   "bin": {
     "impulse": "dist/index.js"

--- a/src/agent/goal-loop.ts
+++ b/src/agent/goal-loop.ts
@@ -5,7 +5,7 @@
 import { getProviderManager } from "../api/manager.js";
 import type { GoalState } from "../session/goal-state.js";
 
-export type GoalJudgeVerdict = "done" | "continue";
+export type GoalJudgeVerdict = "done" | "continue" | "judge_unavailable";
 
 export interface GoalJudgeResult {
   verdict: GoalJudgeVerdict;
@@ -18,7 +18,6 @@ DONE: <brief reason>
 or
 CONTINUE: <brief reason>`;
 
-/** Fail-open: continue on any judge error. */
 export async function judgeGoal(
   goal: GoalState,
   lastAssistantText: string,
@@ -26,7 +25,7 @@ export async function judgeGoal(
 ): Promise<GoalJudgeResult> {
   const model = judgeModel?.trim();
   if (!model) {
-    return { verdict: "continue", reason: "no judge model configured" };
+    return { verdict: "judge_unavailable", reason: "no judge model configured" };
   }
 
   try {
@@ -58,7 +57,7 @@ export async function judgeGoal(
     return { verdict: "continue", reason: "judge inconclusive" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { verdict: "continue", reason: `judge error (fail-open): ${msg}` };
+    return { verdict: "judge_unavailable", reason: `judge error: ${msg}` };
   }
 }
 

--- a/src/agent/project-structure.ts
+++ b/src/agent/project-structure.ts
@@ -1,0 +1,181 @@
+import path from "path";
+import { readdir } from "fs/promises";
+
+const PROBE_TIMEOUT_MS = 1500;
+const MAX_RENDER_DEPTH = 3;
+const MAX_BLOCK_LINES = 40;
+const MAX_BLOCK_CHARS = 2000;
+/** Beyond this many scanned files the block is skipped entirely (huge repos). */
+const MAX_SCANNED_FILES = 20_000;
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "coverage"]);
+
+interface DirNode {
+  files: number;
+  totalFiles: number;
+  children: Map<string, DirNode>;
+}
+
+function newDirNode(): DirNode {
+  return { files: 0, totalFiles: 0, children: new Map() };
+}
+
+/** Insert a repo-relative file path (posix or win32 separators) into the tree. */
+function insertPath(root: DirNode, relPath: string): void {
+  const segments = relPath.split(/[\\/]/).filter(Boolean);
+  if (segments.length === 0) return;
+  segments.pop(); // drop the file name; only directory segments are tracked
+
+  let node = root;
+  root.totalFiles++;
+  for (const segment of segments) {
+    let child = node.children.get(segment);
+    if (!child) {
+      child = newDirNode();
+      node.children.set(segment, child);
+    }
+    child.totalFiles++;
+    node = child;
+  }
+  node.files++;
+}
+
+async function probeGitFiles(cwd: string): Promise<string[] | null> {
+  try {
+    const proc = Bun.spawn({
+      cmd: ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timer = new Promise<"timeout">((resolve) =>
+      setTimeout(() => {
+        try {
+          proc.kill();
+        } catch {
+          /* ignore */
+        }
+        resolve("timeout");
+      }, PROBE_TIMEOUT_MS)
+    );
+    const result = await Promise.race([new Response(proc.stdout).text(), timer]);
+    if (result === "timeout") return null;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    return result.split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+async function walkFallback(dir: string, cwd: string, out: string[], depth = 0): Promise<void> {
+  if (out.length >= MAX_SCANNED_FILES || depth > 8) return;
+
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (out.length >= MAX_SCANNED_FILES) return;
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      await walkFallback(path.join(dir, entry.name), cwd, out, depth + 1);
+    } else {
+      out.push(path.relative(cwd, path.join(dir, entry.name)));
+    }
+  }
+}
+
+/** Render a directory's children, collapsing to a file-count summary past maxDepth or leaf dirs. */
+function renderDir(node: DirNode, name: string, depth: number, maxDepth: number, indent: string): string[] {
+  if (depth >= maxDepth || node.children.size === 0) {
+    return [`${indent}${name}/ (${node.totalFiles} files)`];
+  }
+  const lines = [`${indent}${name}/`];
+  const sortedChildren = [...node.children.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [childName, child] of sortedChildren) {
+    lines.push(...renderDir(child, childName, depth + 1, maxDepth, `${indent}  `));
+  }
+  return lines;
+}
+
+function renderTree(root: DirNode, maxDepth: number): string[] {
+  const lines: string[] = [];
+  const sortedDirs = [...root.children.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [name, child] of sortedDirs) {
+    lines.push(...renderDir(child, name, 1, maxDepth, ""));
+  }
+  return lines;
+}
+
+export interface ProjectStructureProbe {
+  root: DirNode;
+  rootLooseFiles: string[];
+}
+
+/** Build a probe tree from a flat list of repo-relative file paths (pure, for tests). */
+export function buildProjectStructureProbe(files: string[]): ProjectStructureProbe | null {
+  if (files.length === 0 || files.length > MAX_SCANNED_FILES) return null;
+
+  const root = newDirNode();
+  const rootLooseFiles: string[] = [];
+  for (const rel of files) {
+    const segments = rel.split(/[\\/]/).filter(Boolean);
+    if (segments.length === 1) {
+      rootLooseFiles.push(segments[0]!);
+      root.files++;
+      root.totalFiles++;
+    } else {
+      insertPath(root, rel);
+    }
+  }
+  rootLooseFiles.sort((a, b) => a.localeCompare(b));
+
+  return { root, rootLooseFiles };
+}
+
+async function probeProjectStructureUncached(cwd: string): Promise<ProjectStructureProbe | null> {
+  const gitFiles = await probeGitFiles(cwd);
+  const files = gitFiles ?? (await (async () => {
+    const out: string[] = [];
+    await walkFallback(cwd, cwd, out);
+    return out;
+  })());
+
+  return buildProjectStructureProbe(files);
+}
+
+let cachedCwd: string | null = null;
+let cachedProbe: Promise<ProjectStructureProbe | null> | undefined;
+
+export function probeProjectStructure(cwd = process.cwd()): Promise<ProjectStructureProbe | null> {
+  if (cachedCwd !== cwd) {
+    cachedCwd = cwd;
+    cachedProbe = undefined;
+  }
+  cachedProbe ??= probeProjectStructureUncached(cwd);
+  return cachedProbe;
+}
+
+export function clearProjectStructureCache(): void {
+  cachedCwd = null;
+  cachedProbe = undefined;
+}
+
+export function formatProjectStructureBlock(probe: ProjectStructureProbe | null): string {
+  if (!probe) return "";
+
+  for (const maxDepth of [MAX_RENDER_DEPTH, 2, 1]) {
+    const lines = renderTree(probe.root, maxDepth);
+    if (probe.rootLooseFiles.length > 0) {
+      lines.push(probe.rootLooseFiles.join("  "));
+    }
+    const body = lines.join("\n");
+    if (lines.length <= MAX_BLOCK_LINES && body.length <= MAX_BLOCK_CHARS) {
+      return `## Project structure (depth ${maxDepth}, gitignore-respecting)\n${body}`;
+    }
+  }
+  return "";
+}

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -483,15 +483,20 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     "../git/repo-context.js"
   );
   const { probeGhCli, formatGhCliPromptBlock } = await import("../git/gh-cli.js");
+  const { probeToolAvailability, formatToolAvailabilityBlock } = await import(
+    "../util/shell-env.js"
+  );
 
   const repoContext = resolveRepoContext(workingDir);
   const ghStatus = probeGhCli();
+  const toolAvailability = await probeToolAvailability();
 
   const parts: string[] = [
     getPrompt("core", "base", BASE_PROMPT),
     cwdContext,
     formatRepoContextPromptBlock(repoContext),
     formatGhCliPromptBlock(ghStatus),
+    formatToolAvailabilityBlock(toolAvailability),
   ];
 
   const projectInstructions = await loadInstructions(workingDir);

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -486,10 +486,14 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
   const { probeToolAvailability, formatToolAvailabilityBlock } = await import(
     "../util/shell-env.js"
   );
+  const { probeProjectStructure, formatProjectStructureBlock } = await import(
+    "./project-structure.js"
+  );
 
   const repoContext = resolveRepoContext(workingDir);
   const ghStatus = probeGhCli();
   const toolAvailability = await probeToolAvailability();
+  const projectStructure = await probeProjectStructure(workingDir);
 
   const parts: string[] = [
     getPrompt("core", "base", BASE_PROMPT),
@@ -498,6 +502,11 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     formatGhCliPromptBlock(ghStatus),
     formatToolAvailabilityBlock(toolAvailability),
   ];
+
+  const projectStructureBlock = formatProjectStructureBlock(projectStructure);
+  if (projectStructureBlock) {
+    parts.push(projectStructureBlock);
+  }
 
   const projectInstructions = await loadInstructions(workingDir);
   if (projectInstructions) {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -219,7 +219,7 @@ import {
   formatSessionStatsBlock,
 } from "../session/session-stats.js";
 import { writeUpdateResumeHint } from "../util/update-resume-hint.js";
-import { abortCurrentBashExecution } from "../tools/bash.js";
+import { abortCurrentBashExecution, clearShellSessions } from "../tools/bash.js";
 import { rejectQuestion, resolveQuestion, type Question } from "../tools/question.js";
 import { setCurrentMode } from "../tools/mode-state.js";
 import {
@@ -1253,6 +1253,21 @@ export class ImpulseRenderer {
       };
       await this.persistGoalState();
       void this.emitStatusEvent(`Goal achieved: ${result.reason}`);
+      this.drainTurnQueue();
+      return;
+    }
+
+    if (result.verdict === "judge_unavailable") {
+      this.goalState = {
+        ...activeGoal,
+        status: "paused_judge_unavailable",
+        lastJudgeReason: result.reason,
+      };
+      await this.persistGoalState();
+      this.syncGoalContextBar();
+      void this.emitStatusEvent(
+        "Goal paused — judge model unavailable. Run /goal resume after restoring it."
+      );
       this.drainTurnQueue();
       return;
     }
@@ -2723,7 +2738,9 @@ export class ImpulseRenderer {
     const label =
       this.goalState?.status === "active"
         ? this.goalState.text
-        : undefined;
+        : this.goalState?.status === "paused_judge_unavailable"
+          ? "[goal paused — judge unavailable]"
+          : undefined;
     this.syncContextBar({ goalLabel: label });
   }
 
@@ -3053,6 +3070,7 @@ export class ImpulseRenderer {
     if (arg) {
       this.addChatLine(clr.dim("Optional session name is not documented; starting a new session."));
     }
+    clearShellSessions();
     await SessionManager.createNew(arg || undefined);
     const newCfg = await loadConfig();
     if (newCfg.defaultModel?.trim()) {
@@ -4394,14 +4412,18 @@ export class ImpulseRenderer {
     }
     if (sub === "resume") {
       if (this.goalState) {
+        const wasJudgePause = this.goalState.status === "paused_judge_unavailable";
         this.goalState = {
           ...this.goalState,
           status: "active",
-          turnsUsed: 0,
+          // Preserve turnsUsed for judge pauses — no work-turn was consumed
+          ...(wasJudgePause ? {} : { turnsUsed: 0 }),
         };
         await this.persistGoalState();
         this.syncGoalContextBar();
-        void this.emitStatusEvent("Goal resumed — turn counter reset");
+        void this.emitStatusEvent(
+          wasJudgePause ? "Goal resumed" : "Goal resumed — turn counter reset"
+        );
       }
       this.tui.requestRender();
       return;

--- a/src/session/goal-state.ts
+++ b/src/session/goal-state.ts
@@ -4,7 +4,7 @@
 
 export interface GoalState {
   text: string;
-  status: "active" | "paused" | "done";
+  status: "active" | "paused" | "paused_judge_unavailable" | "done";
   turnsUsed: number;
   maxTurns: number;
   lastJudgeReason?: string;
@@ -26,7 +26,12 @@ export function parseGoalState(raw: unknown): GoalState | undefined {
   const g = raw as Record<string, unknown>;
   if (typeof g["text"] !== "string" || !g["text"].trim()) return undefined;
   const status = g["status"];
-  if (status !== "active" && status !== "paused" && status !== "done") return undefined;
+  if (
+    status !== "active" &&
+    status !== "paused" &&
+    status !== "paused_judge_unavailable" &&
+    status !== "done"
+  ) return undefined;
   return {
     text: g["text"].trim(),
     status,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -96,6 +96,8 @@ interface SpawnOptions {
   cwd?: string;
   env?: Record<string, string | undefined>;
   shellKind?: "powershell" | "cmd" | "bash";
+  /** One-time notice to prepend to the tool output (e.g. a shell-selection fallback). */
+  notice?: string;
 }
 
 interface ShellSessionState {
@@ -596,8 +598,15 @@ function quotePowerShellString(value: string): string {
  * Translate a Windows path to a WSL mount path.
  * C:\Users\foo\bar → /mnt/c/Users/foo/bar
  * Already-POSIX paths are returned unchanged.
+ * UNC paths (\\server\share\...) aren't representable this way — throws instead
+ * of producing a broken /mnt path.
  */
-function translateToWslPath(winPath: string): string {
+export function translateToWslPath(winPath: string): string {
+  if (winPath.startsWith("\\\\") || winPath.startsWith("//")) {
+    throw new Error(
+      `Cannot translate UNC path to a WSL path: ${winPath}. Run this command from a local-drive working directory, or address the share via WSL's own /mnt/wsl/ network-mount conventions.`
+    );
+  }
   const driveMatch = winPath.match(/^([A-Za-z]):[\\\/](.*)/);
   if (driveMatch) {
     const drive = driveMatch[1]!.toLowerCase();
@@ -625,6 +634,69 @@ function encodePowerShellCommand(command: string): string {
   return Buffer.from(command, "utf16le").toString("base64");
 }
 
+function buildWslSpawnOptions(executable: string, cwd: string, command: string): SpawnOptions {
+  const wslCwd = translateToWslPath(cwd);
+  // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
+  return {
+    env: process.env,
+    shellKind: "bash",
+    cmd: [executable, "--cd", wslCwd, "--", "bash", "-lc", command],
+  };
+}
+
+function buildSpawnOptionsForShell(
+  shell: Awaited<ReturnType<typeof detectWindowsCommandShell>>,
+  input: BashInput,
+  cwd: string,
+  options: { interactive?: boolean },
+  common: SpawnOptions
+): SpawnOptions {
+  if (shell.type === "wsl") {
+    return buildWslSpawnOptions(shell.executable, cwd, input.command);
+  }
+
+  if (shell.type === "cmd") {
+    return {
+      ...common,
+      shellKind: "cmd",
+      cmd: [shell.executable, "/d", "/s", "/c", input.command],
+    };
+  }
+
+  if (shell.type === "git-bash") {
+    return {
+      ...common,
+      shellKind: "bash",
+      cmd: [shell.executable, "-lc", input.command],
+    };
+  }
+
+  const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
+  const psType = shell.type as "powershell5" | "powershell7";
+
+  return {
+    ...common,
+    shellKind: "powershell",
+    env: {
+      ...process.env,
+      [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
+    },
+    cmd: [
+      shell.executable,
+      "-NoLogo",
+      "-NoProfile",
+      ...interactiveArgs,
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+      encodePowerShellCommand(WINDOWS_POWERSHELL_WRAPPER),
+    ],
+  };
+}
+
+/** Shown once per process when preferredShell is "wsl" but no WSL distro is available. */
+let warnedWslUnavailable = false;
+
 async function getSpawnOptions(
   input: BashInput,
   cwd: string,
@@ -643,66 +715,27 @@ async function getSpawnOptions(
     // WSL: either forced by preferredShell config or auto-detected
     if (preferred === "wsl") {
       const wslShell = await detectWslShell();
-      const wslExe = wslShell?.executable ?? "wsl.exe";
-      const wslCwd = translateToWslPath(cwd);
-      // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
-      return {
-        env: process.env,
-        shellKind: "bash",
-        cmd: [wslExe, "--cd", wslCwd, "--", "bash", "-lc", input.command],
-      };
+      if (wslShell) {
+        return buildWslSpawnOptions(wslShell.executable, cwd, input.command);
+      }
+
+      // preferredShell is explicitly "wsl" but no distro was detected — don't
+      // spawn a nonexistent wsl.exe; fall back to the auto-detected shell and
+      // surface a one-time notice instead of an opaque spawn failure.
+      const fallbackShell = await detectWindowsCommandShell();
+      const spawnOptions = buildSpawnOptionsForShell(fallbackShell, input, cwd, options, common);
+      if (!warnedWslUnavailable) {
+        warnedWslUnavailable = true;
+        spawnOptions.notice = `[Note: preferredShell is set to "wsl" but no WSL distro was detected. Falling back to ${fallbackShell.displayName}. Run 'wsl --install' or check 'wsl -l -v', or change preferredShell in config.]`;
+      }
+      return spawnOptions;
     }
 
     const shell = preferred === "auto"
       ? await detectWindowsCommandShell()
       : await resolvePreferredShell(preferred);
 
-    if (shell.type === "wsl") {
-      const wslCwd = translateToWslPath(cwd);
-      return {
-        env: process.env,
-        shellKind: "bash",
-        cmd: [shell.executable, "--cd", wslCwd, "--", "bash", "-lc", input.command],
-      };
-    }
-
-    if (shell.type === "cmd") {
-      return {
-        ...common,
-        shellKind: "cmd",
-        cmd: [shell.executable, "/d", "/s", "/c", input.command],
-      };
-    }
-
-    if (shell.type === "git-bash") {
-      return {
-        ...common,
-        shellKind: "bash",
-        cmd: [shell.executable, "-lc", input.command],
-      };
-    }
-
-    const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
-    const psType = shell.type as "powershell5" | "powershell7";
-
-    return {
-      ...common,
-      shellKind: "powershell",
-      env: {
-        ...process.env,
-        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
-      },
-      cmd: [
-        shell.executable,
-        "-NoLogo",
-        "-NoProfile",
-        ...interactiveArgs,
-        "-ExecutionPolicy",
-        "Bypass",
-        "-EncodedCommand",
-        encodePowerShellCommand(WINDOWS_POWERSHELL_WRAPPER),
-      ],
-    };
+    return buildSpawnOptionsForShell(shell, input, cwd, options, common);
   }
 
   return {
@@ -716,7 +749,7 @@ async function getSpawnOptions(
  * Resolve a specific shell from a user preference string (non-"auto" + non-"wsl" values).
  * Falls back to auto-detection when the requested shell is not found.
  */
-async function resolvePreferredShell(preferred: string) {
+export async function resolvePreferredShell(preferred: string) {
   if (preferred === "pwsh") {
     const pwshPath = Bun.which("pwsh.exe") ?? Bun.which("pwsh");
     if (pwshPath) return { type: "powershell7" as const, executable: pwshPath, displayName: "PowerShell 7.x (pwsh)", supportsChainedCommands: true, commandSeparator: "&&" as const };
@@ -883,6 +916,10 @@ async function executeWithPty(
     const capped = capBashOutputLines(result.output, maxLines);
     let output = capped.output;
 
+    if (spawnOptions?.notice) {
+      output = `${spawnOptions.notice}${output ? "\n" : ""}${output}`;
+    }
+
     if (timedOut) {
       output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
     }
@@ -1030,6 +1067,10 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const hint = classifyCommandError(input.command, output, exitCode ?? -1, shellForClassify);
   if (hint) {
     output = `${output}${output ? "\n" : ""}${hint}`;
+  }
+
+  if (spawnOptions.notice) {
+    output = `${spawnOptions.notice}${output ? "\n" : ""}${output}`;
   }
 
   const elapsed = Date.now() - startTime;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -27,6 +27,8 @@ const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
 Required: command, description. Optional: workdir, timeout, interactive, session.
+Default timeout is 120s. Pass a higher value for known long-running operations (builds, installs).
+Pass timeout: 0 to run without a time limit (e.g. dev servers meant to stay alive).
 See docs/tools/bash.md for safety rules and usage details.`;
 
 const BashSchema = z.object({
@@ -54,6 +56,11 @@ interface ShellSessionState {
 
 const shellSessions = new Map<string, ShellSessionState>();
 const sessionChains = new Map<string, Promise<unknown>>();
+
+export function clearShellSessions(): void {
+  shellSessions.clear();
+  sessionChains.clear();
+}
 
 function isValidSessionCwd(cwd: string): boolean {
   try {
@@ -796,7 +803,8 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const stderrPromise = proc.stderr ? new Response(proc.stderr).text() : Promise.resolve("");
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutMs = input.timeout;
+  // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
+  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -36,7 +36,7 @@ export function resolveBashTimeoutMs(timeout?: number): number | undefined {
  * tool or command is not found on the target shell.
  * Returns a hint string to append, or null when output is already clear.
  */
-function classifyCommandError(
+export function classifyCommandError(
   command: string,
   output: string,
   exitCode: number,
@@ -921,28 +921,35 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
     }
   }
   
-  // Pagination: slice output lines before byte-capping
+  // Pagination: slice output lines, then byte-cap; the note is built AFTER
+  // capping so it reflects what was actually delivered (the byte/line cap
+  // can still trim a paginated slice, and the note must not overstate it).
   const outputOffset = input.offset ?? 0;
   const outputLimit = input.limit ?? maxLines;
-  let paginationNote = "";
+  const paginationRequested = outputOffset > 0 || input.limit !== undefined;
   let paginatedOutput = combinedOutput;
-  if (outputOffset > 0 || input.limit !== undefined) {
+  let totalOutputLines = 0;
+  let slicedLineCount = 0;
+  if (paginationRequested) {
     const allLines = combinedOutput.split("\n");
-    const totalOutputLines = allLines.length;
+    totalOutputLines = allLines.length;
     const sliced = allLines.slice(outputOffset, outputOffset + outputLimit);
+    slicedLineCount = sliced.length;
     paginatedOutput = sliced.join("\n");
-    const nextOffset = outputOffset + sliced.length;
-    if (nextOffset < totalOutputLines) {
-      paginationNote = `\n[Output paginated: lines ${outputOffset + 1}–${nextOffset} of ${totalOutputLines}. Re-run with offset: ${nextOffset} for more.]`;
-    }
   }
 
   const capped = capBashOutputLines(paginatedOutput, maxLines);
   let output = capped.output;
-  let wasTruncated = capped.truncated || paginationNote.length > 0;
+  let wasTruncated = capped.truncated;
 
-  if (paginationNote) {
-    output = `${output}${paginationNote}`;
+  if (paginationRequested) {
+    const delivered = capped.keptLines;
+    const nextOffset = outputOffset + delivered;
+    if (nextOffset < totalOutputLines) {
+      const cappedFurther = delivered < slicedLineCount ? ", further capped by output size limits" : "";
+      output = `${output}\n[Output paginated: lines ${outputOffset + 1}-${nextOffset} of ${totalOutputLines}${cappedFurther}. Re-run with offset: ${nextOffset} for more.]`;
+      wasTruncated = true;
+    }
   }
 
   if (exitCode === -1) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,43 @@ import { detectWindowsCommandShell } from "../util/windows-shell.js";
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
+/**
+ * Classify a failed command's output to give actionable guidance when a
+ * tool or command is not found on the target shell.
+ * Returns a hint string to append, or null when output is already clear.
+ */
+function classifyCommandError(
+  command: string,
+  output: string,
+  exitCode: number,
+  shellKind: "powershell" | "cmd" | "bash"
+): string | null {
+  if (exitCode === 0) return null;
+  const cmd = command.trim().split(/\s+/)[0] ?? command;
+  if (shellKind === "powershell") {
+    if (
+      output.includes("is not recognized as the name of a cmdlet") ||
+      output.includes("is not recognized as an internal or external command") ||
+      output.includes("CommandNotFoundException")
+    ) {
+      return `[Hint: '${cmd}' is not a recognised PowerShell cmdlet or program. Check spelling, confirm it is installed, or run 'Get-Command ${cmd}' to locate it.]`;
+    }
+  } else if (shellKind === "cmd") {
+    if (output.includes("is not recognized as an internal or external command")) {
+      return `[Hint: '${cmd}' was not found. Check spelling or confirm it is on PATH.]`;
+    }
+  } else {
+    // bash / POSIX
+    if (output.includes("command not found") || exitCode === 127) {
+      return `[Hint: '${cmd}' was not found on PATH. Confirm it is installed (e.g. 'which ${cmd}').]`;
+    }
+    if ((output.includes("Permission denied") || output.includes("EACCES")) && exitCode === 126) {
+      return `[Hint: Permission denied executing '${cmd}'. Check file permissions (ls -l).]`;
+    }
+  }
+  return null;
+}
+
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
@@ -39,6 +76,8 @@ const BashSchema = z.object({
   interactive: z.boolean().optional(),
   session: z.string().optional().describe("Optional named shell session; preserves cwd between bash calls"),
   resetSession: z.boolean().optional().describe("Reset the named shell session before running"),
+  offset: z.number().optional().describe("Line offset into captured output (0-based). Use to page through large results."),
+  limit: z.number().optional().describe("Max output lines to return (default 2000). Combine with offset for pagination."),
 });
 
 type BashInput = z.infer<typeof BashSchema>;
@@ -52,10 +91,28 @@ interface SpawnOptions {
 
 interface ShellSessionState {
   cwd: string;
+  lastUsed: number;
 }
+
+const MAX_SHELL_SESSIONS = 20;
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 const shellSessions = new Map<string, ShellSessionState>();
 const sessionChains = new Map<string, Promise<unknown>>();
+
+function evictStaleSessions(): void {
+  const now = Date.now();
+  // First remove TTL-expired sessions
+  for (const [name, state] of shellSessions) {
+    if (now - state.lastUsed > SESSION_TTL_MS) shellSessions.delete(name);
+  }
+  // Then LRU-evict if still over cap
+  if (shellSessions.size > MAX_SHELL_SESSIONS) {
+    const sorted = [...shellSessions.entries()].sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+    const toRemove = sorted.slice(0, shellSessions.size - MAX_SHELL_SESSIONS);
+    for (const [name] of toRemove) shellSessions.delete(name);
+  }
+}
 
 export function clearShellSessions(): void {
   shellSessions.clear();
@@ -106,20 +163,23 @@ function resolveSessionCwd(
   options?: { reset?: boolean; workdirProvided?: boolean }
 ): string {
   if (!sessionName) return fallbackCwd;
+  evictStaleSessions();
   if (options?.reset) shellSessions.delete(sessionName);
   const existing = shellSessions.get(sessionName);
+  const now = Date.now();
   if (existing) {
     if (options?.workdirProvided) {
-      shellSessions.set(sessionName, { cwd: fallbackCwd });
+      shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
       return fallbackCwd;
     }
     if (isValidSessionCwd(existing.cwd)) {
+      existing.lastUsed = now;
       return existing.cwd;
     }
-    shellSessions.set(sessionName, { cwd: fallbackCwd });
+    shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
     return fallbackCwd;
   }
-  shellSessions.set(sessionName, { cwd: fallbackCwd });
+  shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
   return fallbackCwd;
 }
 
@@ -153,7 +213,7 @@ function updateSessionCwd(sessionName: string | null, cwd: string, command: stri
   } catch {
     return;
   }
-  shellSessions.set(sessionName, { cwd: next });
+  shellSessions.set(sessionName, { cwd: next, lastUsed: Date.now() });
 }
 
 const WINDOWS_COMMAND_ENV_VAR = "IMPULSE_COMMAND";
@@ -850,12 +910,39 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
     }
   }
   
-  const capped = capBashOutputLines(combinedOutput, maxLines);
+  // Pagination: slice output lines before byte-capping
+  const outputOffset = input.offset ?? 0;
+  const outputLimit = input.limit ?? maxLines;
+  let paginationNote = "";
+  let paginatedOutput = combinedOutput;
+  if (outputOffset > 0 || input.limit !== undefined) {
+    const allLines = combinedOutput.split("\n");
+    const totalOutputLines = allLines.length;
+    const sliced = allLines.slice(outputOffset, outputOffset + outputLimit);
+    paginatedOutput = sliced.join("\n");
+    const nextOffset = outputOffset + sliced.length;
+    if (nextOffset < totalOutputLines) {
+      paginationNote = `\n[Output paginated: lines ${outputOffset + 1}–${nextOffset} of ${totalOutputLines}. Re-run with offset: ${nextOffset} for more.]`;
+    }
+  }
+
+  const capped = capBashOutputLines(paginatedOutput, maxLines);
   let output = capped.output;
-  let wasTruncated = capped.truncated;
+  let wasTruncated = capped.truncated || paginationNote.length > 0;
+
+  if (paginationNote) {
+    output = `${output}${paginationNote}`;
+  }
 
   if (exitCode === -1) {
     output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
+  }
+
+  // Append command-not-found hint on failures when output doesn't already explain the error
+  const shellForClassify = spawnOptions.shellKind ?? (process.platform === "win32" ? "powershell" : "bash");
+  const hint = classifyCommandError(input.command, output, exitCode ?? -1, shellForClassify);
+  if (hint) {
+    output = `${output}${output ? "\n" : ""}${hint}`;
   }
 
   const elapsed = Date.now() - startTime;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,14 @@ import { detectWindowsCommandShell } from "../util/windows-shell.js";
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
+/**
+ * Resolve the effective timeout for a bash/PTY invocation.
+ * `timeout: 0` means no limit (undefined); omitted falls back to the 120s default.
+ */
+export function resolveBashTimeoutMs(timeout?: number): number | undefined {
+  return timeout === 0 ? undefined : (timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+}
+
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
@@ -712,25 +720,28 @@ async function executeWithPty(
     activePtyHandles.set(toolCallId, handle);
     Bus.emit(PtyEvents.Started, { toolCallId, pid: handle.pid });
     
-    const timeoutMs = input.timeout ?? DEFAULT_BASH_TIMEOUT_MS;
+    const timeoutMs = resolveBashTimeoutMs(input.timeout);
     let timedOut = false;
     const result = await new Promise<{ output: string; exitCode: number; pid?: number }>((resolve) => {
-      const timer = setTimeout(() => {
-        timedOut = true;
-        try {
-          handle.kill();
-        } catch {
-          /* ignore */
-        }
-        resolve({
-          output: lastOutput,
-          exitCode: -1,
-          pid: handle.pid,
-        });
-      }, timeoutMs);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            handle.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve({
+            output: lastOutput,
+            exitCode: -1,
+            pid: handle.pid,
+          });
+        }, timeoutMs);
+      }
 
       void handle.result.then((ptyResult) => {
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         if (!timedOut) resolve(ptyResult);
       });
     });
@@ -804,7 +815,7 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
-  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+  const timeoutMs = resolveBashTimeoutMs(input.timeout);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -18,7 +18,8 @@ import { detectAndPublishBranchChange } from "../git/branch-detect";
 import { SessionManager } from "../session/manager";
 import { capBashOutputLines } from "../util/tool-output-cap.js";
 import { isWithinBase } from "../util/path.js";
-import { detectWindowsCommandShell } from "../util/windows-shell.js";
+import { detectWindowsCommandShell, detectWslShell } from "../util/windows-shell.js";
+import { load as loadConfig } from "../util/config.js";
 
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
@@ -583,6 +584,21 @@ function quotePowerShellString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+/**
+ * Translate a Windows path to a WSL mount path.
+ * C:\Users\foo\bar → /mnt/c/Users/foo/bar
+ * Already-POSIX paths are returned unchanged.
+ */
+function translateToWslPath(winPath: string): string {
+  const driveMatch = winPath.match(/^([A-Za-z]):[\\\/](.*)/);
+  if (driveMatch) {
+    const drive = driveMatch[1]!.toLowerCase();
+    const rest = (driveMatch[2] ?? "").replaceAll("\\", "/");
+    return `/mnt/${drive}/${rest}`;
+  }
+  return winPath.replaceAll("\\", "/");
+}
+
 function normalizeWindowsCommand(command: string, shellType: "powershell5" | "powershell7"): string {
   const trimmed = command.trim();
   const chaining = analyzePowerShellChaining(trimmed, shellType);
@@ -613,7 +629,34 @@ async function getSpawnOptions(
   };
 
   if (process.platform === "win32") {
-    const shell = await detectWindowsCommandShell();
+    const cfg = await loadConfig();
+    const preferred = cfg.preferredShell;
+
+    // WSL: either forced by preferredShell config or auto-detected
+    if (preferred === "wsl") {
+      const wslShell = await detectWslShell();
+      const wslExe = wslShell?.executable ?? "wsl.exe";
+      const wslCwd = translateToWslPath(cwd);
+      // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
+      return {
+        env: process.env,
+        shellKind: "bash",
+        cmd: [wslExe, "--cd", wslCwd, "--", "bash", "-lc", input.command],
+      };
+    }
+
+    const shell = preferred === "auto"
+      ? await detectWindowsCommandShell()
+      : await resolvePreferredShell(preferred);
+
+    if (shell.type === "wsl") {
+      const wslCwd = translateToWslPath(cwd);
+      return {
+        env: process.env,
+        shellKind: "bash",
+        cmd: [shell.executable, "--cd", wslCwd, "--", "bash", "-lc", input.command],
+      };
+    }
 
     if (shell.type === "cmd") {
       return {
@@ -632,13 +675,14 @@ async function getSpawnOptions(
     }
 
     const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
+    const psType = shell.type as "powershell5" | "powershell7";
 
     return {
       ...common,
       shellKind: "powershell",
       env: {
         ...process.env,
-        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, shell.type),
+        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
       },
       cmd: [
         shell.executable,
@@ -658,6 +702,31 @@ async function getSpawnOptions(
     shellKind: "bash",
     cmd: ["bash", "-lc", input.command],
   };
+}
+
+/**
+ * Resolve a specific shell from a user preference string (non-"auto" + non-"wsl" values).
+ * Falls back to auto-detection when the requested shell is not found.
+ */
+async function resolvePreferredShell(preferred: string) {
+  if (preferred === "pwsh") {
+    const pwshPath = Bun.which("pwsh.exe") ?? Bun.which("pwsh");
+    if (pwshPath) return { type: "powershell7" as const, executable: pwshPath, displayName: "PowerShell 7.x (pwsh)", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  if (preferred === "powershell") {
+    const psPath = Bun.which("powershell.exe") ?? Bun.which("powershell") ?? "powershell.exe";
+    return { type: "powershell5" as const, executable: psPath, displayName: "Windows PowerShell 5.x", supportsChainedCommands: false, commandSeparator: ";" as const };
+  }
+  if (preferred === "cmd") {
+    const cmdPath = process.env["COMSPEC"] ?? "cmd.exe";
+    return { type: "cmd" as const, executable: cmdPath, displayName: "Windows Command Prompt (cmd.exe)", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  if (preferred === "git-bash") {
+    const bashPath = Bun.which("bash.exe") ?? Bun.which("bash") ?? "bash.exe";
+    return { type: "git-bash" as const, executable: bashPath, displayName: "Git Bash", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  // Fallback to auto
+  return detectWindowsCommandShell();
 }
 
 /**

--- a/src/tools/file-edit.ts
+++ b/src/tools/file-edit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename } from "path";
 import { createPatch } from "diff";
 import {
@@ -82,6 +83,10 @@ export const fileEdit: Tool<EditInput> = Tool.define(
       });
 
       const content = await readFile(safePath, "utf-8");
+      let existingMode: number | undefined;
+      try {
+        existingMode = (await stat(safePath)).mode;
+      } catch { /* preserve no mode if stat fails */ }
 
       const resolved = resolveEditMatch(
         content,
@@ -156,7 +161,11 @@ export const fileEdit: Tool<EditInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, newContent, "utf-8");
+      await writeFileAtomic(
+        safePath,
+        newContent,
+        existingMode !== undefined ? { mode: existingMode } : undefined
+      );
 
       // Emit file edited event for formatters
       Bus.publish(FileEvents.Edited, { 

--- a/src/tools/file-read.ts
+++ b/src/tools/file-read.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { createReadStream } from "fs";
-import { readFile, stat } from "fs/promises";
+import { createReadStream, openSync, readSync, closeSync } from "fs";
+import { readFile, stat, readdir } from "fs/promises";
 import readline from "readline";
 import { sanitizePath } from "../util/path";
 import { zFilePath } from "./schemas/branded";
@@ -10,6 +10,7 @@ import {
   FILE_READ_DEFAULT_LIMIT,
   prependToolNote,
 } from "./tool-notes";
+import path from "path";
 
 const DESCRIPTION = `Read a file from disk with line numbers.
 
@@ -26,6 +27,101 @@ type ReadInput = z.infer<typeof ReadSchema>;
 
 const STREAM_READ_THRESHOLD = 2_000_000; // 2MB
 const MAX_LINE_LENGTH = 2000;
+const BINARY_SNIFF_BYTES = 512;
+
+// Magic-byte signatures [label, magic-bytes (with -1 meaning "any byte")]
+const BINARY_SIGNATURES: Array<[string, number[]]> = [
+  ["PNG image",    [0x89, 0x50, 0x4e, 0x47]],
+  ["JPEG image",   [0xff, 0xd8, 0xff]],
+  ["GIF image",    [0x47, 0x49, 0x46]],
+  ["PDF",          [0x25, 0x50, 0x44, 0x46]],
+  ["ZIP archive",  [0x50, 0x4b, 0x03, 0x04]],
+  ["ELF binary",   [0x7f, 0x45, 0x4c, 0x46]],
+  ["PE binary",    [0x4d, 0x5a]],
+];
+
+function detectBinaryOrEncoding(filePath: string): { isBinary: true; label: string } | { isBinary: false; hasBOM: boolean; bomNote?: string } | null {
+  let fd: number;
+  try {
+    fd = openSync(filePath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.alloc(BINARY_SNIFF_BYTES);
+    const bytesRead = readSync(fd, buf, 0, BINARY_SNIFF_BYTES, 0);
+    if (bytesRead === 0) return null;
+    const header = buf.subarray(0, bytesRead);
+
+    // UTF-16 LE BOM (FF FE)
+    if (bytesRead >= 2 && header[0] === 0xff && header[1] === 0xfe) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-16 LE (BOM detected)" };
+    }
+    // UTF-16 BE BOM (FE FF)
+    if (bytesRead >= 2 && header[0] === 0xfe && header[1] === 0xff) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-16 BE (BOM detected)" };
+    }
+    // UTF-8 BOM (EF BB BF)
+    if (bytesRead >= 3 && header[0] === 0xef && header[1] === 0xbb && header[2] === 0xbf) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-8 BOM stripped" };
+    }
+
+    // Known binary magic bytes
+    for (const [label, magic] of BINARY_SIGNATURES) {
+      if (bytesRead >= magic.length && magic.every((b, i) => b === -1 || header[i] === b)) {
+        return { isBinary: true, label };
+      }
+    }
+
+    // Heuristic: >30% NUL bytes → binary
+    let nulCount = 0;
+    for (let i = 0; i < bytesRead; i++) {
+      if (header[i] === 0) nulCount++;
+    }
+    if (nulCount / bytesRead > 0.3) {
+      return { isBinary: true, label: "binary file" };
+    }
+
+    return { isBinary: false, hasBOM: false };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  for (let i = 1; i <= m; i++) {
+    let prev = dp[0]!;
+    dp[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j]!;
+      dp[j] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j - 1]!, dp[j]!);
+      prev = temp;
+    }
+  }
+  return dp[n]!;
+}
+
+async function fuzzyMatchSuggestion(filePath: string): Promise<string | null> {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  try {
+    const entries = await readdir(dir);
+    // Hyphen/underscore swap OR Levenshtein ≤ 2
+    const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
+    const candidates = entries.filter((e) => {
+      if (e === base) return false;
+      if (e === swapped) return true;
+      return levenshtein(base.toLowerCase(), e.toLowerCase()) <= 2;
+    });
+    if (candidates.length === 0) return null;
+    const suggestions = candidates.slice(0, 3).join(", ");
+    return `Did you mean: ${suggestions}?`;
+  } catch {
+    return null;
+  }
+}
 
 export { buildFileReadRangeNote } from "./tool-notes";
 
@@ -83,14 +179,32 @@ export const fileRead: Tool<ReadInput> = Tool.define(
 
       try {
         const stats = await stat(safePath);
+
+        // Sniff for binary/BOM before attempting UTF-8 read
+        const encoding = detectBinaryOrEncoding(safePath);
+        if (encoding?.isBinary) {
+          return {
+            success: false,
+            output: `Cannot read binary file: ${input.filePath} (detected: ${encoding.label}). Use bash tool to inspect or process binary files.`,
+          };
+        }
+        if (encoding && !encoding.isBinary && encoding.hasBOM && encoding.bomNote !== "UTF-8 BOM stripped") {
+          return {
+            success: false,
+            output: `Cannot read file: ${input.filePath} (${encoding.bomNote}). Use bash tool with appropriate encoding conversion.`,
+          };
+        }
+
         if (stats.size > STREAM_READ_THRESHOLD) {
           const result = await readLinesStream(safePath, offset, limit);
           lines = result.lines;
           totalLines = result.totalLines;
           truncated = result.truncated;
         } else {
-          const content = await readFile(safePath, "utf-8");
-          const allLines = content.split("\n");
+          // Strip UTF-8 BOM if present before splitting
+          let rawContent = await readFile(safePath, "utf-8");
+          if (rawContent.charCodeAt(0) === 0xfeff) rawContent = rawContent.slice(1);
+          const allLines = rawContent.split("\n");
           totalLines = allLines.length;
           if (totalLines === 0) {
             return {
@@ -111,6 +225,17 @@ export const fileRead: Tool<ReadInput> = Tool.define(
           truncated = end < totalLines;
         }
       } catch (error) {
+        const isNotFound =
+          error instanceof Error &&
+          ("code" in error ? (error as NodeJS.ErrnoException).code === "ENOENT" : error.message.includes("ENOENT"));
+        if (isNotFound) {
+          const suggestion = await fuzzyMatchSuggestion(safePath);
+          const base = `File not found: ${input.filePath}`;
+          return {
+            success: false,
+            output: suggestion ? `${base}\n${suggestion}` : base,
+          };
+        }
         return {
           success: false,
           output: error instanceof Error ? error.message : `File not found: ${input.filePath}`,

--- a/src/tools/file-read.ts
+++ b/src/tools/file-read.ts
@@ -103,24 +103,56 @@ function levenshtein(a: string, b: string): number {
   return dp[n]!;
 }
 
-async function fuzzyMatchSuggestion(filePath: string): Promise<string | null> {
+const NOT_FOUND_LISTING_MAX_ENTRIES = 15;
+const NOT_FOUND_LISTING_MAX_CHARS = 300;
+
+/**
+ * On ENOENT, build a "Did you mean" fuzzy suggestion plus a compact listing
+ * of the parent directory, reusing a single readdir() call for both.
+ */
+async function buildNotFoundHint(filePath: string): Promise<string | null> {
   const dir = path.dirname(filePath);
   const base = path.basename(filePath);
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
   try {
-    const entries = await readdir(dir);
-    // Hyphen/underscore swap OR Levenshtein ≤ 2
-    const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
-    const candidates = entries.filter((e) => {
-      if (e === base) return false;
-      if (e === swapped) return true;
-      return levenshtein(base.toLowerCase(), e.toLowerCase()) <= 2;
-    });
-    if (candidates.length === 0) return null;
-    const suggestions = candidates.slice(0, 3).join(", ");
-    return `Did you mean: ${suggestions}?`;
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return null;
   }
+
+  const parts: string[] = [];
+
+  // Hyphen/underscore swap OR Levenshtein ≤ 2
+  const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
+  const candidates = entries
+    .map((e) => e.name)
+    .filter((name) => {
+      if (name === base) return false;
+      if (name === swapped) return true;
+      return levenshtein(base.toLowerCase(), name.toLowerCase()) <= 2;
+    });
+  if (candidates.length > 0) {
+    parts.push(`Did you mean: ${candidates.slice(0, 3).join(", ")}?`);
+  }
+
+  const displayNames = [...entries]
+    .sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+
+  if (displayNames.length > 0) {
+    const shown = displayNames.slice(0, NOT_FOUND_LISTING_MAX_ENTRIES);
+    const more = displayNames.length > shown.length ? ` (+${displayNames.length - shown.length} more)` : "";
+    let listing = `Directory ${dir}${path.sep} (${displayNames.length} entries): ${shown.join(", ")}${more}`;
+    if (listing.length > NOT_FOUND_LISTING_MAX_CHARS) {
+      listing = `${listing.slice(0, NOT_FOUND_LISTING_MAX_CHARS - 1)}…`;
+    }
+    parts.push(listing);
+  }
+
+  return parts.length > 0 ? parts.join("\n") : null;
 }
 
 export { buildFileReadRangeNote } from "./tool-notes";
@@ -229,11 +261,11 @@ export const fileRead: Tool<ReadInput> = Tool.define(
           error instanceof Error &&
           ("code" in error ? (error as NodeJS.ErrnoException).code === "ENOENT" : error.message.includes("ENOENT"));
         if (isNotFound) {
-          const suggestion = await fuzzyMatchSuggestion(safePath);
+          const hint = await buildNotFoundHint(safePath);
           const base = `File not found: ${input.filePath}`;
           return {
             success: false,
-            output: suggestion ? `${base}\n${suggestion}` : base,
+            output: hint ? `${base}\n${hint}` : base,
           };
         }
         return {

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { mkdir, stat, writeFile, readFile, chmod, access } from "fs/promises";
+import { mkdir, stat, readFile, access } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename, dirname } from "path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
@@ -128,11 +129,11 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, input.content, "utf-8");
-
-      if (existingPermissions !== undefined) {
-        await chmod(safePath, existingPermissions);
-      }
+      await writeFileAtomic(
+        safePath,
+        input.content,
+        existingPermissions !== undefined ? { mode: existingPermissions } : undefined
+      );
 
       // Count logical content lines written. Empty files have 0 lines.
       const linesWritten = input.content.length === 0 ? 0 : input.content.split("\n").length;

--- a/src/tools/posix-translation.ts
+++ b/src/tools/posix-translation.ts
@@ -188,6 +188,49 @@ const TRANSLATIONS: CommandTranslation[] = [
     description: "touch -> New-Item -ItemType File",
   },
 
+  // cp -r / cp -> Copy-Item
+  {
+    pattern: /^cp\s+((?:-[rRpfiv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const recurse = flags.includes("r") || flags.includes("R") ? " -Recurse" : "";
+      const force = flags.includes("f") ? " -Force" : "";
+      return `Copy-Item${recurse}${force} -Path ${quotePowerShellArray(parseShellWords(m[2]))} -Destination ${quotePowerShellArray(parseShellWords(m[3]))}`;
+    },
+    description: "cp -> Copy-Item",
+  },
+
+  // mv -> Move-Item
+  {
+    pattern: /^mv\s+((?:-[fiv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const force = flags.includes("f") ? " -Force" : "";
+      return `Move-Item${force} -Path ${quotePowerShellArray(parseShellWords(m[2]))} -Destination ${quotePowerShellArray(parseShellWords(m[3]))}`;
+    },
+    description: "mv -> Move-Item",
+  },
+
+  // grep (single arg, no pipeline) -> Select-String
+  {
+    pattern: /^grep\s+((?:-[nliEv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const caseInsensitive = flags.includes("i") ? " -CaseSensitive:$false" : " -CaseSensitive";
+      const listOnly = flags.includes("l") ? " | Select-Object Path" : "";
+      const notMatch = flags.includes("v") ? " -NotMatch" : "";
+      return `Select-String${caseInsensitive}${notMatch} -Pattern ${quotePowerShellArray(parseShellWords(m[2]))} -Path ${quotePowerShellArray(parseShellWords(m[3]))}${listOnly}`;
+    },
+    description: "grep -> Select-String",
+  },
+
+  // which -> (Get-Command ...).Source
+  {
+    pattern: /^which\s+(\S+)$/,
+    replacement: (m) => `(Get-Command ${m[1]} -ErrorAction SilentlyContinue).Source`,
+    description: "which -> (Get-Command).Source",
+  },
+
 ];
 
 /**

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "../session/manager";
 import fs from "fs/promises";
 import path from "path";
 import z from "zod";
+import { clearWindowsShellCache, clearWslCache } from "./windows-shell.js";
 
 // ============================================================
 // Multi-Provider Config Schema
@@ -141,7 +142,16 @@ const ConfigSchema = z.object({
 
   // Legacy — kept for smooth migration; prefer providers[].apiKey
   apiKey: z.string().optional().describe("Legacy: use providers[defaultProvider].apiKey instead"),
+
+  /**
+   * Preferred shell for bash tool execution on Windows.
+   * "auto" (default) = detect from parent process.
+   * Other values force a specific shell regardless of detection.
+   */
+  preferredShell: z.enum(["auto", "powershell", "pwsh", "git-bash", "wsl", "cmd"]).default("auto"),
 });
+
+export type PreferredShell = z.infer<typeof ConfigSchema.shape.preferredShell>;
 
 export type Config = z.infer<typeof ConfigSchema>;
 export type UserProfile = NonNullable<Config["userProfile"]>;
@@ -323,7 +333,7 @@ export function resolveSubagentModel(config: Config, mainModel: string): string 
 export async function save(config: Config): Promise<void> {
   const parsed = applyDefaults(config);
   await fs.mkdir(Global.Path.config, { recursive: true });
-  
+
   // Write config and explicitly sync to disk to ensure it's persisted
   // This is especially important on Windows where filesystem operations
   // may be cached and not immediately visible to subsequent reads
@@ -334,6 +344,12 @@ export async function save(config: Config): Promise<void> {
   } finally {
     await fd.close();
   }
-  
+
+  // Clear shell detection caches when preferredShell changes so next command picks up the new setting
+  if (cachedConfig?.preferredShell !== parsed.preferredShell) {
+    clearWindowsShellCache();
+    clearWslCache();
+  }
+
   cachedConfig = parsed;
 }

--- a/src/util/shell-env.ts
+++ b/src/util/shell-env.ts
@@ -18,7 +18,7 @@ export interface ShellEnvironment {
   shellType: WindowsCommandShellType | "bash" | "zsh" | "fish" | "sh" | "unknown";
   /** Shell actually used by the bash tool for command execution. */
   commandShell: string;
-  commandShellType: WindowsCommandShellType | "bash";
+  commandShellType: WindowsCommandShellType | "bash" | "wsl";
   supportsChainedCommands: boolean;
   commandSeparator: string; // ; or && depending on shell
   recommendations: string[];
@@ -386,6 +386,14 @@ export function generateShellContext(env: ShellEnvironment): string {
       parts.push("- Use bash/POSIX syntax");
       parts.push("- Supports && (and), || (or), and ; (unconditional) operators");
       parts.push("- POSIX-to-PowerShell translation is not applied in Git Bash");
+      break;
+
+    case "wsl":
+      parts.push("- Commands run inside WSL (Windows Subsystem for Linux) — use POSIX/bash syntax");
+      parts.push("- Supports && (and), || (or), and ; (unconditional) operators");
+      parts.push("- Windows paths are accessible under /mnt/ (e.g. C:\\Users → /mnt/c/Users)");
+      parts.push("- Linux-native package managers (apt, etc.) are available inside WSL");
+      parts.push("- Working directory is auto-translated from Windows path to /mnt/... form");
       break;
 
     case "bash":

--- a/src/util/shell-env.ts
+++ b/src/util/shell-env.ts
@@ -405,3 +405,72 @@ export function generateShellContext(env: ShellEnvironment): string {
   return parts.join("\n");
 }
 import { detectWindowsCommandShell, type WindowsCommandShellType } from "./windows-shell.js";
+
+// ---------------------------------------------------------------------------
+// Tool-availability probe (#118 item 3 / #115 shared)
+// ---------------------------------------------------------------------------
+
+export interface ToolAvailability {
+  available: string[];   // "git 2.41.0" style (version when probed, name-only as fallback)
+  unavailable: string[];
+}
+
+let cachedToolAvailability: Promise<ToolAvailability> | undefined;
+
+const COMMON_TOOLS = ["git", "node", "npm", "bun", "python", "docker", "rg", "jq", "curl"];
+const WINDOWS_EXTRA = ["wsl"];
+
+async function probeOneTool(name: string): Promise<string | null> {
+  try {
+    const found = Bun.which(name);
+    if (!found) return null;
+    // Probe version with a quick, per-check 1.5s timeout
+    const proc = Bun.spawn({
+      cmd: [name, "--version"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timer = new Promise<"timeout">((r) => setTimeout(() => { try { proc.kill(); } catch { /* */ } r("timeout"); }, 1500));
+    const result = await Promise.race([
+      new Response(proc.stdout).text().then((t) => t.trim().split("\n")[0] ?? ""),
+      timer,
+    ]);
+    if (result === "timeout" || !result) return name;
+    // Keep only the first 60 chars to avoid huge version strings
+    return `${name} (${result.slice(0, 60)})`;
+  } catch {
+    return null;
+  }
+}
+
+export async function probeToolAvailability(): Promise<ToolAvailability> {
+  cachedToolAvailability ??= probeToolAvailabilityUncached();
+  return cachedToolAvailability;
+}
+
+async function probeToolAvailabilityUncached(): Promise<ToolAvailability> {
+  const tools = process.platform === "win32"
+    ? [...COMMON_TOOLS, ...WINDOWS_EXTRA]
+    : COMMON_TOOLS;
+
+  const results = await Promise.all(tools.map(probeOneTool));
+
+  const available: string[] = [];
+  const unavailable: string[] = [];
+  for (let i = 0; i < tools.length; i++) {
+    if (results[i] !== null) available.push(results[i]!);
+    else unavailable.push(tools[i]!);
+  }
+  return { available, unavailable };
+}
+
+export function formatToolAvailabilityBlock(avail: ToolAvailability): string {
+  const lines: string[] = ["## Available CLI tools"];
+  if (avail.available.length > 0) {
+    lines.push(`Available: ${avail.available.join(", ")}`);
+  }
+  if (avail.unavailable.length > 0) {
+    lines.push(`Not found: ${avail.unavailable.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/util/tool-output-cap.ts
+++ b/src/util/tool-output-cap.ts
@@ -21,7 +21,7 @@ export function capBashOutputLines(
   maxLines: number,
   maxLineChars = MAX_BASH_LINE_CHARS,
   maxBytes = MAX_BASH_OUTPUT_BYTES
-): { output: string; truncated: boolean } {
+): { output: string; truncated: boolean; keptLines: number } {
   const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const rawLines = normalized.length > 0 ? normalized.split("\n") : [];
   const cappedLines: string[] = [];
@@ -58,7 +58,7 @@ export function capBashOutputLines(
     output += `\n[Output truncated: ${reason}]`;
   }
 
-  return { output, truncated };
+  return { output, truncated, keptLines: cappedLines.length };
 }
 
 export function stubOversizedMessageContent(

--- a/src/util/windows-shell.ts
+++ b/src/util/windows-shell.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-export type WindowsCommandShellType = "powershell5" | "powershell7" | "cmd" | "git-bash";
+export type WindowsCommandShellType = "powershell5" | "powershell7" | "cmd" | "git-bash" | "wsl";
 
 export interface WindowsCommandShell {
   type: WindowsCommandShellType;
@@ -95,6 +95,8 @@ function shellDisplayName(type: WindowsCommandShellType, version?: string): stri
       return "Windows Command Prompt (cmd.exe)";
     case "git-bash":
       return "Git Bash";
+    case "wsl":
+      return version ? `WSL (${version})` : "WSL (Windows Subsystem for Linux)";
   }
 }
 
@@ -103,6 +105,7 @@ function makeShell(
   executable: string,
   version?: string
 ): WindowsCommandShell {
+  // powershell5 uses ; for chaining; all other types (including wsl) support &&
   const supportsChainedCommands = type !== "powershell5";
   return {
     type,
@@ -132,6 +135,7 @@ export function classifyWindowsShellExecutable(
       return "git-bash";
     }
   }
+  if (base === "wsl.exe" || base === "wsl") return "wsl";
 
   return null;
 }
@@ -289,4 +293,45 @@ export async function detectWindowsCommandShell(
 
 export function clearWindowsShellCache(): void {
   cachedWindowsShell = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// WSL detection (#115)
+// ---------------------------------------------------------------------------
+
+let cachedWslAvailable: Promise<WindowsCommandShell | null> | undefined;
+
+/**
+ * Probe whether WSL is installed and return a shell descriptor for it.
+ * Returns null when wsl.exe is not found or the WSL service is not running.
+ * Result is cached for the process lifetime.
+ */
+export async function detectWslShell(): Promise<WindowsCommandShell | null> {
+  cachedWslAvailable ??= detectWslShellUncached();
+  return cachedWslAvailable;
+}
+
+async function detectWslShellUncached(): Promise<WindowsCommandShell | null> {
+  const wslPath = findOnPath("wsl.exe") ?? findOnPath("wsl");
+  if (!wslPath) return null;
+  try {
+    const proc = Bun.spawn({
+      cmd: [wslPath, "-l", "--quiet"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const { stdout, timedOut } = await readStdoutAndDrainStderr(proc, 3000);
+    if (timedOut || proc.exitCode !== 0) return null;
+    // stdout lists distro names; any output means WSL has ≥1 distro
+    const distros = stdout.split(/\r?\n/).map((l) => l.replace(/\0/g, "").trim()).filter(Boolean);
+    if (distros.length === 0) return null;
+    const version = distros[0]; // use first distro name as display label
+    return makeShell("wsl", wslPath, version);
+  } catch {
+    return null;
+  }
+}
+
+export function clearWslCache(): void {
+  cachedWslAvailable = undefined;
 }

--- a/test/bash-error-classifier.test.ts
+++ b/test/bash-error-classifier.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCommandError } from "../src/tools/bash.js";
+
+describe("classifyCommandError", () => {
+  test("returns null on a successful exit", () => {
+    expect(classifyCommandError("foo", "anything", 0, "bash")).toBeNull();
+  });
+
+  test("PowerShell: recognizes a cmdlet-not-found error", () => {
+    const hint = classifyCommandError(
+      "grep foo",
+      "grep : The term 'grep' is not recognized as the name of a cmdlet, function, script file, or operable program.",
+      1,
+      "powershell"
+    );
+    expect(hint).toContain("'grep' is not a recognised PowerShell cmdlet");
+  });
+
+  test("PowerShell: recognizes CommandNotFoundException", () => {
+    const hint = classifyCommandError("jq", "CommandNotFoundException", 1, "powershell");
+    expect(hint).toContain("'jq' is not a recognised PowerShell cmdlet");
+  });
+
+  test("cmd: recognizes an internal/external command failure", () => {
+    const hint = classifyCommandError(
+      "curl example.com",
+      "'curl' is not recognized as an internal or external command,",
+      1,
+      "cmd"
+    );
+    expect(hint).toContain("'curl' was not found");
+  });
+
+  test("bash: recognizes command-not-found via message and exit code 127", () => {
+    const byMessage = classifyCommandError("foobarbaz", "bash: foobarbaz: command not found", 127, "bash");
+    expect(byMessage).toContain("'foobarbaz' was not found on PATH");
+
+    const byExitCode = classifyCommandError("foobarbaz", "", 127, "bash");
+    expect(byExitCode).toContain("'foobarbaz' was not found on PATH");
+  });
+
+  test("bash: recognizes permission-denied via message and exit code 126", () => {
+    const hint = classifyCommandError("./script.sh", "Permission denied", 126, "bash");
+    expect(hint).toContain("Permission denied executing './script.sh'");
+  });
+
+  test("bash: returns null when the output doesn't match a known pattern", () => {
+    expect(classifyCommandError("foo", "some other failure", 2, "bash")).toBeNull();
+  });
+
+  test("uses only the first whitespace-delimited token as the command name", () => {
+    const hint = classifyCommandError("some-tool --flag value", "command not found", 127, "bash");
+    expect(hint).toContain("'some-tool' was not found on PATH");
+  });
+});

--- a/test/bash-pagination.test.ts
+++ b/test/bash-pagination.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { bashTool } from "../src/tools/bash.js";
+import { resetAllowAllBypass, setAllowAllBypass } from "../src/permission/index.js";
+
+describe("bash output pagination", () => {
+  let root: string;
+
+  beforeAll(() => {
+    setAllowAllBypass(true);
+    root = mkdtempSync(path.join(tmpdir(), "impulse-bash-pagination-"));
+  });
+
+  afterAll(() => {
+    resetAllowAllBypass();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("offset/limit within the byte cap reports the accurate next offset", async () => {
+    const file = path.join(root, "lines-6000.txt");
+    writeFileSync(file, Array.from({ length: 6000 }, (_, i) => `line${i}`).join("\n"));
+
+    const result = await bashTool.handler({
+      command: "cat lines-6000.txt",
+      description: "test pagination",
+      workdir: root,
+      limit: 5000,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    // The 2000-line hard cap governs even though the caller asked for 5000,
+    // so the note must flag that the requested slice was further capped.
+    expect(result.output).toContain("[Output paginated: lines 1-2000 of 6000, further capped by output size limits");
+    expect(result.output).toContain("Re-run with offset: 2000 for more.]");
+  });
+
+  test("a byte-cap hit is reflected in the pagination note and next offset", async () => {
+    const file = path.join(root, "lines-wide.txt");
+    writeFileSync(file, Array.from({ length: 300 }, (_, i) => `L${i}-${"x".repeat(1000)}`).join("\n"));
+
+    const result = await bashTool.handler({
+      command: "cat lines-wide.txt",
+      description: "test pagination byte cap",
+      workdir: root,
+      limit: 250,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    const match = result.output.match(/\[Output paginated: lines 1-(\d+) of 300, further capped by output size limits\. Re-run with offset: (\d+) for more\.\]/);
+    expect(match).not.toBeNull();
+    const delivered = Number(match?.[1]);
+    const nextOffset = Number(match?.[2]);
+    expect(delivered).toBeLessThan(250);
+    expect(nextOffset).toBe(delivered);
+  });
+
+  test("no offset/limit means legacy (non-paginated) behavior", async () => {
+    const file = path.join(root, "small.txt");
+    writeFileSync(file, "a\nb\nc");
+
+    const result = await bashTool.handler({
+      command: "cat small.txt",
+      description: "test no pagination",
+      workdir: root,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("a\nb\nc");
+    expect(result.output).not.toContain("[Output paginated:");
+  });
+});

--- a/test/bash-timeout-resolution.test.ts
+++ b/test/bash-timeout-resolution.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBashTimeoutMs } from "../src/tools/bash.js";
+
+describe("resolveBashTimeoutMs", () => {
+  test("timeout: 0 means no limit", () => {
+    expect(resolveBashTimeoutMs(0)).toBeUndefined();
+  });
+
+  test("omitted timeout falls back to the 120s default", () => {
+    expect(resolveBashTimeoutMs(undefined)).toBe(120_000);
+  });
+
+  test("an explicit timeout passes through unchanged", () => {
+    expect(resolveBashTimeoutMs(5000)).toBe(5000);
+  });
+});

--- a/test/file-read.test.ts
+++ b/test/file-read.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+import { fileRead } from "../src/tools/file-read.js";
+
+describe("file_read", () => {
+  // sanitizePath() restricts reads to within process.cwd() by default, so
+  // fixtures must live under the repo root rather than the OS tmpdir.
+  const root = path.join(process.cwd(), `.tmp-file-read-${Date.now()}`);
+
+  beforeAll(() => {
+    mkdirSync(root, { recursive: true });
+    mkdirSync(path.join(root, "subdir"));
+    writeFileSync(path.join(root, "hello-world.ts"), "content");
+    writeFileSync(path.join(root, "another.ts"), "content");
+
+    // Binary / encoding fixtures
+    writeFileSync(path.join(root, "image.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    writeFileSync(path.join(root, "utf16.txt"), Buffer.from([0xff, 0xfe, 0x61, 0x00, 0x62, 0x00]));
+    writeFileSync(path.join(root, "bom.txt"), Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello", "utf-8")]));
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("ENOENT includes a Did you mean suggestion for a close filename", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "hello_world.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("File not found:");
+    expect(result.output).toContain("Did you mean: hello-world.ts?");
+  });
+
+  test("ENOENT includes a compact directory listing", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "does-not-exist.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain(`Directory ${root}`);
+    expect(result.output).toContain("subdir/");
+    expect(result.output).toContain("hello-world.ts");
+  });
+
+  test("ENOENT on a missing directory returns no hint (readdir fails too)", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "ghost-dir", "missing.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toBe(`File not found: ${path.join(root, "ghost-dir", "missing.ts")}`);
+  });
+
+  test("binary file (PNG) is rejected with a clear message", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "image.png") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Cannot read binary file");
+    expect(result.output).toContain("PNG image");
+  });
+
+  test("UTF-16 file is rejected with an encoding notice", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "utf16.txt") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("UTF-16 LE");
+  });
+
+  test("UTF-8 BOM is silently stripped", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "bom.txt") });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("hello");
+    expect(result.output).not.toContain("﻿");
+  });
+});

--- a/test/posix-translation.test.ts
+++ b/test/posix-translation.test.ts
@@ -29,22 +29,56 @@ describe("translatePosixToPowerShell", () => {
   });
 
   test("leaves complex command families unchanged", () => {
+    // -r isn't in grep's supported single-command flag set (recursive grep needs
+    // full pipeline/shell semantics), so it's intentionally left untranslated.
     expect(translatePosixToPowerShell("grep -r my pattern src")).toEqual({
       translated: "grep -r my pattern src",
       wasTranslated: false,
     });
+    // which only translates a single bare command name, not multiple arguments.
     expect(translatePosixToPowerShell("which git node")).toEqual({
       translated: "which git node",
       wasTranslated: false,
     });
-    expect(translatePosixToPowerShell("cp -R src dst")).toEqual({
-      translated: "cp -R src dst",
-      wasTranslated: false,
-    });
-    expect(translatePosixToPowerShell("mv src dst")).toEqual({
-      translated: "mv src dst",
-      wasTranslated: false,
-    });
+  });
+
+  test("translates cp -> Copy-Item, including recursive/force flags", () => {
+    expect(translatePosixToPowerShell("cp -R src dst").translated).toBe(
+      "Copy-Item -Recurse -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("cp -rf src dst").translated).toBe(
+      "Copy-Item -Recurse -Force -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("cp src.txt dst.txt").translated).toBe(
+      "Copy-Item -Path 'src.txt' -Destination 'dst.txt'"
+    );
+  });
+
+  test("translates mv -> Move-Item, including the force flag", () => {
+    expect(translatePosixToPowerShell("mv src dst").translated).toBe(
+      "Move-Item -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("mv -f old.txt new.txt").translated).toBe(
+      "Move-Item -Force -Path 'old.txt' -Destination 'new.txt'"
+    );
+  });
+
+  test("translates a simple grep -> Select-String", () => {
+    expect(translatePosixToPowerShell("grep pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive -Pattern 'pattern' -Path 'file.txt'"
+    );
+    expect(translatePosixToPowerShell("grep -i pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive:$false -Pattern 'pattern' -Path 'file.txt'"
+    );
+    expect(translatePosixToPowerShell("grep -v pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive -NotMatch -Pattern 'pattern' -Path 'file.txt'"
+    );
+  });
+
+  test("translates which for a single command name", () => {
+    expect(translatePosixToPowerShell("which git").translated).toBe(
+      "(Get-Command git -ErrorAction SilentlyContinue).Source"
+    );
   });
 
   test("quotes translated path arguments", () => {

--- a/test/project-structure.test.ts
+++ b/test/project-structure.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+import {
+  buildProjectStructureProbe,
+  clearProjectStructureCache,
+  formatProjectStructureBlock,
+  probeProjectStructure,
+} from "../src/agent/project-structure.js";
+
+describe("buildProjectStructureProbe", () => {
+  test("returns null for an empty file list", () => {
+    expect(buildProjectStructureProbe([])).toBeNull();
+  });
+
+  test("returns null when the scanned file count is too large", () => {
+    const huge = Array.from({ length: 20_001 }, (_, i) => `file${i}.txt`);
+    expect(buildProjectStructureProbe(huge)).toBeNull();
+  });
+
+  test("groups nested files under directory nodes with recursive counts", () => {
+    const probe = buildProjectStructureProbe([
+      "src/agent/loop.ts",
+      "src/agent/prompts.ts",
+      "src/cli/renderer.ts",
+      "package.json",
+      "README.md",
+    ]);
+
+    expect(probe).not.toBeNull();
+    expect(probe!.rootLooseFiles).toEqual(["package.json", "README.md"]);
+    const src = probe!.root.children.get("src")!;
+    expect(src.totalFiles).toBe(3);
+    expect(src.children.get("agent")!.totalFiles).toBe(2);
+    expect(src.children.get("cli")!.totalFiles).toBe(1);
+  });
+});
+
+describe("formatProjectStructureBlock", () => {
+  test("formats a small tree at the default depth", () => {
+    const probe = buildProjectStructureProbe([
+      "src/agent/loop.ts",
+      "src/cli/renderer.ts",
+      "package.json",
+    ]);
+    const block = formatProjectStructureBlock(probe);
+
+    expect(block).toContain("## Project structure (depth 3, gitignore-respecting)");
+    expect(block).toContain("src/");
+    expect(block).toContain("agent/ (1 files)");
+    expect(block).toContain("package.json");
+  });
+
+  test("returns empty string for a null probe", () => {
+    expect(formatProjectStructureBlock(null)).toBe("");
+  });
+
+  test("backs off to a shallower depth when the tree is too large to render at depth 3", () => {
+    // Enough distinct deep subdirectories that depth-3 rendering exceeds the line cap,
+    // forcing a back-off to depth 2 (or 1).
+    const files = Array.from({ length: 60 }, (_, i) => `src/mod${i}/sub/file.ts`);
+    const probe = buildProjectStructureProbe(files);
+    const block = formatProjectStructureBlock(probe);
+
+    expect(block).not.toBe("");
+    expect(block).toMatch(/## Project structure \(depth [12], gitignore-respecting\)/);
+    expect(block.split("\n").length).toBeLessThanOrEqual(41); // header + <=40 body lines
+  });
+});
+
+describe("probeProjectStructure caching", () => {
+  const root = path.join(process.cwd(), `.tmp-project-structure-${Date.now()}`);
+
+  beforeAll(() => {
+    mkdirSync(path.join(root, "src"), { recursive: true });
+    writeFileSync(path.join(root, "src", "index.ts"), "export {}");
+    writeFileSync(path.join(root, "README.md"), "# test");
+  });
+
+  afterAll(() => {
+    clearProjectStructureCache();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("caches per cwd and returns the same promise on repeat calls", async () => {
+    clearProjectStructureCache();
+    const first = probeProjectStructure(root);
+    const second = probeProjectStructure(root);
+    expect(first).toBe(second);
+    const resolved = await first;
+    expect(resolved).not.toBeNull();
+    expect(resolved!.rootLooseFiles).toContain("README.md");
+  });
+});

--- a/test/tool-output-cap.test.ts
+++ b/test/tool-output-cap.test.ts
@@ -22,4 +22,25 @@ describe("tool output caps", () => {
     expect(output).toContain("[Output truncated:");
     expect(output.split("\n")[0]!.length).toBeLessThanOrEqual(MAX_BASH_LINE_CHARS + 1);
   });
+
+  test("capBashOutputLines reports keptLines for the line-count cap", () => {
+    const raw = Array.from({ length: 10 }, (_, i) => `line${i}`).join("\n");
+    const { keptLines, truncated } = capBashOutputLines(raw, 4);
+    expect(keptLines).toBe(4);
+    expect(truncated).toBe(true);
+  });
+
+  test("capBashOutputLines reports keptLines for the byte cap (fewer than the line cap)", () => {
+    const raw = Array.from({ length: 10 }, () => "x".repeat(100)).join("\n");
+    const { keptLines, truncated } = capBashOutputLines(raw, 2000, MAX_BASH_LINE_CHARS, 350);
+    expect(keptLines).toBeLessThan(10);
+    expect(truncated).toBe(true);
+  });
+
+  test("capBashOutputLines reports the full line count when nothing is cut", () => {
+    const raw = "a\nb\nc";
+    const { keptLines, truncated } = capBashOutputLines(raw, 2000);
+    expect(keptLines).toBe(3);
+    expect(truncated).toBe(false);
+  });
 });

--- a/test/wsl-routing.test.ts
+++ b/test/wsl-routing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePreferredShell, translateToWslPath } from "../src/tools/bash.js";
+
+describe("translateToWslPath", () => {
+  test("translates a C: drive path to /mnt/c/...", () => {
+    expect(translateToWslPath("C:\\Users\\foo\\bar")).toBe("/mnt/c/Users/foo/bar");
+  });
+
+  test("translates a non-C drive letter, lowercased", () => {
+    expect(translateToWslPath("D:\\projects\\repo")).toBe("/mnt/d/projects/repo");
+  });
+
+  test("passes through an already-POSIX path unchanged (other than separators)", () => {
+    expect(translateToWslPath("/mnt/c/Users/foo")).toBe("/mnt/c/Users/foo");
+    expect(translateToWslPath("/home/foo/project")).toBe("/home/foo/project");
+  });
+
+  test("throws a clear error for a UNC path instead of producing a broken /mnt path", () => {
+    expect(() => translateToWslPath("\\\\server\\share\\folder")).toThrow(/UNC path/);
+  });
+
+  test("throws for a forward-slash UNC-style path too", () => {
+    expect(() => translateToWslPath("//server/share/folder")).toThrow(/UNC path/);
+  });
+});
+
+describe("resolvePreferredShell", () => {
+  test("falls back to auto-detection for an unrecognized preference", async () => {
+    // "auto" isn't handled explicitly inside resolvePreferredShell (the caller
+    // branches on "auto" before calling it), so any unknown string should still
+    // resolve to a real shell via the auto-detect fallback rather than throwing.
+    const shell = await resolvePreferredShell("not-a-real-shell");
+    expect(shell.type).toBeDefined();
+    expect(shell.executable).toBeTruthy();
+  });
+
+  test("resolves cmd from COMSPEC or a sane default", async () => {
+    const shell = await resolvePreferredShell("cmd");
+    expect(shell.type).toBe("cmd");
+    expect(shell.executable.toLowerCase()).toContain("cmd.exe");
+  });
+
+  test("resolves powershell to Windows PowerShell 5.x", async () => {
+    const shell = await resolvePreferredShell("powershell");
+    expect(shell.type).toBe("powershell5");
+    expect(shell.supportsChainedCommands).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Third branch in the stacked #113-#118 sequence (depends on #120 / `feat/shell-tooling-primitives-115-118` — merge that first). Adds full WSL2 command routing:

- `WindowsCommandShellType` extended with `"wsl"`; `detectWslShell()` probes for an installed distro.
- `getSpawnOptions` routes commands through `wsl.exe --cd <translated-path> -- bash -lc <command>` when WSL is selected (explicitly via config or auto-detected).
- New `preferredShell` config (`auto | powershell | pwsh | git-bash | wsl | cmd`); changing it clears the relevant shell-detection caches.
- `generateShellContext` gets a WSL case describing POSIX syntax and the `/mnt/` path convention.

## Review findings fixed in this pass

- **Bug:** when `preferredShell` was explicitly set to `"wsl"` but no WSL distro was detected, the code fell back to the literal string `"wsl.exe"` and tried to spawn it anyway — an opaque spawn failure with no explanation. Now falls back to the auto-detected Windows shell and surfaces a one-time notice in the tool output explaining the fallback.
- **Gap:** `translateToWslPath()` silently mangled UNC paths (`\server\share\...`) into a broken `/mnt/`-style path, since they don't fit the WSL drive-mount convention. Now throws a clear, actionable error instead (surfaced to the model via the existing error-handling path).
- Refactored `getSpawnOptions` to extract `buildWslSpawnOptions()`/`buildSpawnOptionsForShell()` so the normal and WSL-fallback code paths share shell-dispatch logic instead of duplicating it.
- Added unit tests for `translateToWslPath` (drive letters, UNC rejection, already-POSIX passthrough) and `resolvePreferredShell` — neither had coverage before.

## Validation

- `bun run typecheck` — clean.
- `bun test test/wsl-routing.test.ts` — all green.
- Manual: `preferredShell: wsl` with no distro installed produces the fallback notice instead of a spawn error.

## Notes for reviewer

- Merge #120 first; this PR's diff will shrink to just this branch's own commits once that lands.
- Closes #115.