### PR TITLE
feat: goal artifacts, plan completion overlay, PLAN interrogation persona

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0",
+        "typescript": "^5.9.3",
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/diff": "^8.0.0",
         "@types/node": "^22.10.0",
         "@types/semver": "^7.7.1",
-        "typescript": "^5.7.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "bun": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/diff": "^8.0.0",
     "@types/node": "^22.10.0",
     "@types/semver": "^7.7.1",
-    "typescript": "^5.7.0"
+    "typescript": "^5.9.3"
   },
   "bin": {
     "impulse": "dist/index.js"

--- a/prompts/core/mode-switch.md
+++ b/prompts/core/mode-switch.md
@@ -9,7 +9,7 @@ You should recognize when the conversation is shifting toward a different mode's
 | EXPLORE | PLAN | "I want to build...", "Let's create...", planning before execution |
 | EXPLORE | WORK | User explicitly wants to start coding |
 | EXPLORE | DEBUG | "Something's broken...", "This error...", "Why isn't..." |
-| PLAN | WORK | Plan is clear and user says "let's do it" |
+| PLAN | WORK | Plan artifacts complete; user approves via the completion overlay (execute/proceed) |
 | WORK | PLAN | Scope is unclear, cross-cutting, or requires architecture decisions |
 | Any | EXPLORE | "Wait, explain...", "I don't understand...", "Back up..." |
 

--- a/prompts/modes/plan.md
+++ b/prompts/modes/plan.md
@@ -23,8 +23,6 @@ Once interrogation is complete, produce `design.md`, `spec.md`, and `tasks.md` i
 - **revise** — re-interrogate only the changed scope (one `question` call, not a full restart)
 - **cancel** — stay in PLAN; treat the next message as a new planning request
 
-Planning mode. Research the problem, then produce spec-driven plan artifacts under the active plan revision.
-
 ### Core rule: latest revision wins
 
 - If planning runs more than once in this session, the **latest** plan revision is the only current context.

--- a/prompts/modes/plan.md
+++ b/prompts/modes/plan.md
@@ -1,5 +1,28 @@
 ## Mode: PLAN
 
+Planning mode. Act as a sharp product-manager / architect who surfaces hidden assumptions **before** writing a single spec line.
+
+### Interrogation persona (scale to complexity)
+
+Before producing artifacts, use the `question` tool to uncover unknowns — scaled by task complexity:
+
+- **Trivial** (one-liner UI change, 1 file, 0 risks): skip interrogation, go straight to artifacts.
+- **Moderate** (new feature, <5 files, clear requirements): ask 1–3 targeted questions — e.g. edge cases, rollback, data ownership.
+- **Complex** (cross-cutting, architecture impact, migration, external deps): ask 3–7 questions covering: scope creep risks, affected systems, constraints, testing strategy, phasing.
+
+Use **one topic per `question` call**. Recommended answers must appear in the options. Do **not** write "Question N:" in chat; use the `question` tool exclusively.
+
+After the user answers, write the artifacts. Only call `question` again if the answers reveal a new unknown.
+
+### Artifact-first flow
+
+Once interrogation is complete, produce `design.md`, `spec.md`, and `tasks.md` in the active revision. The approval overlay (`execute | proceed | revise | cancel`) appears when planning ends — respond to whichever path the user picks:
+
+- **execute** — user starts implementation immediately; offer `AGENT` mode guidance
+- **proceed** — user will direct next steps; stay ready to help
+- **revise** — re-interrogate only the changed scope (one `question` call, not a full restart)
+- **cancel** — stay in PLAN; treat the next message as a new planning request
+
 Planning mode. Research the problem, then produce spec-driven plan artifacts under the active plan revision.
 
 ### Core rule: latest revision wins

--- a/src/agent/goal-loop.ts
+++ b/src/agent/goal-loop.ts
@@ -5,7 +5,7 @@
 import { getProviderManager } from "../api/manager.js";
 import type { GoalState } from "../session/goal-state.js";
 
-export type GoalJudgeVerdict = "done" | "continue";
+export type GoalJudgeVerdict = "done" | "continue" | "judge_unavailable";
 
 export interface GoalJudgeResult {
   verdict: GoalJudgeVerdict;
@@ -18,7 +18,6 @@ DONE: <brief reason>
 or
 CONTINUE: <brief reason>`;
 
-/** Fail-open: continue on any judge error. */
 export async function judgeGoal(
   goal: GoalState,
   lastAssistantText: string,
@@ -26,7 +25,7 @@ export async function judgeGoal(
 ): Promise<GoalJudgeResult> {
   const model = judgeModel?.trim();
   if (!model) {
-    return { verdict: "continue", reason: "no judge model configured" };
+    return { verdict: "judge_unavailable", reason: "no judge model configured" };
   }
 
   try {
@@ -58,7 +57,7 @@ export async function judgeGoal(
     return { verdict: "continue", reason: "judge inconclusive" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { verdict: "continue", reason: `judge error (fail-open): ${msg}` };
+    return { verdict: "judge_unavailable", reason: `judge error: ${msg}` };
   }
 }
 

--- a/src/agent/goal-loop.ts
+++ b/src/agent/goal-loop.ts
@@ -18,10 +18,48 @@ DONE: <brief reason>
 or
 CONTINUE: <brief reason>`;
 
+const CHECKLIST_JUDGE_PROMPT = `You judge whether a coding agent has completed a plan's task checklist.
+The goal is complete ONLY when every task in tasks.md is done (checked off or explicitly reported complete).
+Reply with exactly one line:
+DONE: <brief reason>
+or
+CONTINUE: <which tasks remain>`;
+
+export interface JudgeMessage {
+  role: "system" | "user";
+  content: string;
+}
+
+/** Build the judge's [system, user] message pair, pure and unit-testable. */
+export function buildJudgeMessages(
+  goal: GoalState,
+  lastAssistantText: string,
+  planTasksMarkdown?: string
+): [JudgeMessage, JudgeMessage] {
+  if (planTasksMarkdown) {
+    return [
+      { role: "system", content: CHECKLIST_JUDGE_PROMPT },
+      {
+        role: "user",
+        content: `Goal: ${goal.text}\n\nPlan tasks.md (revision ${goal.planRevisionId ?? "unknown"}):\n${planTasksMarkdown.slice(0, 6000)}\n\nLast assistant message:\n${lastAssistantText.slice(0, 4000)}`,
+      },
+    ];
+  }
+
+  return [
+    { role: "system", content: JUDGE_PROMPT },
+    {
+      role: "user",
+      content: `Goal: ${goal.text}\n\nLast assistant message:\n${lastAssistantText.slice(0, 4000)}`,
+    },
+  ];
+}
+
 export async function judgeGoal(
   goal: GoalState,
   lastAssistantText: string,
-  judgeModel?: string
+  judgeModel?: string,
+  opts?: { planTasksMarkdown?: string }
 ): Promise<GoalJudgeResult> {
   const model = judgeModel?.trim();
   if (!model) {
@@ -31,17 +69,12 @@ export async function judgeGoal(
   try {
     const manager = await getProviderManager();
     const provider = manager.getProvider(model);
+    const messages = buildJudgeMessages(goal, lastAssistantText, opts?.planTasksMarkdown);
     const response = await provider.complete({
       model,
-      messages: [
-        { role: "system", content: JUDGE_PROMPT },
-        {
-          role: "user",
-          content: `Goal: ${goal.text}\n\nLast assistant message:\n${lastAssistantText.slice(0, 4000)}`,
-        },
-      ],
+      messages,
       stream: false,
-      max_tokens: 120,
+      max_tokens: 200,
       reasoningLevel: "off",
     });
 
@@ -61,6 +94,10 @@ export async function judgeGoal(
   }
 }
 
-export function buildGoalContinuationMessage(goal: GoalState): string {
-  return `Goal continuation (turn ${goal.turnsUsed + 1}/${goal.maxTurns}): ${goal.text}\nContinue working toward this goal. Finish concisely if context is tight.`;
+export function buildGoalContinuationMessage(goal: GoalState, opts?: { planTasksPath?: string }): string {
+  const base = `Goal continuation (turn ${goal.turnsUsed + 1}/${goal.maxTurns}): ${goal.text}\nContinue working toward this goal. Finish concisely if context is tight.`;
+  if (opts?.planTasksPath) {
+    return `${base}\nWork from the plan checklist at \`${opts.planTasksPath}\`; complete unchecked tasks in order and check them off.`;
+  }
+  return base;
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -96,6 +96,11 @@ import { setCurrentMode } from "../tools/mode-state";
 import { ADVISOR_GATE_MESSAGE, shouldBlockBeforeAdvisor } from "./advisor-gate.js";
 import { shouldRetryInEnglish } from "./language-guard.js";
 import type { Mode } from "../constants";
+import {
+  checkPlanCompletionHandoff,
+  planCompletionToolBehavior,
+  type PlanCompletionDecision,
+} from "./plan-completion.js";
 import { modelSupportsVision } from "../api/capabilities.js";
 import type { PromptSegment } from "../cli/prompt-input.js";
 import { buildUserMessageContent, normalizePasteContent } from "../cli/prompt-input.js";
@@ -139,6 +144,14 @@ export interface LoopEvents {
     summary: string;
     planMarkdown: string;
   }) => Promise<"proceed" | "decline">;
+  /**
+   * Block until the user decides how to handle a PLAN → AGENT handoff once
+   * plan artifacts (tasks.md) exist. Intercepts set_mode("AGENT") from PLAN.
+   */
+  onPlanCompletion?: (input: {
+    planPath: string;
+    summary: string;
+  }) => Promise<PlanCompletionDecision>;
   /** Tool call lifecycle */
   onToolStart(id: string, name: string, args: Record<string, unknown>): void;
   onToolEnd(
@@ -356,7 +369,10 @@ export class AgentLoop {
       this.pendingImages = [];
 
       // ── Tool definitions ───────────────────────────────────────────────────
-      const toolDefs: ToolDefinition[] = Tool.getAPIDefinitionsForMode(mode);
+      // let: reassigned when the PLAN-completion handoff switches mode mid-turn
+      // (see checkPlanCompletionHandoff below) so subsequent iterations of this
+      // same turn see the AGENT tool set instead of the stale PLAN one.
+      let toolDefs: ToolDefinition[] = Tool.getAPIDefinitionsForMode(mode);
 
       // Add consult_advisor tool if experimental advisor is enabled
       if (
@@ -1029,6 +1045,45 @@ export class AgentLoop {
           }
 
           await flushTaskBatch();
+
+          // PLAN → AGENT handoff: when the model calls set_mode("AGENT") from
+          // PLAN mode with plan artifacts (tasks.md) already written, show the
+          // execute/proceed/revise/cancel overlay instead of switching modes
+          // silently. Bus events can't await a user decision, so this has to
+          // be intercepted here in the tool loop (mirrors the advisor
+          // consult_advisor special-case above).
+          if (
+            tc.name === "set_mode" &&
+            args["mode"] === "AGENT" &&
+            events.onPlanCompletion
+          ) {
+            const handoff = checkPlanCompletionHandoff(mode, "AGENT", session.id);
+            if (handoff) {
+              const toolStart = Date.now();
+              events.onToolStart(tc.id, "set_mode", args);
+
+              const decision = await events.onPlanCompletion({
+                planPath: handoff.planDirRel,
+                summary: String(args["reason"] ?? ""),
+              });
+              const behavior = planCompletionToolBehavior(decision, handoff.tasksPathRel);
+
+              let switchResult: ToolResult;
+              if (behavior.performSwitch) {
+                switchResult = await Tool.execute(tc.name, args);
+                mode = "AGENT";
+                toolDefs = Tool.getAPIDefinitionsForMode("AGENT");
+              } else {
+                switchResult = { success: true, output: `Mode switched to ${mode}` };
+              }
+
+              const output = `${switchResult.output}\n\n${behavior.output}`;
+              const durationMs = Date.now() - toolStart;
+              await persistToolResult(tc.id, output);
+              events.onToolEnd(tc.id, "set_mode", { success: switchResult.success, output }, durationMs);
+              continue;
+            }
+          }
 
           // Question requires a questions array — fail fast with a clear tool row.
           if (

--- a/src/agent/plan-completion.ts
+++ b/src/agent/plan-completion.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import { getActivePlanRevision } from "../plan/revisions.js";
+import { toRelativePlanPath } from "../plan/paths.js";
+import type { Mode } from "../constants.js";
+
+/**
+ * Decision values for PLAN mode completion.
+ *
+ * execute — switch to AGENT and immediately run tasks.md
+ * proceed — switch to AGENT and await the next user turn
+ * revise  — stay in PLAN, end agent turn, prompt "what to revise?"
+ * cancel  — stay in PLAN, discard the handoff
+ */
+export type PlanCompletionDecision = "execute" | "proceed" | "revise" | "cancel";
+
+export interface PlanCompletionHandoff {
+  planDirRel: string;
+  tasksPathRel: string;
+}
+
+/**
+ * Detect whether a set_mode(AGENT) call issued from PLAN mode should be
+ * intercepted by the plan-completion overlay instead of switching modes
+ * silently. Returns null when the handoff doesn't apply: wrong mode
+ * transition, no active plan revision, or tasks.md hasn't been written yet.
+ */
+export function checkPlanCompletionHandoff(
+  currentMode: Mode,
+  requestedMode: string,
+  sessionId: string,
+  cwd = process.cwd()
+): PlanCompletionHandoff | null {
+  if (currentMode !== "PLAN" || requestedMode !== "AGENT") return null;
+
+  const revision = getActivePlanRevision(sessionId, cwd);
+  if (!revision) return null;
+
+  const tasksPath = revision.files["tasks.md"];
+  if (!tasksPath || !fs.existsSync(tasksPath)) return null;
+
+  return {
+    planDirRel: toRelativePlanPath(revision.dir, cwd),
+    tasksPathRel: toRelativePlanPath(tasksPath, cwd),
+  };
+}
+
+export interface PlanCompletionBehavior {
+  /** Whether the real set_mode tool call should actually run (switch to AGENT). */
+  performSwitch: boolean;
+  /** Instruction text appended to the set_mode tool result. */
+  output: string;
+}
+
+/** Map a user's plan-completion decision to loop behavior + tool-result text. */
+export function planCompletionToolBehavior(
+  decision: PlanCompletionDecision,
+  tasksPathRel: string
+): PlanCompletionBehavior {
+  switch (decision) {
+    case "execute":
+      return {
+        performSwitch: true,
+        output: `User chose EXECUTE — immediately read ${tasksPathRel} and implement its tasks in order, checking them off as you complete them. Do not wait for further input.`,
+      };
+    case "proceed":
+      return {
+        performSwitch: true,
+        output: `User chose PROCEED — mode is now AGENT. Briefly confirm the handoff and end your turn; wait for the user's next instruction before implementing.`,
+      };
+    case "revise":
+      return {
+        performSwitch: false,
+        output: `User chose REVISE — stay in PLAN mode. Ask the user what they want revised (one direct question or a single question tool call), then end your turn.`,
+      };
+    case "cancel":
+      return {
+        performSwitch: false,
+        output: `User cancelled the handoff — remain in PLAN mode and end your turn.`,
+      };
+  }
+}

--- a/src/agent/project-structure.ts
+++ b/src/agent/project-structure.ts
@@ -1,0 +1,181 @@
+import path from "path";
+import { readdir } from "fs/promises";
+
+const PROBE_TIMEOUT_MS = 1500;
+const MAX_RENDER_DEPTH = 3;
+const MAX_BLOCK_LINES = 40;
+const MAX_BLOCK_CHARS = 2000;
+/** Beyond this many scanned files the block is skipped entirely (huge repos). */
+const MAX_SCANNED_FILES = 20_000;
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "coverage"]);
+
+interface DirNode {
+  files: number;
+  totalFiles: number;
+  children: Map<string, DirNode>;
+}
+
+function newDirNode(): DirNode {
+  return { files: 0, totalFiles: 0, children: new Map() };
+}
+
+/** Insert a repo-relative file path (posix or win32 separators) into the tree. */
+function insertPath(root: DirNode, relPath: string): void {
+  const segments = relPath.split(/[\\/]/).filter(Boolean);
+  if (segments.length === 0) return;
+  segments.pop(); // drop the file name; only directory segments are tracked
+
+  let node = root;
+  root.totalFiles++;
+  for (const segment of segments) {
+    let child = node.children.get(segment);
+    if (!child) {
+      child = newDirNode();
+      node.children.set(segment, child);
+    }
+    child.totalFiles++;
+    node = child;
+  }
+  node.files++;
+}
+
+async function probeGitFiles(cwd: string): Promise<string[] | null> {
+  try {
+    const proc = Bun.spawn({
+      cmd: ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timer = new Promise<"timeout">((resolve) =>
+      setTimeout(() => {
+        try {
+          proc.kill();
+        } catch {
+          /* ignore */
+        }
+        resolve("timeout");
+      }, PROBE_TIMEOUT_MS)
+    );
+    const result = await Promise.race([new Response(proc.stdout).text(), timer]);
+    if (result === "timeout") return null;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    return result.split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+async function walkFallback(dir: string, cwd: string, out: string[], depth = 0): Promise<void> {
+  if (out.length >= MAX_SCANNED_FILES || depth > 8) return;
+
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (out.length >= MAX_SCANNED_FILES) return;
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      await walkFallback(path.join(dir, entry.name), cwd, out, depth + 1);
+    } else {
+      out.push(path.relative(cwd, path.join(dir, entry.name)));
+    }
+  }
+}
+
+/** Render a directory's children, collapsing to a file-count summary past maxDepth or leaf dirs. */
+function renderDir(node: DirNode, name: string, depth: number, maxDepth: number, indent: string): string[] {
+  if (depth >= maxDepth || node.children.size === 0) {
+    return [`${indent}${name}/ (${node.totalFiles} files)`];
+  }
+  const lines = [`${indent}${name}/`];
+  const sortedChildren = [...node.children.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [childName, child] of sortedChildren) {
+    lines.push(...renderDir(child, childName, depth + 1, maxDepth, `${indent}  `));
+  }
+  return lines;
+}
+
+function renderTree(root: DirNode, maxDepth: number): string[] {
+  const lines: string[] = [];
+  const sortedDirs = [...root.children.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  for (const [name, child] of sortedDirs) {
+    lines.push(...renderDir(child, name, 1, maxDepth, ""));
+  }
+  return lines;
+}
+
+export interface ProjectStructureProbe {
+  root: DirNode;
+  rootLooseFiles: string[];
+}
+
+/** Build a probe tree from a flat list of repo-relative file paths (pure, for tests). */
+export function buildProjectStructureProbe(files: string[]): ProjectStructureProbe | null {
+  if (files.length === 0 || files.length > MAX_SCANNED_FILES) return null;
+
+  const root = newDirNode();
+  const rootLooseFiles: string[] = [];
+  for (const rel of files) {
+    const segments = rel.split(/[\\/]/).filter(Boolean);
+    if (segments.length === 1) {
+      rootLooseFiles.push(segments[0]!);
+      root.files++;
+      root.totalFiles++;
+    } else {
+      insertPath(root, rel);
+    }
+  }
+  rootLooseFiles.sort((a, b) => a.localeCompare(b));
+
+  return { root, rootLooseFiles };
+}
+
+async function probeProjectStructureUncached(cwd: string): Promise<ProjectStructureProbe | null> {
+  const gitFiles = await probeGitFiles(cwd);
+  const files = gitFiles ?? (await (async () => {
+    const out: string[] = [];
+    await walkFallback(cwd, cwd, out);
+    return out;
+  })());
+
+  return buildProjectStructureProbe(files);
+}
+
+let cachedCwd: string | null = null;
+let cachedProbe: Promise<ProjectStructureProbe | null> | undefined;
+
+export function probeProjectStructure(cwd = process.cwd()): Promise<ProjectStructureProbe | null> {
+  if (cachedCwd !== cwd) {
+    cachedCwd = cwd;
+    cachedProbe = undefined;
+  }
+  cachedProbe ??= probeProjectStructureUncached(cwd);
+  return cachedProbe;
+}
+
+export function clearProjectStructureCache(): void {
+  cachedCwd = null;
+  cachedProbe = undefined;
+}
+
+export function formatProjectStructureBlock(probe: ProjectStructureProbe | null): string {
+  if (!probe) return "";
+
+  for (const maxDepth of [MAX_RENDER_DEPTH, 2, 1]) {
+    const lines = renderTree(probe.root, maxDepth);
+    if (probe.rootLooseFiles.length > 0) {
+      lines.push(probe.rootLooseFiles.join("  "));
+    }
+    const body = lines.join("\n");
+    if (lines.length <= MAX_BLOCK_LINES && body.length <= MAX_BLOCK_CHARS) {
+      return `## Project structure (depth ${maxDepth}, gitignore-respecting)\n${body}`;
+    }
+  }
+  return "";
+}

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -483,15 +483,20 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     "../git/repo-context.js"
   );
   const { probeGhCli, formatGhCliPromptBlock } = await import("../git/gh-cli.js");
+  const { probeToolAvailability, formatToolAvailabilityBlock } = await import(
+    "../util/shell-env.js"
+  );
 
   const repoContext = resolveRepoContext(workingDir);
   const ghStatus = probeGhCli();
+  const toolAvailability = await probeToolAvailability();
 
   const parts: string[] = [
     getPrompt("core", "base", BASE_PROMPT),
     cwdContext,
     formatRepoContextPromptBlock(repoContext),
     formatGhCliPromptBlock(ghStatus),
+    formatToolAvailabilityBlock(toolAvailability),
   ];
 
   const projectInstructions = await loadInstructions(workingDir);

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -374,9 +374,17 @@ This helps you understand where the conversation is heading.
   PLAN: `
 ## Mode: PLAN
 
-Planning mode — research first, then write spec-driven plan artifacts. Latest plan revision is always current context.
+Act as a sharp product-manager / architect who surfaces hidden assumptions before writing a single spec line. Research first, then write spec-driven plan artifacts. Latest plan revision is always current context.
 
 See injected "Active plan" block below for revision paths. Use \`plan_revision\` when the user reworks the plan.
+
+### Interrogation (scale to complexity)
+
+Before writing artifacts, use the \`question\` tool to surface unknowns — one topic per call, never plain-text "Question N:" in chat: trivial changes skip interrogation; moderate features get 1-3 targeted questions; complex/cross-cutting work gets 3-7 covering scope creep, affected systems, constraints, testing, phasing.
+
+### Artifact-first flow
+
+Once interrogation is complete, write the plan artifacts. Switching to AGENT afterward shows an execute/proceed/revise/cancel overlay, not a silent mode change: **execute** starts implementation immediately, **proceed** waits for the user's next instruction, **revise** stays in PLAN and re-interrogates only the changed scope, **cancel** stays in PLAN and treats the next message as a new request.
 
 ### Capabilities
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -486,10 +486,14 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
   const { probeToolAvailability, formatToolAvailabilityBlock } = await import(
     "../util/shell-env.js"
   );
+  const { probeProjectStructure, formatProjectStructureBlock } = await import(
+    "./project-structure.js"
+  );
 
   const repoContext = resolveRepoContext(workingDir);
   const ghStatus = probeGhCli();
   const toolAvailability = await probeToolAvailability();
+  const projectStructure = await probeProjectStructure(workingDir);
 
   const parts: string[] = [
     getPrompt("core", "base", BASE_PROMPT),
@@ -498,6 +502,11 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     formatGhCliPromptBlock(ghStatus),
     formatToolAvailabilityBlock(toolAvailability),
   ];
+
+  const projectStructureBlock = formatProjectStructureBlock(projectStructure);
+  if (projectStructureBlock) {
+    parts.push(projectStructureBlock);
+  }
 
   const projectInstructions = await loadInstructions(workingDir);
   if (projectInstructions) {

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -580,7 +580,16 @@ Advisor output is ADVISORY — trust-but-verify against code and logs.`);
       const statusLine = activeGoal.status === "active"
         ? `Status: active (turn ${activeGoal.turnsUsed}/${activeGoal.maxTurns})`
         : `Status: ${activeGoal.status}`;
-      parts.push(`## Active goal\n\n${activeGoal.text}\n\n${statusLine}\n\nContinue working toward this goal unless the user redirects you.`);
+      let planNote = "";
+      if (activeGoal.planRevisionId) {
+        const { getRevisionDir, toRelativePlanPath } = await import("../plan/paths.js");
+        const tasksPathRel = toRelativePlanPath(
+          `${getRevisionDir(options.sessionId, activeGoal.planRevisionId, workingDir)}/tasks.md`,
+          workingDir
+        );
+        planNote = `\n\nThis goal tracks plan revision \`${activeGoal.planRevisionId}\`. Execute the tasks in \`${tasksPathRel}\` and check each off (\`- [x]\`) as you complete it.`;
+      }
+      parts.push(`## Active goal\n\n${activeGoal.text}\n\n${statusLine}${planNote}\n\nContinue working toward this goal unless the user redirects you.`);
     }
   }
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -555,6 +555,18 @@ Advisor output is ADVISORY — trust-but-verify against code and logs.`);
     parts.push(buildPlanModeContextBlock(options.sessionId, workingDir));
   }
 
+  // Active-goal context: inject when a goal is set so it survives /compact
+  if (options?.sessionId) {
+    const { readGoalArtifact } = await import("../goal/artifact.js");
+    const activeGoal = readGoalArtifact(options.sessionId, workingDir);
+    if (activeGoal && activeGoal.status !== "done") {
+      const statusLine = activeGoal.status === "active"
+        ? `Status: active (turn ${activeGoal.turnsUsed}/${activeGoal.maxTurns})`
+        : `Status: ${activeGoal.status}`;
+      parts.push(`## Active goal\n\n${activeGoal.text}\n\n${statusLine}\n\nContinue working toward this goal unless the user redirects you.`);
+    }
+  }
+
   const allowAllBlock = buildAllowAllBypassPromptBlock();
   if (allowAllBlock) {
     parts.push(allowAllBlock);

--- a/src/cli/components/plan-completion-overlay.ts
+++ b/src/cli/components/plan-completion-overlay.ts
@@ -1,0 +1,104 @@
+import { type Component } from "@mariozechner/pi-tui";
+import { overlayBoxWidth } from "../layout.js";
+import {
+  overlayBottomBorder,
+  overlayEmptyLine,
+  overlayPushWrapped,
+  overlayTitleLine,
+  overlaySideLine,
+  overlayAnsi,
+  OVERLAY_SELECT_BG,
+  OVERLAY_SELECT_FG,
+  OVERLAY_MUTED_FG,
+} from "./overlay-theme.js";
+
+/**
+ * Decision values for PLAN mode completion.
+ *
+ * execute — switch to AGENT and immediately run tasks.md
+ * proceed — switch to AGENT and await the next user turn
+ * revise  — stay in PLAN, end agent turn, prompt "what to revise?"
+ * cancel  — stay in PLAN, discard the handoff
+ */
+export type PlanCompletionDecision = "execute" | "proceed" | "revise" | "cancel";
+
+export interface PlanCompletionOverlayInput {
+  planPath: string;
+  summary: string;
+}
+
+const OPTIONS: Array<{ key: string; label: string; value: PlanCompletionDecision }> = [
+  { key: "1", label: "Execute", value: "execute" },
+  { key: "2", label: "Proceed", value: "proceed" },
+  { key: "3", label: "Revise",  value: "revise"  },
+  { key: "4", label: "Cancel",  value: "cancel"  },
+];
+
+export class PlanCompletionOverlay implements Component {
+  private readonly planPath: string;
+  private readonly summary: string;
+  private selectedIndex = 0;
+
+  onDecision?: (decision: PlanCompletionDecision) => void;
+
+  constructor(input: PlanCompletionOverlayInput) {
+    this.planPath = input.planPath;
+    this.summary = input.summary;
+  }
+
+  invalidate(): void {}
+
+  handleInput(data: string): void {
+    if (data === "\x1b" || data === "\x03" || data === "4" || data.toLowerCase() === "q") {
+      this.onDecision?.("cancel");
+      return;
+    }
+    if (data === "1" || data === "\r") {
+      this.onDecision?.(OPTIONS[this.selectedIndex]?.value ?? "proceed");
+      return;
+    }
+    if (data === "2") { this.onDecision?.("proceed"); return; }
+    if (data === "3") { this.onDecision?.("revise");  return; }
+
+    // Arrow navigation
+    if (data === "\x1b[D" || data === "h") {
+      this.selectedIndex = (this.selectedIndex - 1 + OPTIONS.length) % OPTIONS.length;
+    }
+    if (data === "\x1b[C" || data === "l") {
+      this.selectedIndex = (this.selectedIndex + 1) % OPTIONS.length;
+    }
+  }
+
+  render(width: number): string[] {
+    const boxWidth = overlayBoxWidth(width);
+    const innerWidth = Math.max(20, boxWidth - 4);
+    const lines: string[] = [];
+
+    lines.push(overlayTitleLine("Plan ready", boxWidth));
+    lines.push(overlayEmptyLine(boxWidth));
+    overlayPushWrapped(lines, `Path: ${this.planPath}`, innerWidth, boxWidth);
+    lines.push(overlayEmptyLine(boxWidth));
+    if (this.summary.trim()) {
+      overlayPushWrapped(lines, `Summary: ${this.summary.slice(0, 200)}`, innerWidth, boxWidth);
+      lines.push(overlayEmptyLine(boxWidth));
+    }
+
+    // Build option buttons row
+    const buttons = OPTIONS.map((opt, i) => {
+      const isSelected = i === this.selectedIndex;
+      const label = `[${opt.key}] ${opt.label}`;
+      if (isSelected) {
+        return `\x1b[48;5;${OVERLAY_SELECT_BG}m\x1b[38;5;${OVERLAY_SELECT_FG}m ${label} \x1b[0m`;
+      }
+      return overlayAnsi.fg(OVERLAY_MUTED_FG, ` ${label} `);
+    }).join("  ");
+
+    const hint = overlayAnsi.fg(OVERLAY_MUTED_FG, "← → navigate  Enter select  Esc cancel");
+    overlaySideLine(buttons, innerWidth, boxWidth);
+    lines.push(overlaySideLine(buttons, innerWidth, boxWidth));
+    lines.push(overlayEmptyLine(boxWidth));
+    lines.push(overlaySideLine(hint, innerWidth, boxWidth));
+    lines.push(overlayBottomBorder(boxWidth));
+    return lines;
+  }
+}

--- a/src/cli/components/plan-completion-overlay.ts
+++ b/src/cli/components/plan-completion-overlay.ts
@@ -11,16 +11,9 @@ import {
   OVERLAY_SELECT_FG,
   OVERLAY_MUTED_FG,
 } from "./overlay-theme.js";
+import type { PlanCompletionDecision } from "../../agent/plan-completion.js";
 
-/**
- * Decision values for PLAN mode completion.
- *
- * execute — switch to AGENT and immediately run tasks.md
- * proceed — switch to AGENT and await the next user turn
- * revise  — stay in PLAN, end agent turn, prompt "what to revise?"
- * cancel  — stay in PLAN, discard the handoff
- */
-export type PlanCompletionDecision = "execute" | "proceed" | "revise" | "cancel";
+export type { PlanCompletionDecision } from "../../agent/plan-completion.js";
 
 export interface PlanCompletionOverlayInput {
   planPath: string;
@@ -53,7 +46,11 @@ export class PlanCompletionOverlay implements Component {
       this.onDecision?.("cancel");
       return;
     }
-    if (data === "1" || data === "\r") {
+    if (data === "1") {
+      this.onDecision?.("execute");
+      return;
+    }
+    if (data === "\r") {
       this.onDecision?.(OPTIONS[this.selectedIndex]?.value ?? "proceed");
       return;
     }
@@ -94,7 +91,6 @@ export class PlanCompletionOverlay implements Component {
     }).join("  ");
 
     const hint = overlayAnsi.fg(OVERLAY_MUTED_FG, "← → navigate  Enter select  Esc cancel");
-    overlaySideLine(buttons, innerWidth, boxWidth);
     lines.push(overlaySideLine(buttons, innerWidth, boxWidth));
     lines.push(overlayEmptyLine(boxWidth));
     lines.push(overlaySideLine(hint, innerWidth, boxWidth));

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -212,6 +212,10 @@ import {
   type GoalState,
 } from "../session/goal-state.js";
 import { buildGoalContinuationMessage, judgeGoal } from "../agent/goal-loop.js";
+import {
+  writeGoalArtifact,
+  readGoalArtifact,
+} from "../goal/artifact.js";
 import { invalidatePromptCache } from "../agent/prompts.js";
 import { getRepairTelemetrySummary } from "../harness/repair-telemetry.js";
 import {
@@ -1204,12 +1208,27 @@ export class ImpulseRenderer {
   private async persistGoalState(): Promise<void> {
     const session = SessionManager.getCurrentSession();
     if (!session) return;
+    // Write to .impulse/goals/ artifact (primary) and keep metadata key for
+    // backward compat with older sessions that only have the metadata path.
+    if (this.goalState) {
+      try {
+        await writeGoalArtifact(session.id, this.goalState);
+      } catch {
+        // Non-fatal: fall back to metadata-only path
+      }
+    }
     const metadata = { ...(session.metadata ?? {}), goal: this.goalState };
     await SessionManager.update({ metadata });
   }
 
   private loadGoalFromSession(session: Session): void {
-    this.goalState = parseGoalState(session.metadata?.["goal"]);
+    // Prefer artifact if available; fall back to legacy session.metadata['goal'].
+    const fromArtifact = readGoalArtifact(session.id);
+    this.goalState = fromArtifact ?? parseGoalState(session.metadata?.["goal"]);
+    // One-time migration: if we loaded from metadata but have no artifact yet, write the artifact.
+    if (!fromArtifact && this.goalState) {
+      void writeGoalArtifact(session.id, this.goalState).catch(() => { /* non-fatal */ });
+    }
   }
 
   private goalLoopActive(): boolean {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -111,6 +111,10 @@ import { SessionPickerOverlay } from "./components/session-picker-overlay.js";
 import { ProfileOverlay } from "./components/profile-overlay.js";
 import { SelectableListOverlay } from "./components/selectable-list-overlay.js";
 import { PlanApprovalOverlay } from "./components/plan-approval-overlay.js";
+import {
+  PlanCompletionOverlay,
+  type PlanCompletionDecision,
+} from "./components/plan-completion-overlay.js";
 import { AllowAllDisclaimerOverlay } from "./components/allow-all-disclaimer-overlay.js";
 import { ExperimentalOverlay } from "./components/experimental-overlay.js";
 import {
@@ -1486,6 +1490,8 @@ export class ImpulseRenderer {
   private modelSetup: ModelSetupState | null = null;
   private planApprovalOverlayHandle: OverlayHandle | null = null;
   private planApprovalInputCleanup: (() => void) | null = null;
+  private planCompletionOverlayHandle: OverlayHandle | null = null;
+  private planCompletionInputCleanup: (() => void) | null = null;
   private helpInputCleanup: (() => void) | null = null;
   private experimentalOverlayHandle: OverlayHandle | null = null;
   private settingsOverlayHandle: OverlayHandle | null = null;
@@ -2495,6 +2501,7 @@ export class ImpulseRenderer {
         this.tui.requestRender();
       },
       onPlanApproval: (input) => this.showPlanApprovalOverlay(input),
+      onPlanCompletion: (input) => this.showPlanCompletionOverlay(input),
       onTaskBatchPermission: (input) => this.showTaskBatchPermission(input.count),
       onLoopCheckin: (input) => this.showLoopCheckin(input),
       onSubagentTaskStatus: (id, status) => {
@@ -2854,6 +2861,68 @@ export class ImpulseRenderer {
     this.planApprovalInputCleanup = null;
     this.planApprovalOverlayHandle?.hide();
     this.planApprovalOverlayHandle = null;
+  }
+
+  /** Block agent loop until user picks execute/proceed/revise/cancel for a completed plan. */
+  private async showPlanCompletionOverlay(input: {
+    planPath: string;
+    summary: string;
+  }): Promise<PlanCompletionDecision> {
+    if (!this.tui) return "cancel";
+
+    const shortPath = input.planPath.replace(
+      new RegExp(`^${os.homedir().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`),
+      "~"
+    );
+
+    const overlay = new PlanCompletionOverlay({
+      planPath: shortPath,
+      summary: input.summary,
+    });
+
+    return new Promise<PlanCompletionDecision>((resolve) => {
+      this.dismissPlanCompletionOverlay();
+
+      const handle = this.tui.showOverlay(overlay, {
+        anchor: "bottom-center",
+        offsetY: -4,
+        width: "100%",
+        minWidth: this.overlayMin(),
+        maxHeight: LIST_OVERLAY_MAX_HEIGHT,
+        margin: this.listOverlayMargin(),
+      });
+      this.planCompletionOverlayHandle = handle;
+      this.setBusyStatus("Waiting for plan decision ...", "Plan ready...");
+      handle.focus();
+
+      const decisionLines: Record<PlanCompletionDecision, string> = {
+        execute: "Plan approved — executing tasks now",
+        proceed: "Plan approved — mode switched to AGENT",
+        revise: "Revising plan — staying in PLAN mode",
+        cancel: "Plan handoff cancelled — staying in PLAN mode",
+      };
+
+      overlay.onDecision = (decision) => {
+        this.dismissPlanCompletionOverlay();
+        this.addChatLine(advisorStatusLine(decisionLines[decision]));
+        this.tui.setFocus(this.promptInput);
+        this.tui.requestRender();
+        resolve(decision);
+      };
+
+      this.planCompletionInputCleanup = this.tui.addInputListener((data: string) => {
+        overlay.handleInput(data);
+        this.tui.requestRender();
+        return { consume: true };
+      });
+    });
+  }
+
+  private dismissPlanCompletionOverlay(): void {
+    this.planCompletionInputCleanup?.();
+    this.planCompletionInputCleanup = null;
+    this.planCompletionOverlayHandle?.hide();
+    this.planCompletionOverlayHandle = null;
   }
 
   /** Request a layout refresh after content above the prompt changes. */

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -217,6 +217,12 @@ import {
 } from "../session/goal-state.js";
 import { buildGoalContinuationMessage, judgeGoal } from "../agent/goal-loop.js";
 import {
+  getActivePlanRevision,
+  listRevisionIds,
+  readPlanTasksMarkdown,
+} from "../plan/revisions.js";
+import { getRevisionDir, toRelativePlanPath } from "../plan/paths.js";
+import {
   writeGoalArtifact,
   readGoalArtifact,
 } from "../goal/artifact.js";
@@ -1262,10 +1268,27 @@ export class ImpulseRenderer {
 
     const cfg = await loadConfig();
     const judgeModel = cfg.subagentModel?.trim() || cfg.defaultModel?.trim();
+
+    let planTasksMarkdown: string | undefined;
+    let planTasksPath: string | undefined;
+    if (activeGoal.planRevisionId) {
+      const sessionId = SessionManager.getCurrentSessionID() ?? "";
+      const tasks = readPlanTasksMarkdown(sessionId, activeGoal.planRevisionId);
+      if (tasks) {
+        planTasksMarkdown = tasks;
+        planTasksPath = toRelativePlanPath(getRevisionDir(sessionId, activeGoal.planRevisionId));
+      } else {
+        void this.emitStatusEvent(
+          `Plan revision ${activeGoal.planRevisionId} not found — judging against goal text only.`
+        );
+      }
+    }
+
     const result = await judgeGoal(
       activeGoal,
       this.lastAssistantTurnText,
-      judgeModel
+      judgeModel,
+      planTasksMarkdown ? { planTasksMarkdown } : undefined
     );
 
     if (result.verdict === "done") {
@@ -1314,7 +1337,10 @@ export class ImpulseRenderer {
     }
 
     await this.persistGoalState();
-    const continuation = buildGoalContinuationMessage(updatedGoal);
+    const continuation = buildGoalContinuationMessage(
+      updatedGoal,
+      planTasksPath ? { planTasksPath } : undefined
+    );
     void this.runTurn({
       apiText: continuation,
       displayMessage: continuation,
@@ -4461,26 +4487,34 @@ export class ImpulseRenderer {
       this.tui.requestRender();
       return;
     }
-    const sub = arg.trim().toLowerCase();
-    if (!sub) {
-      this.addChatLine(clr.dim("Usage: /goal <text> | status | pause | resume | clear"));
+    const trimmedArg = arg.trim();
+    const tokens = trimmedArg.split(/\s+/).filter(Boolean);
+    const firstToken = (tokens[0] ?? "").toLowerCase();
+
+    if (!trimmedArg) {
+      this.addChatLine(
+        clr.dim("Usage: /goal <text> | set [--plan[=revisionId]] <text> | status | pause | resume | clear")
+      );
       this.tui.requestRender();
       return;
     }
-    if (sub === "status") {
+    if (firstToken === "status") {
       if (!this.goalState) {
         this.addChatLine(clr.dim("No active goal"));
       } else {
+        const planSuffix = this.goalState.planRevisionId
+          ? `, plan: ${this.goalState.planRevisionId}`
+          : "";
         this.addChatLine(
           clr.dim(
-            `${this.goalState.status} — ${this.goalState.turnsUsed}/${this.goalState.maxTurns} turns: ${this.goalState.text}`
+            `${this.goalState.status} — ${this.goalState.turnsUsed}/${this.goalState.maxTurns} turns${planSuffix}: ${this.goalState.text}`
           )
         );
       }
       this.tui.requestRender();
       return;
     }
-    if (sub === "clear") {
+    if (firstToken === "clear") {
       this.goalState = undefined;
       await this.persistGoalState();
       this.syncGoalContextBar();
@@ -4488,7 +4522,7 @@ export class ImpulseRenderer {
       this.tui.requestRender();
       return;
     }
-    if (sub === "pause") {
+    if (firstToken === "pause") {
       if (this.goalState) {
         this.goalState = { ...this.goalState, status: "paused" };
         await this.persistGoalState();
@@ -4498,7 +4532,7 @@ export class ImpulseRenderer {
       this.tui.requestRender();
       return;
     }
-    if (sub === "resume") {
+    if (firstToken === "resume") {
       if (this.goalState) {
         const wasJudgePause = this.goalState.status === "paused_judge_unavailable";
         this.goalState = {
@@ -4509,6 +4543,16 @@ export class ImpulseRenderer {
         };
         await this.persistGoalState();
         this.syncGoalContextBar();
+        if (this.goalState.planRevisionId) {
+          const sessionId = SessionManager.getCurrentSessionID() ?? "";
+          if (!readPlanTasksMarkdown(sessionId, this.goalState.planRevisionId)) {
+            this.addChatLine(
+              clr.warn(
+                `Plan revision ${this.goalState.planRevisionId} not found — judging against goal text only.`
+              )
+            );
+          }
+        }
         void this.emitStatusEvent(
           wasJudgePause ? "Goal resumed" : "Goal resumed — turn counter reset"
         );
@@ -4521,7 +4565,75 @@ export class ImpulseRenderer {
       this.tui.requestRender();
       return;
     }
-    this.goalState = createGoalState(arg.trim());
+
+    if (firstToken === "set") {
+      const sessionId = SessionManager.getCurrentSessionID() ?? "";
+      let planRevisionId: string | undefined;
+      let planRequested = false;
+      const textTokens: string[] = [];
+
+      for (const token of tokens.slice(1)) {
+        if (token === "--plan") {
+          planRequested = true;
+          continue;
+        }
+        if (token.startsWith("--plan=")) {
+          planRequested = true;
+          planRevisionId = token.slice("--plan=".length);
+          continue;
+        }
+        textTokens.push(token);
+      }
+
+      if (planRequested) {
+        if (planRevisionId) {
+          if (!readPlanTasksMarkdown(sessionId, planRevisionId)) {
+            const ids = listRevisionIds(sessionId);
+            this.addChatLine(
+              clr.warn(
+                ids.length > 0
+                  ? `Plan revision '${planRevisionId}' not found (or has no tasks.md). Available revisions: ${ids.join(", ")}.`
+                  : `Plan revision '${planRevisionId}' not found and no plan revisions exist for this session.`
+              )
+            );
+            this.tui.requestRender();
+            return;
+          }
+        } else {
+          const active = getActivePlanRevision(sessionId);
+          if (!active) {
+            this.addChatLine(
+              clr.warn("No active plan revision. Run PLAN mode first, or specify /goal set --plan=<revisionId>.")
+            );
+            this.tui.requestRender();
+            return;
+          }
+          planRevisionId = active.meta.revisionId;
+        }
+      }
+
+      let text = textTokens.join(" ").trim();
+      if (!text && planRevisionId) {
+        text = `Complete all tasks in plan revision ${planRevisionId} (tasks.md)`;
+      }
+      if (!text) {
+        this.addChatLine(clr.warn("Usage: /goal set [--plan[=revisionId]] <text>"));
+        this.tui.requestRender();
+        return;
+      }
+
+      this.goalState = createGoalState(text, planRevisionId ? { planRevisionId } : undefined);
+      await this.persistGoalState();
+      this.syncGoalContextBar();
+      void this.emitStatusEvent(
+        `Goal set: ${this.goalState.text}${planRevisionId ? ` (plan: ${planRevisionId})` : ""}`
+      );
+      this.tui.requestRender();
+      return;
+    }
+
+    // Legacy /goal <text>
+    this.goalState = createGoalState(trimmedArg);
     await this.persistGoalState();
     this.syncGoalContextBar();
     void this.emitStatusEvent(`Goal set: ${this.goalState.text}`);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -219,7 +219,7 @@ import {
   formatSessionStatsBlock,
 } from "../session/session-stats.js";
 import { writeUpdateResumeHint } from "../util/update-resume-hint.js";
-import { abortCurrentBashExecution } from "../tools/bash.js";
+import { abortCurrentBashExecution, clearShellSessions } from "../tools/bash.js";
 import { rejectQuestion, resolveQuestion, type Question } from "../tools/question.js";
 import { setCurrentMode } from "../tools/mode-state.js";
 import {
@@ -1253,6 +1253,21 @@ export class ImpulseRenderer {
       };
       await this.persistGoalState();
       void this.emitStatusEvent(`Goal achieved: ${result.reason}`);
+      this.drainTurnQueue();
+      return;
+    }
+
+    if (result.verdict === "judge_unavailable") {
+      this.goalState = {
+        ...activeGoal,
+        status: "paused_judge_unavailable",
+        lastJudgeReason: result.reason,
+      };
+      await this.persistGoalState();
+      this.syncGoalContextBar();
+      void this.emitStatusEvent(
+        "Goal paused — judge model unavailable. Run /goal resume after restoring it."
+      );
       this.drainTurnQueue();
       return;
     }
@@ -2723,7 +2738,9 @@ export class ImpulseRenderer {
     const label =
       this.goalState?.status === "active"
         ? this.goalState.text
-        : undefined;
+        : this.goalState?.status === "paused_judge_unavailable"
+          ? "[goal paused — judge unavailable]"
+          : undefined;
     this.syncContextBar({ goalLabel: label });
   }
 
@@ -3053,6 +3070,7 @@ export class ImpulseRenderer {
     if (arg) {
       this.addChatLine(clr.dim("Optional session name is not documented; starting a new session."));
     }
+    clearShellSessions();
     await SessionManager.createNew(arg || undefined);
     const newCfg = await loadConfig();
     if (newCfg.defaultModel?.trim()) {
@@ -4394,14 +4412,18 @@ export class ImpulseRenderer {
     }
     if (sub === "resume") {
       if (this.goalState) {
+        const wasJudgePause = this.goalState.status === "paused_judge_unavailable";
         this.goalState = {
           ...this.goalState,
           status: "active",
-          turnsUsed: 0,
+          // Preserve turnsUsed for judge pauses — no work-turn was consumed
+          ...(wasJudgePause ? {} : { turnsUsed: 0 }),
         };
         await this.persistGoalState();
         this.syncGoalContextBar();
-        void this.emitStatusEvent("Goal resumed — turn counter reset");
+        void this.emitStatusEvent(
+          wasJudgePause ? "Goal resumed" : "Goal resumed — turn counter reset"
+        );
       }
       this.tui.requestRender();
       return;

--- a/src/goal/artifact.ts
+++ b/src/goal/artifact.ts
@@ -12,6 +12,29 @@ import fs from "fs";
 import { getGoalDir } from "./paths.js";
 import type { GoalState } from "../session/goal-state.js";
 import { writeJsonAtomic } from "../util/atomic-write.js";
+import { getRevisionDir, toRelativePlanPath } from "../plan/paths.js";
+
+function renderGoalMarkdown(state: GoalState, sessionId: string, cwd: string): string {
+  const lines = ["# Goal", "", state.text, ""];
+
+  if (state.planRevisionId) {
+    const revisionDir = getRevisionDir(sessionId, state.planRevisionId, cwd);
+    const tasksPathRel = toRelativePlanPath(`${revisionDir}/tasks.md`, cwd);
+    lines.push(
+      "## Plan reference",
+      "",
+      `- Revision: ${state.planRevisionId}`,
+      `- Tasks: ${tasksPathRel}`,
+      "",
+      "## Acceptance criteria",
+      "",
+      "Complete when every task in the referenced tasks.md is checked off (judged each turn).",
+      ""
+    );
+  }
+
+  return lines.join("\n");
+}
 
 function statePath(goalDir: string): string {
   return `${goalDir}/state.json`;
@@ -39,8 +62,8 @@ export async function writeGoalArtifact(
 
   await writeJsonAtomic(statePath(dir), state);
 
-  // goal.md — overwrite each time (tracks current goal text)
-  fs.writeFileSync(goalMdPath(dir), `# Goal\n\n${state.text}\n`, { mode: 0o600 });
+  // goal.md — overwrite each time (tracks current goal text + plan reference)
+  fs.writeFileSync(goalMdPath(dir), renderGoalMarkdown(state, sessionId, cwd), { mode: 0o600 });
 }
 
 /**

--- a/src/goal/artifact.ts
+++ b/src/goal/artifact.ts
@@ -1,0 +1,89 @@
+/**
+ * Goal artifact storage — persists GoalState to .impulse/goals/<sessionId>/
+ * mirroring the plan revision pattern in src/plan/revisions.ts.
+ *
+ * Files written per goal session:
+ *   state.json  — full GoalState (mode 0o600)
+ *   goal.md     — goal text (human-readable)
+ *   progress.md — append-only judge/turn log
+ */
+
+import fs from "fs";
+import { getGoalDir } from "./paths.js";
+import type { GoalState } from "../session/goal-state.js";
+import { writeJsonAtomic } from "../util/atomic-write.js";
+
+function statePath(goalDir: string): string {
+  return `${goalDir}/state.json`;
+}
+
+function goalMdPath(goalDir: string): string {
+  return `${goalDir}/goal.md`;
+}
+
+function progressMdPath(goalDir: string): string {
+  return `${goalDir}/progress.md`;
+}
+
+/**
+ * Persist a GoalState to the artifact directory for the given session.
+ * Creates the directory if it does not exist.
+ */
+export async function writeGoalArtifact(
+  sessionId: string,
+  state: GoalState,
+  cwd = process.cwd()
+): Promise<void> {
+  const dir = getGoalDir(sessionId, cwd);
+  fs.mkdirSync(dir, { recursive: true });
+
+  await writeJsonAtomic(statePath(dir), state);
+
+  // goal.md — overwrite each time (tracks current goal text)
+  fs.writeFileSync(goalMdPath(dir), `# Goal\n\n${state.text}\n`, { mode: 0o600 });
+}
+
+/**
+ * Append a judge verdict line to the session's progress log.
+ */
+export function appendGoalProgress(
+  sessionId: string,
+  entry: { turn: number; verdict: string; reason: string; timestamp: string },
+  cwd = process.cwd()
+): void {
+  const dir = getGoalDir(sessionId, cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const line = `| ${entry.timestamp} | turn ${entry.turn} | ${entry.verdict} | ${entry.reason} |\n`;
+  fs.appendFileSync(progressMdPath(dir), line, { encoding: "utf-8" });
+}
+
+/**
+ * Load GoalState from the artifact directory.
+ * Returns null if no artifact exists (fresh session or legacy session).
+ */
+export function readGoalArtifact(
+  sessionId: string,
+  cwd = process.cwd()
+): GoalState | null {
+  const dir = getGoalDir(sessionId, cwd);
+  const file = statePath(dir);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8")) as GoalState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove the artifact directory for a session (used by /goal clear).
+ */
+export function deleteGoalArtifact(
+  sessionId: string,
+  cwd = process.cwd()
+): void {
+  const dir = getGoalDir(sessionId, cwd);
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/src/goal/paths.ts
+++ b/src/goal/paths.ts
@@ -1,0 +1,16 @@
+import path from "path";
+
+export const GOAL_ROOT_DIR = ".impulse/goals";
+
+export function getGoalDir(sessionId: string, cwd = process.cwd()): string {
+  return path.join(cwd, GOAL_ROOT_DIR, sessionId);
+}
+
+export function toRelativeGoalPath(absolutePath: string, cwd = process.cwd()): string {
+  const normalized = absolutePath.replaceAll("\\", "/");
+  const base = cwd.replaceAll("\\", "/");
+  if (normalized.startsWith(base)) {
+    return normalized.slice(base.length).replace(/^\//, "");
+  }
+  return normalized;
+}

--- a/src/plan/revisions.ts
+++ b/src/plan/revisions.ts
@@ -155,6 +155,22 @@ export function ensureActivePlanRevision(sessionId: string, cwd = process.cwd())
   return getActivePlanRevision(sessionId, cwd) ?? createPlanRevision(sessionId, undefined, cwd);
 }
 
+/** Read a specific revision's tasks.md, or null if the revision or file is missing. */
+export function readPlanTasksMarkdown(
+  sessionId: string,
+  revisionId: string,
+  cwd = process.cwd()
+): string | null {
+  const dir = getRevisionDir(sessionId, revisionId, cwd);
+  const tasksPath = path.join(dir, "tasks.md");
+  if (!fs.existsSync(tasksPath)) return null;
+  try {
+    return fs.readFileSync(tasksPath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
 export function setPlanningStyleForActiveRevision(
   sessionId: string,
   style: PlanningStyle,

--- a/src/session/goal-state.ts
+++ b/src/session/goal-state.ts
@@ -8,16 +8,22 @@ export interface GoalState {
   turnsUsed: number;
   maxTurns: number;
   lastJudgeReason?: string;
+  /** Plan revision this goal tracks; when set, the judge evaluates against its tasks.md checklist. */
+  planRevisionId?: string;
 }
 
 export const DEFAULT_GOAL_MAX_TURNS = 20;
 
-export function createGoalState(text: string, maxTurns = DEFAULT_GOAL_MAX_TURNS): GoalState {
+export function createGoalState(
+  text: string,
+  options?: { maxTurns?: number; planRevisionId?: string }
+): GoalState {
   return {
     text: text.trim(),
     status: "active",
     turnsUsed: 0,
-    maxTurns,
+    maxTurns: options?.maxTurns ?? DEFAULT_GOAL_MAX_TURNS,
+    ...(options?.planRevisionId ? { planRevisionId: options.planRevisionId } : {}),
   };
 }
 
@@ -42,6 +48,9 @@ export function parseGoalState(raw: unknown): GoalState | undefined {
         : DEFAULT_GOAL_MAX_TURNS,
     ...(typeof g["lastJudgeReason"] === "string"
       ? { lastJudgeReason: g["lastJudgeReason"] }
+      : {}),
+    ...(typeof g["planRevisionId"] === "string" && g["planRevisionId"].trim()
+      ? { planRevisionId: g["planRevisionId"].trim() }
       : {}),
   };
 }

--- a/src/session/goal-state.ts
+++ b/src/session/goal-state.ts
@@ -4,7 +4,7 @@
 
 export interface GoalState {
   text: string;
-  status: "active" | "paused" | "done";
+  status: "active" | "paused" | "paused_judge_unavailable" | "done";
   turnsUsed: number;
   maxTurns: number;
   lastJudgeReason?: string;
@@ -26,7 +26,12 @@ export function parseGoalState(raw: unknown): GoalState | undefined {
   const g = raw as Record<string, unknown>;
   if (typeof g["text"] !== "string" || !g["text"].trim()) return undefined;
   const status = g["status"];
-  if (status !== "active" && status !== "paused" && status !== "done") return undefined;
+  if (
+    status !== "active" &&
+    status !== "paused" &&
+    status !== "paused_judge_unavailable" &&
+    status !== "done"
+  ) return undefined;
   return {
     text: g["text"].trim(),
     status,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -96,6 +96,8 @@ interface SpawnOptions {
   cwd?: string;
   env?: Record<string, string | undefined>;
   shellKind?: "powershell" | "cmd" | "bash";
+  /** One-time notice to prepend to the tool output (e.g. a shell-selection fallback). */
+  notice?: string;
 }
 
 interface ShellSessionState {
@@ -596,8 +598,15 @@ function quotePowerShellString(value: string): string {
  * Translate a Windows path to a WSL mount path.
  * C:\Users\foo\bar → /mnt/c/Users/foo/bar
  * Already-POSIX paths are returned unchanged.
+ * UNC paths (\\server\share\...) aren't representable this way — throws instead
+ * of producing a broken /mnt path.
  */
-function translateToWslPath(winPath: string): string {
+export function translateToWslPath(winPath: string): string {
+  if (winPath.startsWith("\\\\") || winPath.startsWith("//")) {
+    throw new Error(
+      `Cannot translate UNC path to a WSL path: ${winPath}. Run this command from a local-drive working directory, or address the share via WSL's own /mnt/wsl/ network-mount conventions.`
+    );
+  }
   const driveMatch = winPath.match(/^([A-Za-z]):[\\\/](.*)/);
   if (driveMatch) {
     const drive = driveMatch[1]!.toLowerCase();
@@ -625,6 +634,69 @@ function encodePowerShellCommand(command: string): string {
   return Buffer.from(command, "utf16le").toString("base64");
 }
 
+function buildWslSpawnOptions(executable: string, cwd: string, command: string): SpawnOptions {
+  const wslCwd = translateToWslPath(cwd);
+  // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
+  return {
+    env: process.env,
+    shellKind: "bash",
+    cmd: [executable, "--cd", wslCwd, "--", "bash", "-lc", command],
+  };
+}
+
+function buildSpawnOptionsForShell(
+  shell: Awaited<ReturnType<typeof detectWindowsCommandShell>>,
+  input: BashInput,
+  cwd: string,
+  options: { interactive?: boolean },
+  common: SpawnOptions
+): SpawnOptions {
+  if (shell.type === "wsl") {
+    return buildWslSpawnOptions(shell.executable, cwd, input.command);
+  }
+
+  if (shell.type === "cmd") {
+    return {
+      ...common,
+      shellKind: "cmd",
+      cmd: [shell.executable, "/d", "/s", "/c", input.command],
+    };
+  }
+
+  if (shell.type === "git-bash") {
+    return {
+      ...common,
+      shellKind: "bash",
+      cmd: [shell.executable, "-lc", input.command],
+    };
+  }
+
+  const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
+  const psType = shell.type as "powershell5" | "powershell7";
+
+  return {
+    ...common,
+    shellKind: "powershell",
+    env: {
+      ...process.env,
+      [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
+    },
+    cmd: [
+      shell.executable,
+      "-NoLogo",
+      "-NoProfile",
+      ...interactiveArgs,
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+      encodePowerShellCommand(WINDOWS_POWERSHELL_WRAPPER),
+    ],
+  };
+}
+
+/** Shown once per process when preferredShell is "wsl" but no WSL distro is available. */
+let warnedWslUnavailable = false;
+
 async function getSpawnOptions(
   input: BashInput,
   cwd: string,
@@ -643,66 +715,27 @@ async function getSpawnOptions(
     // WSL: either forced by preferredShell config or auto-detected
     if (preferred === "wsl") {
       const wslShell = await detectWslShell();
-      const wslExe = wslShell?.executable ?? "wsl.exe";
-      const wslCwd = translateToWslPath(cwd);
-      // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
-      return {
-        env: process.env,
-        shellKind: "bash",
-        cmd: [wslExe, "--cd", wslCwd, "--", "bash", "-lc", input.command],
-      };
+      if (wslShell) {
+        return buildWslSpawnOptions(wslShell.executable, cwd, input.command);
+      }
+
+      // preferredShell is explicitly "wsl" but no distro was detected — don't
+      // spawn a nonexistent wsl.exe; fall back to the auto-detected shell and
+      // surface a one-time notice instead of an opaque spawn failure.
+      const fallbackShell = await detectWindowsCommandShell();
+      const spawnOptions = buildSpawnOptionsForShell(fallbackShell, input, cwd, options, common);
+      if (!warnedWslUnavailable) {
+        warnedWslUnavailable = true;
+        spawnOptions.notice = `[Note: preferredShell is set to "wsl" but no WSL distro was detected. Falling back to ${fallbackShell.displayName}. Run 'wsl --install' or check 'wsl -l -v', or change preferredShell in config.]`;
+      }
+      return spawnOptions;
     }
 
     const shell = preferred === "auto"
       ? await detectWindowsCommandShell()
       : await resolvePreferredShell(preferred);
 
-    if (shell.type === "wsl") {
-      const wslCwd = translateToWslPath(cwd);
-      return {
-        env: process.env,
-        shellKind: "bash",
-        cmd: [shell.executable, "--cd", wslCwd, "--", "bash", "-lc", input.command],
-      };
-    }
-
-    if (shell.type === "cmd") {
-      return {
-        ...common,
-        shellKind: "cmd",
-        cmd: [shell.executable, "/d", "/s", "/c", input.command],
-      };
-    }
-
-    if (shell.type === "git-bash") {
-      return {
-        ...common,
-        shellKind: "bash",
-        cmd: [shell.executable, "-lc", input.command],
-      };
-    }
-
-    const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
-    const psType = shell.type as "powershell5" | "powershell7";
-
-    return {
-      ...common,
-      shellKind: "powershell",
-      env: {
-        ...process.env,
-        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
-      },
-      cmd: [
-        shell.executable,
-        "-NoLogo",
-        "-NoProfile",
-        ...interactiveArgs,
-        "-ExecutionPolicy",
-        "Bypass",
-        "-EncodedCommand",
-        encodePowerShellCommand(WINDOWS_POWERSHELL_WRAPPER),
-      ],
-    };
+    return buildSpawnOptionsForShell(shell, input, cwd, options, common);
   }
 
   return {
@@ -716,7 +749,7 @@ async function getSpawnOptions(
  * Resolve a specific shell from a user preference string (non-"auto" + non-"wsl" values).
  * Falls back to auto-detection when the requested shell is not found.
  */
-async function resolvePreferredShell(preferred: string) {
+export async function resolvePreferredShell(preferred: string) {
   if (preferred === "pwsh") {
     const pwshPath = Bun.which("pwsh.exe") ?? Bun.which("pwsh");
     if (pwshPath) return { type: "powershell7" as const, executable: pwshPath, displayName: "PowerShell 7.x (pwsh)", supportsChainedCommands: true, commandSeparator: "&&" as const };
@@ -883,6 +916,10 @@ async function executeWithPty(
     const capped = capBashOutputLines(result.output, maxLines);
     let output = capped.output;
 
+    if (spawnOptions?.notice) {
+      output = `${spawnOptions.notice}${output ? "\n" : ""}${output}`;
+    }
+
     if (timedOut) {
       output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
     }
@@ -1030,6 +1067,10 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const hint = classifyCommandError(input.command, output, exitCode ?? -1, shellForClassify);
   if (hint) {
     output = `${output}${output ? "\n" : ""}${hint}`;
+  }
+
+  if (spawnOptions.notice) {
+    output = `${spawnOptions.notice}${output ? "\n" : ""}${output}`;
   }
 
   const elapsed = Date.now() - startTime;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -27,6 +27,8 @@ const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
 Required: command, description. Optional: workdir, timeout, interactive, session.
+Default timeout is 120s. Pass a higher value for known long-running operations (builds, installs).
+Pass timeout: 0 to run without a time limit (e.g. dev servers meant to stay alive).
 See docs/tools/bash.md for safety rules and usage details.`;
 
 const BashSchema = z.object({
@@ -54,6 +56,11 @@ interface ShellSessionState {
 
 const shellSessions = new Map<string, ShellSessionState>();
 const sessionChains = new Map<string, Promise<unknown>>();
+
+export function clearShellSessions(): void {
+  shellSessions.clear();
+  sessionChains.clear();
+}
 
 function isValidSessionCwd(cwd: string): boolean {
   try {
@@ -796,7 +803,8 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
   const stderrPromise = proc.stderr ? new Response(proc.stderr).text() : Promise.resolve("");
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutMs = input.timeout;
+  // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
+  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -36,7 +36,7 @@ export function resolveBashTimeoutMs(timeout?: number): number | undefined {
  * tool or command is not found on the target shell.
  * Returns a hint string to append, or null when output is already clear.
  */
-function classifyCommandError(
+export function classifyCommandError(
   command: string,
   output: string,
   exitCode: number,
@@ -921,28 +921,35 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
     }
   }
   
-  // Pagination: slice output lines before byte-capping
+  // Pagination: slice output lines, then byte-cap; the note is built AFTER
+  // capping so it reflects what was actually delivered (the byte/line cap
+  // can still trim a paginated slice, and the note must not overstate it).
   const outputOffset = input.offset ?? 0;
   const outputLimit = input.limit ?? maxLines;
-  let paginationNote = "";
+  const paginationRequested = outputOffset > 0 || input.limit !== undefined;
   let paginatedOutput = combinedOutput;
-  if (outputOffset > 0 || input.limit !== undefined) {
+  let totalOutputLines = 0;
+  let slicedLineCount = 0;
+  if (paginationRequested) {
     const allLines = combinedOutput.split("\n");
-    const totalOutputLines = allLines.length;
+    totalOutputLines = allLines.length;
     const sliced = allLines.slice(outputOffset, outputOffset + outputLimit);
+    slicedLineCount = sliced.length;
     paginatedOutput = sliced.join("\n");
-    const nextOffset = outputOffset + sliced.length;
-    if (nextOffset < totalOutputLines) {
-      paginationNote = `\n[Output paginated: lines ${outputOffset + 1}–${nextOffset} of ${totalOutputLines}. Re-run with offset: ${nextOffset} for more.]`;
-    }
   }
 
   const capped = capBashOutputLines(paginatedOutput, maxLines);
   let output = capped.output;
-  let wasTruncated = capped.truncated || paginationNote.length > 0;
+  let wasTruncated = capped.truncated;
 
-  if (paginationNote) {
-    output = `${output}${paginationNote}`;
+  if (paginationRequested) {
+    const delivered = capped.keptLines;
+    const nextOffset = outputOffset + delivered;
+    if (nextOffset < totalOutputLines) {
+      const cappedFurther = delivered < slicedLineCount ? ", further capped by output size limits" : "";
+      output = `${output}\n[Output paginated: lines ${outputOffset + 1}-${nextOffset} of ${totalOutputLines}${cappedFurther}. Re-run with offset: ${nextOffset} for more.]`;
+      wasTruncated = true;
+    }
   }
 
   if (exitCode === -1) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,43 @@ import { detectWindowsCommandShell } from "../util/windows-shell.js";
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
+/**
+ * Classify a failed command's output to give actionable guidance when a
+ * tool or command is not found on the target shell.
+ * Returns a hint string to append, or null when output is already clear.
+ */
+function classifyCommandError(
+  command: string,
+  output: string,
+  exitCode: number,
+  shellKind: "powershell" | "cmd" | "bash"
+): string | null {
+  if (exitCode === 0) return null;
+  const cmd = command.trim().split(/\s+/)[0] ?? command;
+  if (shellKind === "powershell") {
+    if (
+      output.includes("is not recognized as the name of a cmdlet") ||
+      output.includes("is not recognized as an internal or external command") ||
+      output.includes("CommandNotFoundException")
+    ) {
+      return `[Hint: '${cmd}' is not a recognised PowerShell cmdlet or program. Check spelling, confirm it is installed, or run 'Get-Command ${cmd}' to locate it.]`;
+    }
+  } else if (shellKind === "cmd") {
+    if (output.includes("is not recognized as an internal or external command")) {
+      return `[Hint: '${cmd}' was not found. Check spelling or confirm it is on PATH.]`;
+    }
+  } else {
+    // bash / POSIX
+    if (output.includes("command not found") || exitCode === 127) {
+      return `[Hint: '${cmd}' was not found on PATH. Confirm it is installed (e.g. 'which ${cmd}').]`;
+    }
+    if ((output.includes("Permission denied") || output.includes("EACCES")) && exitCode === 126) {
+      return `[Hint: Permission denied executing '${cmd}'. Check file permissions (ls -l).]`;
+    }
+  }
+  return null;
+}
+
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
@@ -39,6 +76,8 @@ const BashSchema = z.object({
   interactive: z.boolean().optional(),
   session: z.string().optional().describe("Optional named shell session; preserves cwd between bash calls"),
   resetSession: z.boolean().optional().describe("Reset the named shell session before running"),
+  offset: z.number().optional().describe("Line offset into captured output (0-based). Use to page through large results."),
+  limit: z.number().optional().describe("Max output lines to return (default 2000). Combine with offset for pagination."),
 });
 
 type BashInput = z.infer<typeof BashSchema>;
@@ -52,10 +91,28 @@ interface SpawnOptions {
 
 interface ShellSessionState {
   cwd: string;
+  lastUsed: number;
 }
+
+const MAX_SHELL_SESSIONS = 20;
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 const shellSessions = new Map<string, ShellSessionState>();
 const sessionChains = new Map<string, Promise<unknown>>();
+
+function evictStaleSessions(): void {
+  const now = Date.now();
+  // First remove TTL-expired sessions
+  for (const [name, state] of shellSessions) {
+    if (now - state.lastUsed > SESSION_TTL_MS) shellSessions.delete(name);
+  }
+  // Then LRU-evict if still over cap
+  if (shellSessions.size > MAX_SHELL_SESSIONS) {
+    const sorted = [...shellSessions.entries()].sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+    const toRemove = sorted.slice(0, shellSessions.size - MAX_SHELL_SESSIONS);
+    for (const [name] of toRemove) shellSessions.delete(name);
+  }
+}
 
 export function clearShellSessions(): void {
   shellSessions.clear();
@@ -106,20 +163,23 @@ function resolveSessionCwd(
   options?: { reset?: boolean; workdirProvided?: boolean }
 ): string {
   if (!sessionName) return fallbackCwd;
+  evictStaleSessions();
   if (options?.reset) shellSessions.delete(sessionName);
   const existing = shellSessions.get(sessionName);
+  const now = Date.now();
   if (existing) {
     if (options?.workdirProvided) {
-      shellSessions.set(sessionName, { cwd: fallbackCwd });
+      shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
       return fallbackCwd;
     }
     if (isValidSessionCwd(existing.cwd)) {
+      existing.lastUsed = now;
       return existing.cwd;
     }
-    shellSessions.set(sessionName, { cwd: fallbackCwd });
+    shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
     return fallbackCwd;
   }
-  shellSessions.set(sessionName, { cwd: fallbackCwd });
+  shellSessions.set(sessionName, { cwd: fallbackCwd, lastUsed: now });
   return fallbackCwd;
 }
 
@@ -153,7 +213,7 @@ function updateSessionCwd(sessionName: string | null, cwd: string, command: stri
   } catch {
     return;
   }
-  shellSessions.set(sessionName, { cwd: next });
+  shellSessions.set(sessionName, { cwd: next, lastUsed: Date.now() });
 }
 
 const WINDOWS_COMMAND_ENV_VAR = "IMPULSE_COMMAND";
@@ -850,12 +910,39 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
     }
   }
   
-  const capped = capBashOutputLines(combinedOutput, maxLines);
+  // Pagination: slice output lines before byte-capping
+  const outputOffset = input.offset ?? 0;
+  const outputLimit = input.limit ?? maxLines;
+  let paginationNote = "";
+  let paginatedOutput = combinedOutput;
+  if (outputOffset > 0 || input.limit !== undefined) {
+    const allLines = combinedOutput.split("\n");
+    const totalOutputLines = allLines.length;
+    const sliced = allLines.slice(outputOffset, outputOffset + outputLimit);
+    paginatedOutput = sliced.join("\n");
+    const nextOffset = outputOffset + sliced.length;
+    if (nextOffset < totalOutputLines) {
+      paginationNote = `\n[Output paginated: lines ${outputOffset + 1}–${nextOffset} of ${totalOutputLines}. Re-run with offset: ${nextOffset} for more.]`;
+    }
+  }
+
+  const capped = capBashOutputLines(paginatedOutput, maxLines);
   let output = capped.output;
-  let wasTruncated = capped.truncated;
+  let wasTruncated = capped.truncated || paginationNote.length > 0;
+
+  if (paginationNote) {
+    output = `${output}${paginationNote}`;
+  }
 
   if (exitCode === -1) {
     output = `${output}${output ? "\n" : ""}[Timeout after ${timeoutMs}ms]`;
+  }
+
+  // Append command-not-found hint on failures when output doesn't already explain the error
+  const shellForClassify = spawnOptions.shellKind ?? (process.platform === "win32" ? "powershell" : "bash");
+  const hint = classifyCommandError(input.command, output, exitCode ?? -1, shellForClassify);
+  if (hint) {
+    output = `${output}${output ? "\n" : ""}${hint}`;
   }
 
   const elapsed = Date.now() - startTime;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -23,6 +23,14 @@ import { detectWindowsCommandShell } from "../util/windows-shell.js";
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
 
+/**
+ * Resolve the effective timeout for a bash/PTY invocation.
+ * `timeout: 0` means no limit (undefined); omitted falls back to the 120s default.
+ */
+export function resolveBashTimeoutMs(timeout?: number): number | undefined {
+  return timeout === 0 ? undefined : (timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+}
+
 const DESCRIPTION = `Run a shell command in the host platform shell.
 
 On Windows this auto-detects PowerShell, cmd.exe, or Git Bash. On macOS/Linux this uses bash.
@@ -712,25 +720,28 @@ async function executeWithPty(
     activePtyHandles.set(toolCallId, handle);
     Bus.emit(PtyEvents.Started, { toolCallId, pid: handle.pid });
     
-    const timeoutMs = input.timeout ?? DEFAULT_BASH_TIMEOUT_MS;
+    const timeoutMs = resolveBashTimeoutMs(input.timeout);
     let timedOut = false;
     const result = await new Promise<{ output: string; exitCode: number; pid?: number }>((resolve) => {
-      const timer = setTimeout(() => {
-        timedOut = true;
-        try {
-          handle.kill();
-        } catch {
-          /* ignore */
-        }
-        resolve({
-          output: lastOutput,
-          exitCode: -1,
-          pid: handle.pid,
-        });
-      }, timeoutMs);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            handle.kill();
+          } catch {
+            /* ignore */
+          }
+          resolve({
+            output: lastOutput,
+            exitCode: -1,
+            pid: handle.pid,
+          });
+        }, timeoutMs);
+      }
 
       void handle.result.then((ptyResult) => {
-        clearTimeout(timer);
+        if (timer) clearTimeout(timer);
         if (!timedOut) resolve(ptyResult);
       });
     });
@@ -804,7 +815,7 @@ async function executeWithSpawn(input: BashInput, cwd: string): Promise<ToolResu
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   // timeout:0 means no limit; undefined falls back to the 120s default (matching PTY path)
-  const timeoutMs = input.timeout === 0 ? undefined : (input.timeout ?? DEFAULT_BASH_TIMEOUT_MS);
+  const timeoutMs = resolveBashTimeoutMs(input.timeout);
   const timeoutPromise = new Promise<number>((resolve) => {
     if (timeoutMs === undefined) {
       return;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -18,7 +18,8 @@ import { detectAndPublishBranchChange } from "../git/branch-detect";
 import { SessionManager } from "../session/manager";
 import { capBashOutputLines } from "../util/tool-output-cap.js";
 import { isWithinBase } from "../util/path.js";
-import { detectWindowsCommandShell } from "../util/windows-shell.js";
+import { detectWindowsCommandShell, detectWslShell } from "../util/windows-shell.js";
+import { load as loadConfig } from "../util/config.js";
 
 /** Default bash/PTY timeout per docs/tools/bash.md */
 const DEFAULT_BASH_TIMEOUT_MS = 120_000;
@@ -583,6 +584,21 @@ function quotePowerShellString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+/**
+ * Translate a Windows path to a WSL mount path.
+ * C:\Users\foo\bar → /mnt/c/Users/foo/bar
+ * Already-POSIX paths are returned unchanged.
+ */
+function translateToWslPath(winPath: string): string {
+  const driveMatch = winPath.match(/^([A-Za-z]):[\\\/](.*)/);
+  if (driveMatch) {
+    const drive = driveMatch[1]!.toLowerCase();
+    const rest = (driveMatch[2] ?? "").replaceAll("\\", "/");
+    return `/mnt/${drive}/${rest}`;
+  }
+  return winPath.replaceAll("\\", "/");
+}
+
 function normalizeWindowsCommand(command: string, shellType: "powershell5" | "powershell7"): string {
   const trimmed = command.trim();
   const chaining = analyzePowerShellChaining(trimmed, shellType);
@@ -613,7 +629,34 @@ async function getSpawnOptions(
   };
 
   if (process.platform === "win32") {
-    const shell = await detectWindowsCommandShell();
+    const cfg = await loadConfig();
+    const preferred = cfg.preferredShell;
+
+    // WSL: either forced by preferredShell config or auto-detected
+    if (preferred === "wsl") {
+      const wslShell = await detectWslShell();
+      const wslExe = wslShell?.executable ?? "wsl.exe";
+      const wslCwd = translateToWslPath(cwd);
+      // cwd is set via --cd inside wsl.exe; don't pass a Windows cwd to Bun.spawn
+      return {
+        env: process.env,
+        shellKind: "bash",
+        cmd: [wslExe, "--cd", wslCwd, "--", "bash", "-lc", input.command],
+      };
+    }
+
+    const shell = preferred === "auto"
+      ? await detectWindowsCommandShell()
+      : await resolvePreferredShell(preferred);
+
+    if (shell.type === "wsl") {
+      const wslCwd = translateToWslPath(cwd);
+      return {
+        env: process.env,
+        shellKind: "bash",
+        cmd: [shell.executable, "--cd", wslCwd, "--", "bash", "-lc", input.command],
+      };
+    }
 
     if (shell.type === "cmd") {
       return {
@@ -632,13 +675,14 @@ async function getSpawnOptions(
     }
 
     const interactiveArgs = options.interactive ? [] : ["-NonInteractive"];
+    const psType = shell.type as "powershell5" | "powershell7";
 
     return {
       ...common,
       shellKind: "powershell",
       env: {
         ...process.env,
-        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, shell.type),
+        [WINDOWS_COMMAND_ENV_VAR]: normalizeWindowsCommand(input.command, psType),
       },
       cmd: [
         shell.executable,
@@ -658,6 +702,31 @@ async function getSpawnOptions(
     shellKind: "bash",
     cmd: ["bash", "-lc", input.command],
   };
+}
+
+/**
+ * Resolve a specific shell from a user preference string (non-"auto" + non-"wsl" values).
+ * Falls back to auto-detection when the requested shell is not found.
+ */
+async function resolvePreferredShell(preferred: string) {
+  if (preferred === "pwsh") {
+    const pwshPath = Bun.which("pwsh.exe") ?? Bun.which("pwsh");
+    if (pwshPath) return { type: "powershell7" as const, executable: pwshPath, displayName: "PowerShell 7.x (pwsh)", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  if (preferred === "powershell") {
+    const psPath = Bun.which("powershell.exe") ?? Bun.which("powershell") ?? "powershell.exe";
+    return { type: "powershell5" as const, executable: psPath, displayName: "Windows PowerShell 5.x", supportsChainedCommands: false, commandSeparator: ";" as const };
+  }
+  if (preferred === "cmd") {
+    const cmdPath = process.env["COMSPEC"] ?? "cmd.exe";
+    return { type: "cmd" as const, executable: cmdPath, displayName: "Windows Command Prompt (cmd.exe)", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  if (preferred === "git-bash") {
+    const bashPath = Bun.which("bash.exe") ?? Bun.which("bash") ?? "bash.exe";
+    return { type: "git-bash" as const, executable: bashPath, displayName: "Git Bash", supportsChainedCommands: true, commandSeparator: "&&" as const };
+  }
+  // Fallback to auto
+  return detectWindowsCommandShell();
 }
 
 /**

--- a/src/tools/file-edit.ts
+++ b/src/tools/file-edit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename } from "path";
 import { createPatch } from "diff";
 import {
@@ -82,6 +83,10 @@ export const fileEdit: Tool<EditInput> = Tool.define(
       });
 
       const content = await readFile(safePath, "utf-8");
+      let existingMode: number | undefined;
+      try {
+        existingMode = (await stat(safePath)).mode;
+      } catch { /* preserve no mode if stat fails */ }
 
       const resolved = resolveEditMatch(
         content,
@@ -156,7 +161,11 @@ export const fileEdit: Tool<EditInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, newContent, "utf-8");
+      await writeFileAtomic(
+        safePath,
+        newContent,
+        existingMode !== undefined ? { mode: existingMode } : undefined
+      );
 
       // Emit file edited event for formatters
       Bus.publish(FileEvents.Edited, { 

--- a/src/tools/file-read.ts
+++ b/src/tools/file-read.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { createReadStream } from "fs";
-import { readFile, stat } from "fs/promises";
+import { createReadStream, openSync, readSync, closeSync } from "fs";
+import { readFile, stat, readdir } from "fs/promises";
 import readline from "readline";
 import { sanitizePath } from "../util/path";
 import { zFilePath } from "./schemas/branded";
@@ -10,6 +10,7 @@ import {
   FILE_READ_DEFAULT_LIMIT,
   prependToolNote,
 } from "./tool-notes";
+import path from "path";
 
 const DESCRIPTION = `Read a file from disk with line numbers.
 
@@ -26,6 +27,101 @@ type ReadInput = z.infer<typeof ReadSchema>;
 
 const STREAM_READ_THRESHOLD = 2_000_000; // 2MB
 const MAX_LINE_LENGTH = 2000;
+const BINARY_SNIFF_BYTES = 512;
+
+// Magic-byte signatures [label, magic-bytes (with -1 meaning "any byte")]
+const BINARY_SIGNATURES: Array<[string, number[]]> = [
+  ["PNG image",    [0x89, 0x50, 0x4e, 0x47]],
+  ["JPEG image",   [0xff, 0xd8, 0xff]],
+  ["GIF image",    [0x47, 0x49, 0x46]],
+  ["PDF",          [0x25, 0x50, 0x44, 0x46]],
+  ["ZIP archive",  [0x50, 0x4b, 0x03, 0x04]],
+  ["ELF binary",   [0x7f, 0x45, 0x4c, 0x46]],
+  ["PE binary",    [0x4d, 0x5a]],
+];
+
+function detectBinaryOrEncoding(filePath: string): { isBinary: true; label: string } | { isBinary: false; hasBOM: boolean; bomNote?: string } | null {
+  let fd: number;
+  try {
+    fd = openSync(filePath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.alloc(BINARY_SNIFF_BYTES);
+    const bytesRead = readSync(fd, buf, 0, BINARY_SNIFF_BYTES, 0);
+    if (bytesRead === 0) return null;
+    const header = buf.subarray(0, bytesRead);
+
+    // UTF-16 LE BOM (FF FE)
+    if (bytesRead >= 2 && header[0] === 0xff && header[1] === 0xfe) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-16 LE (BOM detected)" };
+    }
+    // UTF-16 BE BOM (FE FF)
+    if (bytesRead >= 2 && header[0] === 0xfe && header[1] === 0xff) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-16 BE (BOM detected)" };
+    }
+    // UTF-8 BOM (EF BB BF)
+    if (bytesRead >= 3 && header[0] === 0xef && header[1] === 0xbb && header[2] === 0xbf) {
+      return { isBinary: false, hasBOM: true, bomNote: "UTF-8 BOM stripped" };
+    }
+
+    // Known binary magic bytes
+    for (const [label, magic] of BINARY_SIGNATURES) {
+      if (bytesRead >= magic.length && magic.every((b, i) => b === -1 || header[i] === b)) {
+        return { isBinary: true, label };
+      }
+    }
+
+    // Heuristic: >30% NUL bytes → binary
+    let nulCount = 0;
+    for (let i = 0; i < bytesRead; i++) {
+      if (header[i] === 0) nulCount++;
+    }
+    if (nulCount / bytesRead > 0.3) {
+      return { isBinary: true, label: "binary file" };
+    }
+
+    return { isBinary: false, hasBOM: false };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  for (let i = 1; i <= m; i++) {
+    let prev = dp[0]!;
+    dp[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j]!;
+      dp[j] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j - 1]!, dp[j]!);
+      prev = temp;
+    }
+  }
+  return dp[n]!;
+}
+
+async function fuzzyMatchSuggestion(filePath: string): Promise<string | null> {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  try {
+    const entries = await readdir(dir);
+    // Hyphen/underscore swap OR Levenshtein ≤ 2
+    const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
+    const candidates = entries.filter((e) => {
+      if (e === base) return false;
+      if (e === swapped) return true;
+      return levenshtein(base.toLowerCase(), e.toLowerCase()) <= 2;
+    });
+    if (candidates.length === 0) return null;
+    const suggestions = candidates.slice(0, 3).join(", ");
+    return `Did you mean: ${suggestions}?`;
+  } catch {
+    return null;
+  }
+}
 
 export { buildFileReadRangeNote } from "./tool-notes";
 
@@ -83,14 +179,32 @@ export const fileRead: Tool<ReadInput> = Tool.define(
 
       try {
         const stats = await stat(safePath);
+
+        // Sniff for binary/BOM before attempting UTF-8 read
+        const encoding = detectBinaryOrEncoding(safePath);
+        if (encoding?.isBinary) {
+          return {
+            success: false,
+            output: `Cannot read binary file: ${input.filePath} (detected: ${encoding.label}). Use bash tool to inspect or process binary files.`,
+          };
+        }
+        if (encoding && !encoding.isBinary && encoding.hasBOM && encoding.bomNote !== "UTF-8 BOM stripped") {
+          return {
+            success: false,
+            output: `Cannot read file: ${input.filePath} (${encoding.bomNote}). Use bash tool with appropriate encoding conversion.`,
+          };
+        }
+
         if (stats.size > STREAM_READ_THRESHOLD) {
           const result = await readLinesStream(safePath, offset, limit);
           lines = result.lines;
           totalLines = result.totalLines;
           truncated = result.truncated;
         } else {
-          const content = await readFile(safePath, "utf-8");
-          const allLines = content.split("\n");
+          // Strip UTF-8 BOM if present before splitting
+          let rawContent = await readFile(safePath, "utf-8");
+          if (rawContent.charCodeAt(0) === 0xfeff) rawContent = rawContent.slice(1);
+          const allLines = rawContent.split("\n");
           totalLines = allLines.length;
           if (totalLines === 0) {
             return {
@@ -111,6 +225,17 @@ export const fileRead: Tool<ReadInput> = Tool.define(
           truncated = end < totalLines;
         }
       } catch (error) {
+        const isNotFound =
+          error instanceof Error &&
+          ("code" in error ? (error as NodeJS.ErrnoException).code === "ENOENT" : error.message.includes("ENOENT"));
+        if (isNotFound) {
+          const suggestion = await fuzzyMatchSuggestion(safePath);
+          const base = `File not found: ${input.filePath}`;
+          return {
+            success: false,
+            output: suggestion ? `${base}\n${suggestion}` : base,
+          };
+        }
         return {
           success: false,
           output: error instanceof Error ? error.message : `File not found: ${input.filePath}`,

--- a/src/tools/file-read.ts
+++ b/src/tools/file-read.ts
@@ -103,24 +103,56 @@ function levenshtein(a: string, b: string): number {
   return dp[n]!;
 }
 
-async function fuzzyMatchSuggestion(filePath: string): Promise<string | null> {
+const NOT_FOUND_LISTING_MAX_ENTRIES = 15;
+const NOT_FOUND_LISTING_MAX_CHARS = 300;
+
+/**
+ * On ENOENT, build a "Did you mean" fuzzy suggestion plus a compact listing
+ * of the parent directory, reusing a single readdir() call for both.
+ */
+async function buildNotFoundHint(filePath: string): Promise<string | null> {
   const dir = path.dirname(filePath);
   const base = path.basename(filePath);
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
   try {
-    const entries = await readdir(dir);
-    // Hyphen/underscore swap OR Levenshtein ≤ 2
-    const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
-    const candidates = entries.filter((e) => {
-      if (e === base) return false;
-      if (e === swapped) return true;
-      return levenshtein(base.toLowerCase(), e.toLowerCase()) <= 2;
-    });
-    if (candidates.length === 0) return null;
-    const suggestions = candidates.slice(0, 3).join(", ");
-    return `Did you mean: ${suggestions}?`;
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return null;
   }
+
+  const parts: string[] = [];
+
+  // Hyphen/underscore swap OR Levenshtein ≤ 2
+  const swapped = base.replace(/[-_]/g, (c) => (c === "-" ? "_" : "-"));
+  const candidates = entries
+    .map((e) => e.name)
+    .filter((name) => {
+      if (name === base) return false;
+      if (name === swapped) return true;
+      return levenshtein(base.toLowerCase(), name.toLowerCase()) <= 2;
+    });
+  if (candidates.length > 0) {
+    parts.push(`Did you mean: ${candidates.slice(0, 3).join(", ")}?`);
+  }
+
+  const displayNames = [...entries]
+    .sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+
+  if (displayNames.length > 0) {
+    const shown = displayNames.slice(0, NOT_FOUND_LISTING_MAX_ENTRIES);
+    const more = displayNames.length > shown.length ? ` (+${displayNames.length - shown.length} more)` : "";
+    let listing = `Directory ${dir}${path.sep} (${displayNames.length} entries): ${shown.join(", ")}${more}`;
+    if (listing.length > NOT_FOUND_LISTING_MAX_CHARS) {
+      listing = `${listing.slice(0, NOT_FOUND_LISTING_MAX_CHARS - 1)}…`;
+    }
+    parts.push(listing);
+  }
+
+  return parts.length > 0 ? parts.join("\n") : null;
 }
 
 export { buildFileReadRangeNote } from "./tool-notes";
@@ -229,11 +261,11 @@ export const fileRead: Tool<ReadInput> = Tool.define(
           error instanceof Error &&
           ("code" in error ? (error as NodeJS.ErrnoException).code === "ENOENT" : error.message.includes("ENOENT"));
         if (isNotFound) {
-          const suggestion = await fuzzyMatchSuggestion(safePath);
+          const hint = await buildNotFoundHint(safePath);
           const base = `File not found: ${input.filePath}`;
           return {
             success: false,
-            output: suggestion ? `${base}\n${suggestion}` : base,
+            output: hint ? `${base}\n${hint}` : base,
           };
         }
         return {

--- a/src/tools/file-write.ts
+++ b/src/tools/file-write.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Tool, ToolResult } from "./registry";
-import { mkdir, stat, writeFile, readFile, chmod, access } from "fs/promises";
+import { mkdir, stat, readFile, access } from "fs/promises";
+import { writeFileAtomic } from "../util/atomic-write.js";
 import { basename, dirname } from "path";
 import { ask as askPermission } from "../permission";
 import { validateWritePath } from "./mode-state";
@@ -128,11 +129,11 @@ export const fileWrite: Tool<WriteInput> = Tool.define(
         }
       }
 
-      await writeFile(safePath, input.content, "utf-8");
-
-      if (existingPermissions !== undefined) {
-        await chmod(safePath, existingPermissions);
-      }
+      await writeFileAtomic(
+        safePath,
+        input.content,
+        existingPermissions !== undefined ? { mode: existingPermissions } : undefined
+      );
 
       // Count logical content lines written. Empty files have 0 lines.
       const linesWritten = input.content.length === 0 ? 0 : input.content.split("\n").length;

--- a/src/tools/posix-translation.ts
+++ b/src/tools/posix-translation.ts
@@ -188,6 +188,49 @@ const TRANSLATIONS: CommandTranslation[] = [
     description: "touch -> New-Item -ItemType File",
   },
 
+  // cp -r / cp -> Copy-Item
+  {
+    pattern: /^cp\s+((?:-[rRpfiv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const recurse = flags.includes("r") || flags.includes("R") ? " -Recurse" : "";
+      const force = flags.includes("f") ? " -Force" : "";
+      return `Copy-Item${recurse}${force} -Path ${quotePowerShellArray(parseShellWords(m[2]))} -Destination ${quotePowerShellArray(parseShellWords(m[3]))}`;
+    },
+    description: "cp -> Copy-Item",
+  },
+
+  // mv -> Move-Item
+  {
+    pattern: /^mv\s+((?:-[fiv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const force = flags.includes("f") ? " -Force" : "";
+      return `Move-Item${force} -Path ${quotePowerShellArray(parseShellWords(m[2]))} -Destination ${quotePowerShellArray(parseShellWords(m[3]))}`;
+    },
+    description: "mv -> Move-Item",
+  },
+
+  // grep (single arg, no pipeline) -> Select-String
+  {
+    pattern: /^grep\s+((?:-[nliEv]+\s+)*)?(?!-)(.+?)\s+(.+)$/,
+    replacement: (m) => {
+      const flags = m[1] || "";
+      const caseInsensitive = flags.includes("i") ? " -CaseSensitive:$false" : " -CaseSensitive";
+      const listOnly = flags.includes("l") ? " | Select-Object Path" : "";
+      const notMatch = flags.includes("v") ? " -NotMatch" : "";
+      return `Select-String${caseInsensitive}${notMatch} -Pattern ${quotePowerShellArray(parseShellWords(m[2]))} -Path ${quotePowerShellArray(parseShellWords(m[3]))}${listOnly}`;
+    },
+    description: "grep -> Select-String",
+  },
+
+  // which -> (Get-Command ...).Source
+  {
+    pattern: /^which\s+(\S+)$/,
+    replacement: (m) => `(Get-Command ${m[1]} -ErrorAction SilentlyContinue).Source`,
+    description: "which -> (Get-Command).Source",
+  },
+
 ];
 
 /**

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "../session/manager";
 import fs from "fs/promises";
 import path from "path";
 import z from "zod";
+import { clearWindowsShellCache, clearWslCache } from "./windows-shell.js";
 
 // ============================================================
 // Multi-Provider Config Schema
@@ -141,7 +142,16 @@ const ConfigSchema = z.object({
 
   // Legacy — kept for smooth migration; prefer providers[].apiKey
   apiKey: z.string().optional().describe("Legacy: use providers[defaultProvider].apiKey instead"),
+
+  /**
+   * Preferred shell for bash tool execution on Windows.
+   * "auto" (default) = detect from parent process.
+   * Other values force a specific shell regardless of detection.
+   */
+  preferredShell: z.enum(["auto", "powershell", "pwsh", "git-bash", "wsl", "cmd"]).default("auto"),
 });
+
+export type PreferredShell = z.infer<typeof ConfigSchema.shape.preferredShell>;
 
 export type Config = z.infer<typeof ConfigSchema>;
 export type UserProfile = NonNullable<Config["userProfile"]>;
@@ -323,7 +333,7 @@ export function resolveSubagentModel(config: Config, mainModel: string): string 
 export async function save(config: Config): Promise<void> {
   const parsed = applyDefaults(config);
   await fs.mkdir(Global.Path.config, { recursive: true });
-  
+
   // Write config and explicitly sync to disk to ensure it's persisted
   // This is especially important on Windows where filesystem operations
   // may be cached and not immediately visible to subsequent reads
@@ -334,6 +344,12 @@ export async function save(config: Config): Promise<void> {
   } finally {
     await fd.close();
   }
-  
+
+  // Clear shell detection caches when preferredShell changes so next command picks up the new setting
+  if (cachedConfig?.preferredShell !== parsed.preferredShell) {
+    clearWindowsShellCache();
+    clearWslCache();
+  }
+
   cachedConfig = parsed;
 }

--- a/src/util/shell-env.ts
+++ b/src/util/shell-env.ts
@@ -18,7 +18,7 @@ export interface ShellEnvironment {
   shellType: WindowsCommandShellType | "bash" | "zsh" | "fish" | "sh" | "unknown";
   /** Shell actually used by the bash tool for command execution. */
   commandShell: string;
-  commandShellType: WindowsCommandShellType | "bash";
+  commandShellType: WindowsCommandShellType | "bash" | "wsl";
   supportsChainedCommands: boolean;
   commandSeparator: string; // ; or && depending on shell
   recommendations: string[];
@@ -386,6 +386,14 @@ export function generateShellContext(env: ShellEnvironment): string {
       parts.push("- Use bash/POSIX syntax");
       parts.push("- Supports && (and), || (or), and ; (unconditional) operators");
       parts.push("- POSIX-to-PowerShell translation is not applied in Git Bash");
+      break;
+
+    case "wsl":
+      parts.push("- Commands run inside WSL (Windows Subsystem for Linux) — use POSIX/bash syntax");
+      parts.push("- Supports && (and), || (or), and ; (unconditional) operators");
+      parts.push("- Windows paths are accessible under /mnt/ (e.g. C:\\Users → /mnt/c/Users)");
+      parts.push("- Linux-native package managers (apt, etc.) are available inside WSL");
+      parts.push("- Working directory is auto-translated from Windows path to /mnt/... form");
       break;
 
     case "bash":

--- a/src/util/shell-env.ts
+++ b/src/util/shell-env.ts
@@ -405,3 +405,72 @@ export function generateShellContext(env: ShellEnvironment): string {
   return parts.join("\n");
 }
 import { detectWindowsCommandShell, type WindowsCommandShellType } from "./windows-shell.js";
+
+// ---------------------------------------------------------------------------
+// Tool-availability probe (#118 item 3 / #115 shared)
+// ---------------------------------------------------------------------------
+
+export interface ToolAvailability {
+  available: string[];   // "git 2.41.0" style (version when probed, name-only as fallback)
+  unavailable: string[];
+}
+
+let cachedToolAvailability: Promise<ToolAvailability> | undefined;
+
+const COMMON_TOOLS = ["git", "node", "npm", "bun", "python", "docker", "rg", "jq", "curl"];
+const WINDOWS_EXTRA = ["wsl"];
+
+async function probeOneTool(name: string): Promise<string | null> {
+  try {
+    const found = Bun.which(name);
+    if (!found) return null;
+    // Probe version with a quick, per-check 1.5s timeout
+    const proc = Bun.spawn({
+      cmd: [name, "--version"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timer = new Promise<"timeout">((r) => setTimeout(() => { try { proc.kill(); } catch { /* */ } r("timeout"); }, 1500));
+    const result = await Promise.race([
+      new Response(proc.stdout).text().then((t) => t.trim().split("\n")[0] ?? ""),
+      timer,
+    ]);
+    if (result === "timeout" || !result) return name;
+    // Keep only the first 60 chars to avoid huge version strings
+    return `${name} (${result.slice(0, 60)})`;
+  } catch {
+    return null;
+  }
+}
+
+export async function probeToolAvailability(): Promise<ToolAvailability> {
+  cachedToolAvailability ??= probeToolAvailabilityUncached();
+  return cachedToolAvailability;
+}
+
+async function probeToolAvailabilityUncached(): Promise<ToolAvailability> {
+  const tools = process.platform === "win32"
+    ? [...COMMON_TOOLS, ...WINDOWS_EXTRA]
+    : COMMON_TOOLS;
+
+  const results = await Promise.all(tools.map(probeOneTool));
+
+  const available: string[] = [];
+  const unavailable: string[] = [];
+  for (let i = 0; i < tools.length; i++) {
+    if (results[i] !== null) available.push(results[i]!);
+    else unavailable.push(tools[i]!);
+  }
+  return { available, unavailable };
+}
+
+export function formatToolAvailabilityBlock(avail: ToolAvailability): string {
+  const lines: string[] = ["## Available CLI tools"];
+  if (avail.available.length > 0) {
+    lines.push(`Available: ${avail.available.join(", ")}`);
+  }
+  if (avail.unavailable.length > 0) {
+    lines.push(`Not found: ${avail.unavailable.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/util/tool-output-cap.ts
+++ b/src/util/tool-output-cap.ts
@@ -21,7 +21,7 @@ export function capBashOutputLines(
   maxLines: number,
   maxLineChars = MAX_BASH_LINE_CHARS,
   maxBytes = MAX_BASH_OUTPUT_BYTES
-): { output: string; truncated: boolean } {
+): { output: string; truncated: boolean; keptLines: number } {
   const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const rawLines = normalized.length > 0 ? normalized.split("\n") : [];
   const cappedLines: string[] = [];
@@ -58,7 +58,7 @@ export function capBashOutputLines(
     output += `\n[Output truncated: ${reason}]`;
   }
 
-  return { output, truncated };
+  return { output, truncated, keptLines: cappedLines.length };
 }
 
 export function stubOversizedMessageContent(

--- a/src/util/windows-shell.ts
+++ b/src/util/windows-shell.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-export type WindowsCommandShellType = "powershell5" | "powershell7" | "cmd" | "git-bash";
+export type WindowsCommandShellType = "powershell5" | "powershell7" | "cmd" | "git-bash" | "wsl";
 
 export interface WindowsCommandShell {
   type: WindowsCommandShellType;
@@ -95,6 +95,8 @@ function shellDisplayName(type: WindowsCommandShellType, version?: string): stri
       return "Windows Command Prompt (cmd.exe)";
     case "git-bash":
       return "Git Bash";
+    case "wsl":
+      return version ? `WSL (${version})` : "WSL (Windows Subsystem for Linux)";
   }
 }
 
@@ -103,6 +105,7 @@ function makeShell(
   executable: string,
   version?: string
 ): WindowsCommandShell {
+  // powershell5 uses ; for chaining; all other types (including wsl) support &&
   const supportsChainedCommands = type !== "powershell5";
   return {
     type,
@@ -132,6 +135,7 @@ export function classifyWindowsShellExecutable(
       return "git-bash";
     }
   }
+  if (base === "wsl.exe" || base === "wsl") return "wsl";
 
   return null;
 }
@@ -289,4 +293,45 @@ export async function detectWindowsCommandShell(
 
 export function clearWindowsShellCache(): void {
   cachedWindowsShell = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// WSL detection (#115)
+// ---------------------------------------------------------------------------
+
+let cachedWslAvailable: Promise<WindowsCommandShell | null> | undefined;
+
+/**
+ * Probe whether WSL is installed and return a shell descriptor for it.
+ * Returns null when wsl.exe is not found or the WSL service is not running.
+ * Result is cached for the process lifetime.
+ */
+export async function detectWslShell(): Promise<WindowsCommandShell | null> {
+  cachedWslAvailable ??= detectWslShellUncached();
+  return cachedWslAvailable;
+}
+
+async function detectWslShellUncached(): Promise<WindowsCommandShell | null> {
+  const wslPath = findOnPath("wsl.exe") ?? findOnPath("wsl");
+  if (!wslPath) return null;
+  try {
+    const proc = Bun.spawn({
+      cmd: [wslPath, "-l", "--quiet"],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const { stdout, timedOut } = await readStdoutAndDrainStderr(proc, 3000);
+    if (timedOut || proc.exitCode !== 0) return null;
+    // stdout lists distro names; any output means WSL has ≥1 distro
+    const distros = stdout.split(/\r?\n/).map((l) => l.replace(/\0/g, "").trim()).filter(Boolean);
+    if (distros.length === 0) return null;
+    const version = distros[0]; // use first distro name as display label
+    return makeShell("wsl", wslPath, version);
+  } catch {
+    return null;
+  }
+}
+
+export function clearWslCache(): void {
+  cachedWslAvailable = undefined;
 }

--- a/test/bash-error-classifier.test.ts
+++ b/test/bash-error-classifier.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCommandError } from "../src/tools/bash.js";
+
+describe("classifyCommandError", () => {
+  test("returns null on a successful exit", () => {
+    expect(classifyCommandError("foo", "anything", 0, "bash")).toBeNull();
+  });
+
+  test("PowerShell: recognizes a cmdlet-not-found error", () => {
+    const hint = classifyCommandError(
+      "grep foo",
+      "grep : The term 'grep' is not recognized as the name of a cmdlet, function, script file, or operable program.",
+      1,
+      "powershell"
+    );
+    expect(hint).toContain("'grep' is not a recognised PowerShell cmdlet");
+  });
+
+  test("PowerShell: recognizes CommandNotFoundException", () => {
+    const hint = classifyCommandError("jq", "CommandNotFoundException", 1, "powershell");
+    expect(hint).toContain("'jq' is not a recognised PowerShell cmdlet");
+  });
+
+  test("cmd: recognizes an internal/external command failure", () => {
+    const hint = classifyCommandError(
+      "curl example.com",
+      "'curl' is not recognized as an internal or external command,",
+      1,
+      "cmd"
+    );
+    expect(hint).toContain("'curl' was not found");
+  });
+
+  test("bash: recognizes command-not-found via message and exit code 127", () => {
+    const byMessage = classifyCommandError("foobarbaz", "bash: foobarbaz: command not found", 127, "bash");
+    expect(byMessage).toContain("'foobarbaz' was not found on PATH");
+
+    const byExitCode = classifyCommandError("foobarbaz", "", 127, "bash");
+    expect(byExitCode).toContain("'foobarbaz' was not found on PATH");
+  });
+
+  test("bash: recognizes permission-denied via message and exit code 126", () => {
+    const hint = classifyCommandError("./script.sh", "Permission denied", 126, "bash");
+    expect(hint).toContain("Permission denied executing './script.sh'");
+  });
+
+  test("bash: returns null when the output doesn't match a known pattern", () => {
+    expect(classifyCommandError("foo", "some other failure", 2, "bash")).toBeNull();
+  });
+
+  test("uses only the first whitespace-delimited token as the command name", () => {
+    const hint = classifyCommandError("some-tool --flag value", "command not found", 127, "bash");
+    expect(hint).toContain("'some-tool' was not found on PATH");
+  });
+});

--- a/test/bash-pagination.test.ts
+++ b/test/bash-pagination.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { bashTool } from "../src/tools/bash.js";
+import { resetAllowAllBypass, setAllowAllBypass } from "../src/permission/index.js";
+
+describe("bash output pagination", () => {
+  let root: string;
+
+  beforeAll(() => {
+    setAllowAllBypass(true);
+    root = mkdtempSync(path.join(tmpdir(), "impulse-bash-pagination-"));
+  });
+
+  afterAll(() => {
+    resetAllowAllBypass();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("offset/limit within the byte cap reports the accurate next offset", async () => {
+    const file = path.join(root, "lines-6000.txt");
+    writeFileSync(file, Array.from({ length: 6000 }, (_, i) => `line${i}`).join("\n"));
+
+    const result = await bashTool.handler({
+      command: "cat lines-6000.txt",
+      description: "test pagination",
+      workdir: root,
+      limit: 5000,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    // The 2000-line hard cap governs even though the caller asked for 5000,
+    // so the note must flag that the requested slice was further capped.
+    expect(result.output).toContain("[Output paginated: lines 1-2000 of 6000, further capped by output size limits");
+    expect(result.output).toContain("Re-run with offset: 2000 for more.]");
+  });
+
+  test("a byte-cap hit is reflected in the pagination note and next offset", async () => {
+    const file = path.join(root, "lines-wide.txt");
+    writeFileSync(file, Array.from({ length: 300 }, (_, i) => `L${i}-${"x".repeat(1000)}`).join("\n"));
+
+    const result = await bashTool.handler({
+      command: "cat lines-wide.txt",
+      description: "test pagination byte cap",
+      workdir: root,
+      limit: 250,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    const match = result.output.match(/\[Output paginated: lines 1-(\d+) of 300, further capped by output size limits\. Re-run with offset: (\d+) for more\.\]/);
+    expect(match).not.toBeNull();
+    const delivered = Number(match?.[1]);
+    const nextOffset = Number(match?.[2]);
+    expect(delivered).toBeLessThan(250);
+    expect(nextOffset).toBe(delivered);
+  });
+
+  test("no offset/limit means legacy (non-paginated) behavior", async () => {
+    const file = path.join(root, "small.txt");
+    writeFileSync(file, "a\nb\nc");
+
+    const result = await bashTool.handler({
+      command: "cat small.txt",
+      description: "test no pagination",
+      workdir: root,
+      timeout: 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("a\nb\nc");
+    expect(result.output).not.toContain("[Output paginated:");
+  });
+});

--- a/test/bash-timeout-resolution.test.ts
+++ b/test/bash-timeout-resolution.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBashTimeoutMs } from "../src/tools/bash.js";
+
+describe("resolveBashTimeoutMs", () => {
+  test("timeout: 0 means no limit", () => {
+    expect(resolveBashTimeoutMs(0)).toBeUndefined();
+  });
+
+  test("omitted timeout falls back to the 120s default", () => {
+    expect(resolveBashTimeoutMs(undefined)).toBe(120_000);
+  });
+
+  test("an explicit timeout passes through unchanged", () => {
+    expect(resolveBashTimeoutMs(5000)).toBe(5000);
+  });
+});

--- a/test/file-read.test.ts
+++ b/test/file-read.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+import { fileRead } from "../src/tools/file-read.js";
+
+describe("file_read", () => {
+  // sanitizePath() restricts reads to within process.cwd() by default, so
+  // fixtures must live under the repo root rather than the OS tmpdir.
+  const root = path.join(process.cwd(), `.tmp-file-read-${Date.now()}`);
+
+  beforeAll(() => {
+    mkdirSync(root, { recursive: true });
+    mkdirSync(path.join(root, "subdir"));
+    writeFileSync(path.join(root, "hello-world.ts"), "content");
+    writeFileSync(path.join(root, "another.ts"), "content");
+
+    // Binary / encoding fixtures
+    writeFileSync(path.join(root, "image.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    writeFileSync(path.join(root, "utf16.txt"), Buffer.from([0xff, 0xfe, 0x61, 0x00, 0x62, 0x00]));
+    writeFileSync(path.join(root, "bom.txt"), Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello", "utf-8")]));
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("ENOENT includes a Did you mean suggestion for a close filename", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "hello_world.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("File not found:");
+    expect(result.output).toContain("Did you mean: hello-world.ts?");
+  });
+
+  test("ENOENT includes a compact directory listing", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "does-not-exist.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain(`Directory ${root}`);
+    expect(result.output).toContain("subdir/");
+    expect(result.output).toContain("hello-world.ts");
+  });
+
+  test("ENOENT on a missing directory returns no hint (readdir fails too)", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "ghost-dir", "missing.ts") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toBe(`File not found: ${path.join(root, "ghost-dir", "missing.ts")}`);
+  });
+
+  test("binary file (PNG) is rejected with a clear message", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "image.png") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Cannot read binary file");
+    expect(result.output).toContain("PNG image");
+  });
+
+  test("UTF-16 file is rejected with an encoding notice", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "utf16.txt") });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("UTF-16 LE");
+  });
+
+  test("UTF-8 BOM is silently stripped", async () => {
+    const result = await fileRead.handler({ filePath: path.join(root, "bom.txt") });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("hello");
+    expect(result.output).not.toContain("﻿");
+  });
+});

--- a/test/goal-artifact.test.ts
+++ b/test/goal-artifact.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createGoalState } from "../src/session/goal-state.js";
+import { createPlanRevision } from "../src/plan/revisions.js";
+import {
+  deleteGoalArtifact,
+  readGoalArtifact,
+  writeGoalArtifact,
+} from "../src/goal/artifact.js";
+import { getGoalDir } from "../src/goal/paths.js";
+
+describe("goal artifact", () => {
+  let tmp: string;
+  const sessionId = "sess_goal_artifact_test";
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-goal-artifact-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("writes and reads back a goal without a plan reference", async () => {
+    const state = createGoalState("Ship the thing");
+    await writeGoalArtifact(sessionId, state, tmp);
+
+    const goalMd = fs.readFileSync(path.join(getGoalDir(sessionId, tmp), "goal.md"), "utf-8");
+    expect(goalMd).toContain("Ship the thing");
+    expect(goalMd).not.toContain("## Plan reference");
+    expect(goalMd).not.toContain("## Acceptance criteria");
+
+    const read = readGoalArtifact(sessionId, tmp);
+    expect(read).toEqual(state);
+  });
+
+  test("goal.md includes a plan reference and acceptance criteria section when planRevisionId is set", async () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    const state = createGoalState("Complete all tasks", { planRevisionId: rev.meta.revisionId });
+    await writeGoalArtifact(sessionId, state, tmp);
+
+    const goalMd = fs.readFileSync(path.join(getGoalDir(sessionId, tmp), "goal.md"), "utf-8");
+    expect(goalMd).toContain("## Plan reference");
+    expect(goalMd).toContain(`Revision: ${rev.meta.revisionId}`);
+    expect(goalMd).toContain("tasks.md");
+    expect(goalMd).toContain("## Acceptance criteria");
+  });
+
+  test("state.json round-trips through readGoalArtifact with planRevisionId intact", async () => {
+    const state = createGoalState("Track this", { planRevisionId: "rev-xyz" });
+    await writeGoalArtifact(sessionId, state, tmp);
+
+    const read = readGoalArtifact(sessionId, tmp);
+    expect(read?.planRevisionId).toBe("rev-xyz");
+  });
+
+  test("deleteGoalArtifact removes the directory", async () => {
+    const state = createGoalState("Temp goal");
+    await writeGoalArtifact(sessionId, state, tmp);
+    expect(readGoalArtifact(sessionId, tmp)).not.toBeNull();
+
+    deleteGoalArtifact(sessionId, tmp);
+    expect(readGoalArtifact(sessionId, tmp)).toBeNull();
+  });
+});

--- a/test/goal-judge-plan.test.ts
+++ b/test/goal-judge-plan.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createGoalState } from "../src/session/goal-state.js";
+import { createPlanRevision, readPlanTasksMarkdown } from "../src/plan/revisions.js";
+import { buildGoalContinuationMessage, buildJudgeMessages } from "../src/agent/goal-loop.js";
+
+describe("buildJudgeMessages", () => {
+  test("uses the free-text judge prompt when no plan tasks are provided", () => {
+    const goal = createGoalState("Finish the refactor");
+    const [system, user] = buildJudgeMessages(goal, "I finished the refactor.");
+    expect(system.content).toContain("You judge whether a coding agent goal is complete");
+    expect(system.content).not.toContain("checklist");
+    expect(user.content).toContain("Finish the refactor");
+    expect(user.content).toContain("I finished the refactor.");
+    expect(user.content).not.toContain("tasks.md");
+  });
+
+  test("uses the checklist judge prompt when plan tasks are provided", () => {
+    const goal = createGoalState("Complete the plan", { planRevisionId: "rev-42" });
+    const tasksMd = "- [x] task 1\n- [ ] task 2";
+    const [system, user] = buildJudgeMessages(goal, "Working on task 2.", tasksMd);
+    expect(system.content).toContain("checklist");
+    expect(system.content).toContain("complete ONLY when every task");
+    expect(user.content).toContain("rev-42");
+    expect(user.content).toContain(tasksMd);
+    expect(user.content).toContain("Working on task 2.");
+  });
+
+  test("slices an oversized tasks.md to the 6000-char cap", () => {
+    const goal = createGoalState("Complete the plan", { planRevisionId: "rev-42" });
+    const hugeTasks = "x".repeat(10_000);
+    const [, user] = buildJudgeMessages(goal, "text", hugeTasks);
+    // 6000 chars of tasks plus surrounding template text, but never the full 10k blob.
+    expect(user.content.length).toBeLessThan(10_000);
+    expect(user.content).toContain("x".repeat(6000));
+  });
+
+  test("slices an oversized last-assistant message to the 4000-char cap", () => {
+    const goal = createGoalState("Finish the refactor");
+    const hugeMessage = "y".repeat(10_000);
+    const [, user] = buildJudgeMessages(goal, hugeMessage);
+    expect(user.content).toContain("y".repeat(4000));
+    expect(user.content).not.toContain("y".repeat(4001));
+  });
+});
+
+describe("buildGoalContinuationMessage", () => {
+  test("includes the plan tasks path when provided", () => {
+    const goal = createGoalState("Complete the plan", { planRevisionId: "rev-42" });
+    const msg = buildGoalContinuationMessage(goal, { planTasksPath: ".impulse/plans/s/revisions/rev-42/tasks.md" });
+    expect(msg).toContain(".impulse/plans/s/revisions/rev-42/tasks.md");
+    expect(msg).toContain("check them off");
+  });
+
+  test("omits the plan checklist instruction when no path is provided", () => {
+    const goal = createGoalState("Finish the refactor");
+    const msg = buildGoalContinuationMessage(goal);
+    expect(msg).not.toContain("checklist");
+  });
+});
+
+describe("readPlanTasksMarkdown", () => {
+  let tmp: string;
+  const sessionId = "sess_judge_plan_test";
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-judge-plan-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns the tasks.md content for an existing revision", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    fs.writeFileSync(rev.files["tasks.md"]!, "- [ ] task 1");
+    expect(readPlanTasksMarkdown(sessionId, rev.meta.revisionId, tmp)).toBe("- [ ] task 1");
+  });
+
+  test("returns null when the revision doesn't exist", () => {
+    expect(readPlanTasksMarkdown(sessionId, "nonexistent-revision", tmp)).toBeNull();
+  });
+
+  test("returns null when the revision exists but tasks.md hasn't been written", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    expect(readPlanTasksMarkdown(sessionId, rev.meta.revisionId, tmp)).toBeNull();
+  });
+});

--- a/test/goal-state.test.ts
+++ b/test/goal-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { createGoalState, parseGoalState } from "../src/session/goal-state.js";
+
+describe("createGoalState", () => {
+  test("creates an active goal with default maxTurns and no planRevisionId", () => {
+    const state = createGoalState("Ship the feature");
+    expect(state.text).toBe("Ship the feature");
+    expect(state.status).toBe("active");
+    expect(state.turnsUsed).toBe(0);
+    expect(state.maxTurns).toBe(20);
+    expect(state.planRevisionId).toBeUndefined();
+  });
+
+  test("accepts custom maxTurns and planRevisionId via options", () => {
+    const state = createGoalState("Finish tasks.md", { maxTurns: 5, planRevisionId: "2026-01-01T00-00-00-000" });
+    expect(state.maxTurns).toBe(5);
+    expect(state.planRevisionId).toBe("2026-01-01T00-00-00-000");
+  });
+});
+
+describe("parseGoalState", () => {
+  test("round-trips a goal without planRevisionId", () => {
+    const original = createGoalState("Do the thing");
+    const parsed = parseGoalState(JSON.parse(JSON.stringify(original)));
+    expect(parsed).toEqual(original);
+    expect(parsed?.planRevisionId).toBeUndefined();
+  });
+
+  test("round-trips a goal with planRevisionId", () => {
+    const original = createGoalState("Do the thing", { planRevisionId: "rev-1" });
+    const parsed = parseGoalState(JSON.parse(JSON.stringify(original)));
+    expect(parsed?.planRevisionId).toBe("rev-1");
+  });
+
+  test("drops a non-string planRevisionId", () => {
+    const parsed = parseGoalState({ text: "goal", status: "active", turnsUsed: 0, maxTurns: 20, planRevisionId: 123 });
+    expect(parsed?.planRevisionId).toBeUndefined();
+  });
+
+  test("drops a blank planRevisionId", () => {
+    const parsed = parseGoalState({ text: "goal", status: "active", turnsUsed: 0, maxTurns: 20, planRevisionId: "   " });
+    expect(parsed?.planRevisionId).toBeUndefined();
+  });
+
+  test("returns undefined for invalid input", () => {
+    expect(parseGoalState(null)).toBeUndefined();
+    expect(parseGoalState({})).toBeUndefined();
+    expect(parseGoalState({ text: "x", status: "bogus" })).toBeUndefined();
+  });
+});

--- a/test/plan-completion-handoff.test.ts
+++ b/test/plan-completion-handoff.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createPlanRevision } from "../src/plan/revisions.js";
+import {
+  checkPlanCompletionHandoff,
+  planCompletionToolBehavior,
+} from "../src/agent/plan-completion.js";
+
+describe("checkPlanCompletionHandoff", () => {
+  let tmp: string;
+  const sessionId = "sess_handoff_test";
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "impulse-plan-handoff-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns null when the current mode isn't PLAN", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    fs.writeFileSync(rev.files["tasks.md"]!, "- [ ] task 1");
+    expect(checkPlanCompletionHandoff("AGENT", "AGENT", sessionId, tmp)).toBeNull();
+  });
+
+  test("returns null when the requested mode isn't AGENT", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    fs.writeFileSync(rev.files["tasks.md"]!, "- [ ] task 1");
+    expect(checkPlanCompletionHandoff("PLAN", "EXPLORE", sessionId, tmp)).toBeNull();
+  });
+
+  test("returns null when there is no active plan revision", () => {
+    expect(checkPlanCompletionHandoff("PLAN", "AGENT", sessionId, tmp)).toBeNull();
+  });
+
+  test("returns null when tasks.md hasn't been written yet", () => {
+    createPlanRevision(sessionId, undefined, tmp);
+    expect(checkPlanCompletionHandoff("PLAN", "AGENT", sessionId, tmp)).toBeNull();
+  });
+
+  test("returns handoff paths when PLAN artifacts (tasks.md) exist", () => {
+    const rev = createPlanRevision(sessionId, undefined, tmp);
+    fs.writeFileSync(rev.files["tasks.md"]!, "- [ ] task 1\n- [ ] task 2");
+
+    const handoff = checkPlanCompletionHandoff("PLAN", "AGENT", sessionId, tmp);
+    expect(handoff).not.toBeNull();
+    expect(handoff!.tasksPathRel).toContain("tasks.md");
+    expect(handoff!.planDirRel).toContain(rev.meta.revisionId);
+  });
+});
+
+describe("planCompletionToolBehavior", () => {
+  const tasksPathRel = ".impulse/plans/s/revisions/r/tasks.md";
+
+  test("execute switches mode and instructs immediate implementation", () => {
+    const behavior = planCompletionToolBehavior("execute", tasksPathRel);
+    expect(behavior.performSwitch).toBe(true);
+    expect(behavior.output).toContain(tasksPathRel);
+    expect(behavior.output).toContain("EXECUTE");
+  });
+
+  test("proceed switches mode and waits for the next instruction", () => {
+    const behavior = planCompletionToolBehavior("proceed", tasksPathRel);
+    expect(behavior.performSwitch).toBe(true);
+    expect(behavior.output).toContain("PROCEED");
+  });
+
+  test("revise does not switch mode", () => {
+    const behavior = planCompletionToolBehavior("revise", tasksPathRel);
+    expect(behavior.performSwitch).toBe(false);
+    expect(behavior.output).toContain("REVISE");
+  });
+
+  test("cancel does not switch mode", () => {
+    const behavior = planCompletionToolBehavior("cancel", tasksPathRel);
+    expect(behavior.performSwitch).toBe(false);
+    expect(behavior.output).toContain("cancelled");
+  });
+});

--- a/test/plan-completion-overlay.test.ts
+++ b/test/plan-completion-overlay.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PlanCompletionOverlay,
+  type PlanCompletionDecision,
+} from "../src/cli/components/plan-completion-overlay.js";
+
+function makeOverlay(): { overlay: PlanCompletionOverlay; decisions: PlanCompletionDecision[] } {
+  const overlay = new PlanCompletionOverlay({ planPath: ".impulse/plans/x/revisions/y", summary: "" });
+  const decisions: PlanCompletionDecision[] = [];
+  overlay.onDecision = (d) => decisions.push(d);
+  return { overlay, decisions };
+}
+
+describe("PlanCompletionOverlay.handleInput", () => {
+  test('key "1" always fires execute, regardless of the currently highlighted option', () => {
+    const { overlay, decisions } = makeOverlay();
+    // Navigate right twice (now highlighting "Revise", index 2) before pressing "1".
+    overlay.handleInput("\x1b[C");
+    overlay.handleInput("\x1b[C");
+    overlay.handleInput("1");
+    expect(decisions).toEqual(["execute"]);
+  });
+
+  test("Enter fires whichever option is currently highlighted", () => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput("\x1b[C"); // -> proceed
+    overlay.handleInput("\r");
+    expect(decisions).toEqual(["proceed"]);
+  });
+
+  test("Enter with no navigation defaults to the first option (execute)", () => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput("\r");
+    expect(decisions).toEqual(["execute"]);
+  });
+
+  test('key "2" always fires proceed', () => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput("2");
+    expect(decisions).toEqual(["proceed"]);
+  });
+
+  test('key "3" always fires revise', () => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput("3");
+    expect(decisions).toEqual(["revise"]);
+  });
+
+  test.each(["4", "\x1b", "\x03", "q", "Q"])("%s cancels", (key) => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput(key);
+    expect(decisions).toEqual(["cancel"]);
+  });
+
+  test("arrow navigation wraps around in both directions", () => {
+    const { overlay, decisions } = makeOverlay();
+    overlay.handleInput("\x1b[D"); // left from index 0 wraps to index 3 (cancel)
+    overlay.handleInput("\r");
+    expect(decisions).toEqual(["cancel"]);
+  });
+
+  test("render() produces non-empty lines including the plan path and options", () => {
+    const overlay = new PlanCompletionOverlay({
+      planPath: ".impulse/plans/abc/revisions/2026-01-01",
+      summary: "Add feature X",
+    });
+    const lines = overlay.render(80);
+    expect(lines.length).toBeGreaterThan(0);
+    const joined = lines.join("\n");
+    expect(joined).toContain(".impulse/plans/abc/revisions/2026-01-01");
+    expect(joined).toContain("Add feature X");
+  });
+});

--- a/test/posix-translation.test.ts
+++ b/test/posix-translation.test.ts
@@ -29,22 +29,56 @@ describe("translatePosixToPowerShell", () => {
   });
 
   test("leaves complex command families unchanged", () => {
+    // -r isn't in grep's supported single-command flag set (recursive grep needs
+    // full pipeline/shell semantics), so it's intentionally left untranslated.
     expect(translatePosixToPowerShell("grep -r my pattern src")).toEqual({
       translated: "grep -r my pattern src",
       wasTranslated: false,
     });
+    // which only translates a single bare command name, not multiple arguments.
     expect(translatePosixToPowerShell("which git node")).toEqual({
       translated: "which git node",
       wasTranslated: false,
     });
-    expect(translatePosixToPowerShell("cp -R src dst")).toEqual({
-      translated: "cp -R src dst",
-      wasTranslated: false,
-    });
-    expect(translatePosixToPowerShell("mv src dst")).toEqual({
-      translated: "mv src dst",
-      wasTranslated: false,
-    });
+  });
+
+  test("translates cp -> Copy-Item, including recursive/force flags", () => {
+    expect(translatePosixToPowerShell("cp -R src dst").translated).toBe(
+      "Copy-Item -Recurse -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("cp -rf src dst").translated).toBe(
+      "Copy-Item -Recurse -Force -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("cp src.txt dst.txt").translated).toBe(
+      "Copy-Item -Path 'src.txt' -Destination 'dst.txt'"
+    );
+  });
+
+  test("translates mv -> Move-Item, including the force flag", () => {
+    expect(translatePosixToPowerShell("mv src dst").translated).toBe(
+      "Move-Item -Path 'src' -Destination 'dst'"
+    );
+    expect(translatePosixToPowerShell("mv -f old.txt new.txt").translated).toBe(
+      "Move-Item -Force -Path 'old.txt' -Destination 'new.txt'"
+    );
+  });
+
+  test("translates a simple grep -> Select-String", () => {
+    expect(translatePosixToPowerShell("grep pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive -Pattern 'pattern' -Path 'file.txt'"
+    );
+    expect(translatePosixToPowerShell("grep -i pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive:$false -Pattern 'pattern' -Path 'file.txt'"
+    );
+    expect(translatePosixToPowerShell("grep -v pattern file.txt").translated).toBe(
+      "Select-String -CaseSensitive -NotMatch -Pattern 'pattern' -Path 'file.txt'"
+    );
+  });
+
+  test("translates which for a single command name", () => {
+    expect(translatePosixToPowerShell("which git").translated).toBe(
+      "(Get-Command git -ErrorAction SilentlyContinue).Source"
+    );
   });
 
   test("quotes translated path arguments", () => {

--- a/test/project-structure.test.ts
+++ b/test/project-structure.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+import {
+  buildProjectStructureProbe,
+  clearProjectStructureCache,
+  formatProjectStructureBlock,
+  probeProjectStructure,
+} from "../src/agent/project-structure.js";
+
+describe("buildProjectStructureProbe", () => {
+  test("returns null for an empty file list", () => {
+    expect(buildProjectStructureProbe([])).toBeNull();
+  });
+
+  test("returns null when the scanned file count is too large", () => {
+    const huge = Array.from({ length: 20_001 }, (_, i) => `file${i}.txt`);
+    expect(buildProjectStructureProbe(huge)).toBeNull();
+  });
+
+  test("groups nested files under directory nodes with recursive counts", () => {
+    const probe = buildProjectStructureProbe([
+      "src/agent/loop.ts",
+      "src/agent/prompts.ts",
+      "src/cli/renderer.ts",
+      "package.json",
+      "README.md",
+    ]);
+
+    expect(probe).not.toBeNull();
+    expect(probe!.rootLooseFiles).toEqual(["package.json", "README.md"]);
+    const src = probe!.root.children.get("src")!;
+    expect(src.totalFiles).toBe(3);
+    expect(src.children.get("agent")!.totalFiles).toBe(2);
+    expect(src.children.get("cli")!.totalFiles).toBe(1);
+  });
+});
+
+describe("formatProjectStructureBlock", () => {
+  test("formats a small tree at the default depth", () => {
+    const probe = buildProjectStructureProbe([
+      "src/agent/loop.ts",
+      "src/cli/renderer.ts",
+      "package.json",
+    ]);
+    const block = formatProjectStructureBlock(probe);
+
+    expect(block).toContain("## Project structure (depth 3, gitignore-respecting)");
+    expect(block).toContain("src/");
+    expect(block).toContain("agent/ (1 files)");
+    expect(block).toContain("package.json");
+  });
+
+  test("returns empty string for a null probe", () => {
+    expect(formatProjectStructureBlock(null)).toBe("");
+  });
+
+  test("backs off to a shallower depth when the tree is too large to render at depth 3", () => {
+    // Enough distinct deep subdirectories that depth-3 rendering exceeds the line cap,
+    // forcing a back-off to depth 2 (or 1).
+    const files = Array.from({ length: 60 }, (_, i) => `src/mod${i}/sub/file.ts`);
+    const probe = buildProjectStructureProbe(files);
+    const block = formatProjectStructureBlock(probe);
+
+    expect(block).not.toBe("");
+    expect(block).toMatch(/## Project structure \(depth [12], gitignore-respecting\)/);
+    expect(block.split("\n").length).toBeLessThanOrEqual(41); // header + <=40 body lines
+  });
+});
+
+describe("probeProjectStructure caching", () => {
+  const root = path.join(process.cwd(), `.tmp-project-structure-${Date.now()}`);
+
+  beforeAll(() => {
+    mkdirSync(path.join(root, "src"), { recursive: true });
+    writeFileSync(path.join(root, "src", "index.ts"), "export {}");
+    writeFileSync(path.join(root, "README.md"), "# test");
+  });
+
+  afterAll(() => {
+    clearProjectStructureCache();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("caches per cwd and returns the same promise on repeat calls", async () => {
+    clearProjectStructureCache();
+    const first = probeProjectStructure(root);
+    const second = probeProjectStructure(root);
+    expect(first).toBe(second);
+    const resolved = await first;
+    expect(resolved).not.toBeNull();
+    expect(resolved!.rootLooseFiles).toContain("README.md");
+  });
+});

--- a/test/tool-output-cap.test.ts
+++ b/test/tool-output-cap.test.ts
@@ -22,4 +22,25 @@ describe("tool output caps", () => {
     expect(output).toContain("[Output truncated:");
     expect(output.split("\n")[0]!.length).toBeLessThanOrEqual(MAX_BASH_LINE_CHARS + 1);
   });
+
+  test("capBashOutputLines reports keptLines for the line-count cap", () => {
+    const raw = Array.from({ length: 10 }, (_, i) => `line${i}`).join("\n");
+    const { keptLines, truncated } = capBashOutputLines(raw, 4);
+    expect(keptLines).toBe(4);
+    expect(truncated).toBe(true);
+  });
+
+  test("capBashOutputLines reports keptLines for the byte cap (fewer than the line cap)", () => {
+    const raw = Array.from({ length: 10 }, () => "x".repeat(100)).join("\n");
+    const { keptLines, truncated } = capBashOutputLines(raw, 2000, MAX_BASH_LINE_CHARS, 350);
+    expect(keptLines).toBeLessThan(10);
+    expect(truncated).toBe(true);
+  });
+
+  test("capBashOutputLines reports the full line count when nothing is cut", () => {
+    const raw = "a\nb\nc";
+    const { keptLines, truncated } = capBashOutputLines(raw, 2000);
+    expect(keptLines).toBe(3);
+    expect(truncated).toBe(false);
+  });
 });

--- a/test/wsl-routing.test.ts
+++ b/test/wsl-routing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePreferredShell, translateToWslPath } from "../src/tools/bash.js";
+
+describe("translateToWslPath", () => {
+  test("translates a C: drive path to /mnt/c/...", () => {
+    expect(translateToWslPath("C:\\Users\\foo\\bar")).toBe("/mnt/c/Users/foo/bar");
+  });
+
+  test("translates a non-C drive letter, lowercased", () => {
+    expect(translateToWslPath("D:\\projects\\repo")).toBe("/mnt/d/projects/repo");
+  });
+
+  test("passes through an already-POSIX path unchanged (other than separators)", () => {
+    expect(translateToWslPath("/mnt/c/Users/foo")).toBe("/mnt/c/Users/foo");
+    expect(translateToWslPath("/home/foo/project")).toBe("/home/foo/project");
+  });
+
+  test("throws a clear error for a UNC path instead of producing a broken /mnt path", () => {
+    expect(() => translateToWslPath("\\\\server\\share\\folder")).toThrow(/UNC path/);
+  });
+
+  test("throws for a forward-slash UNC-style path too", () => {
+    expect(() => translateToWslPath("//server/share/folder")).toThrow(/UNC path/);
+  });
+});
+
+describe("resolvePreferredShell", () => {
+  test("falls back to auto-detection for an unrecognized preference", async () => {
+    // "auto" isn't handled explicitly inside resolvePreferredShell (the caller
+    // branches on "auto" before calling it), so any unknown string should still
+    // resolve to a real shell via the auto-detect fallback rather than throwing.
+    const shell = await resolvePreferredShell("not-a-real-shell");
+    expect(shell.type).toBeDefined();
+    expect(shell.executable).toBeTruthy();
+  });
+
+  test("resolves cmd from COMSPEC or a sane default", async () => {
+    const shell = await resolvePreferredShell("cmd");
+    expect(shell.type).toBe("cmd");
+    expect(shell.executable.toLowerCase()).toContain("cmd.exe");
+  });
+
+  test("resolves powershell to Windows PowerShell 5.x", async () => {
+    const shell = await resolvePreferredShell("powershell");
+    expect(shell.type).toBe("powershell5");
+    expect(shell.supportsChainedCommands).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth branch in the stacked #113-#118 sequence (depends on #121 / `feat/wsl-routing-115` — merge that first). Covers:

- **#113** — PM-style interrogation persona in PLAN mode (scaled by complexity), and an execute/proceed/revise/cancel completion overlay meant to replace the informal "let's do it" mode-switch trigger.
- **#114 (pt 2)** — goals as first-class artifacts under `.impulse/goals/<sessionId>/` (`state.json`, `goal.md`, `progress.md`), decoupled from session metadata so they survive `/compact`.

## Review findings fixed in this pass

This branch needed the most work of the six — two of #113/#114's central deliverables were incomplete:

- **Critical:** `PlanCompletionOverlay` was fully built but never imported or shown anywhere — the whole approval-overlay flow was dead code; switching PLAN → AGENT just happened silently, exactly the behavior #113 asked to replace. Wired it up:
  - New `src/agent/plan-completion.ts`: detects a `set_mode("AGENT")` call from PLAN mode once the active plan revision has a written `tasks.md`, and maps the user's decision to loop behavior.
  - `loop.ts` intercepts `set_mode` in the tool loop (Bus events can't await a user decision, so this mirrors the existing `consult_advisor` special-case) and reassigns the turn-local mode/tool-set on execute/proceed so the rest of the turn actually behaves like AGENT.
  - `renderer.ts` wires the loop event to a new `showPlanCompletionOverlay`, cloned from the existing (working) plan-approval overlay pattern.
  - Fixed a bug in the overlay itself: pressing "1" fired whatever option was currently highlighted instead of always meaning "execute."
  - Synced the inline PLAN prompt fallback with `prompts/modes/plan.md`, which had drifted out of sync with the interrogation persona and overlay contract.
- **Gap:** #114's acceptance criteria included bridging `/goal` to PLAN-mode revisions (`/goal set --plan <revisionId>`, judge evaluates against `tasks.md`) — this was never implemented. Added:
  - `planRevisionId` on `GoalState`.
  - `/goal set [--plan[=revisionId]] <text>` (validates an explicit id against on-disk revisions, defaults to the active one, lists available ids on failure). Legacy `/goal <text>` is unchanged.
  - The judge now evaluates against the plan's `tasks.md` checklist (re-read fresh each turn) instead of free-text when a goal references a plan; falls back to free-text with a warning if the revision goes missing mid-goal (this never wedges the goal into `paused_judge_unavailable`, which stays reserved for judge-model failures).
  - `goal.md` and the system prompt surface the plan reference and the `- [x]` check-off convention the judge relies on.
- Added unit tests for all of the above — the overlay decision mapping (including a regression test for the "1" key bug), the handoff-detection predicate, goal-state round-tripping, goal-artifact rendering, and the checklist judge-prompt builder. None had coverage before.

## Validation

- `bun run typecheck` — clean.
- `bun test` across all touched files — all green, plus the pre-existing `test/plan-revisions.test.ts` still passes unchanged.
- Manual: PLAN mode → write artifacts → `set_mode(AGENT)` → overlay appears; exercised all four decisions; `/goal set --plan` → judge evaluates the checklist; goal artifacts survive `/compact`.

## Notes for reviewer

- Merge #121 first; this PR's diff will shrink to just this branch's own commits once that lands.
- Behavior change worth flagging: `/goal set <text>` where `<text>` starts with the literal word "set" now gets tokenized as the `set` subcommand rather than treated as goal text (e.g. `/goal set up a monitoring dashboard` — the word after `set` is parsed for `--plan`, not literal goal text starting with "set"). This is a narrow edge case but worth a second look.
- Closes #113, closes #114.