### PR TITLE
fix(#129): reliable user instructions + fix(#127): stream markdown boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-07-31
+
+  **Type:** patch
+  **Title:** Reliable user instructions and streaming Markdown handling
+
+  ### Fixed
+  - **#129** -- User-level instructions now load from `~/.impulse/user-instructions.md`, refresh between turns, and reach main and side-chat system prompts with a legacy config fallback.
+  - **#129** -- Multiline Markdown paste and `@path` imports preserve headings, lists, code fences, and blank lines without manual JSON escaping.
+  - **#129** -- Config saves are atomic with a last-known-good backup, and malformed config files are preserved with a clear recovery error.
+  - **#127** -- Long streamed responses now rotate only at safe Markdown boundaries, preventing punctuation, headings, lists, tables, and inline spans from splitting across terminal lines.
+
 ## [1.9.0] - 2026-07-01
 
   **Type:** minor

--- a/docs/bugfix-user-config-instructions.md
+++ b/docs/bugfix-user-config-instructions.md
@@ -1,0 +1,104 @@
+# User Instructions Reliability Plan
+
+Issue: [#129](https://github.com/spenceriam/impulse/issues/129)
+Branch: `codex/fix-user-config-instructions`
+
+## Outcome
+
+Make user-level instructions reliable from authoring through provider delivery. Users must be able to paste Markdown, import an `@path`, or describe instructions in natural language without manually escaping JSON, losing content after the first newline, or granting an agent unrestricted permissions.
+
+## Confirmed Current Behavior
+
+- `src/util/config.ts` reads `~/.impulse/config.json` with strict `JSON.parse()` and stores custom instructions as an inline JSON string.
+- `src/index.ts` collects custom instructions through `readline.question()`, so a newline ends the answer and a multiline paste can save only its first line.
+- `/user` stops the TUI and reuses that same single-line onboarding flow.
+- `src/cli/prompt-input.ts` already normalizes CRLF and supports multiline paste payloads in the main prompt.
+- `src/agent/prompts.ts` formats `userProfile.customInstructions` and appends the result to the generated system prompt.
+
+The implementation exists, but five reliability gaps remain:
+
+1. Raw Markdown must be JSON-escaped; invalid quotes or line breaks can make the whole config unreadable and prevent startup.
+2. Multiline paste is incompatible with the current single-line onboarding prompt.
+3. The injected prompt does not identify the user config as its source, so the model may incorrectly deny that persistent instructions were loaded.
+4. The process-wide config and prompt caches can retain older instructions after an external edit.
+5. Tests cover formatting in isolation but not the full path from persistent storage to the provider system message.
+
+## Design Decisions
+
+- Store long-form user instructions in `~/.impulse/user-instructions.md`. The distinct name avoids confusion with the existing project-level `.impulse/instructions.md` file.
+- Keep `userProfile.customInstructions` as a backward-compatible fallback during migration, not as the long-term editing surface.
+- Treat an explicit command or natural-language request to replace, append, import, or clear instructions as authorization for that exact action.
+- Do not launch a background agent or enable allow-all. Use a dedicated tool that can modify only the canonical user-instructions file.
+
+## Implementation Plan
+
+### 1. Add canonical Markdown storage and migration
+
+- Add a user-instructions storage module responsible for reading, validating, and atomically writing `~/.impulse/user-instructions.md`.
+- Normalize CRLF and lone carriage returns to LF while preserving Markdown structure and intentional blank lines.
+- On first load, use the Markdown file when present; otherwise read the legacy inline `customInstructions` value.
+- On the first successful edit or import, write the canonical Markdown file and preserve backward compatibility without duplicating instruction content in the system prompt.
+- Define deterministic precedence between user-level Markdown, legacy inline instructions, and project instruction files.
+
+### 2. Replace single-line instruction authoring
+
+- Add an `/instructions` workflow inside the TUI rather than dropping into `readline.question()`.
+- Reuse or extract the existing multiline paste normalization from `PromptInput`.
+- Support view, replace, append, clear, and multiline paste operations.
+- Show the destination path and a compact preview before returning to chat; the user's explicit action is the authorization, so no second permission gate is required.
+- Route custom-instruction editing from `/user` into this workflow instead of rerunning all onboarding questions.
+
+### 3. Support explicit `@path` import and agent-assisted authoring
+
+- Accept a command such as `/instructions import @path` for local Markdown or text files.
+- Add a narrowly scoped `user_instructions` tool with read, replace, append, import, and clear actions; writes are restricted to `~/.impulse/user-instructions.md`.
+- Allow natural-language requests such as "Review `@AGENTS.md`, extract my personal preferences, and save them as my instructions."
+- Require explicit save/import intent; merely mentioning an `@path` must not modify persistent instructions.
+- Perform the work in the active turn. Do not create a background session or grant general allow-all permissions.
+
+### 4. Harden runtime loading, provenance, and config recovery
+
+- Refresh prompt-relevant config and user-instruction content at the start of every user turn using an mtime-aware cache or explicit fresh-load path.
+- Label the generated prompt block with its user-level source so the model can accurately explain where its instructions came from.
+- Include a stable fingerprint of the effective instructions in the prompt-cache key and use one canonical key for cache reads and writes.
+- Make config saves atomic and preserve a last-known-good backup before replacement.
+- If `config.json` is malformed, preserve the original file and show its path plus a useful parse/validation error instead of silently overwriting it with defaults.
+
+### 5. Add regression coverage
+
+- Unit-test newline normalization, Markdown preservation, precedence, migration, and atomic storage.
+- Test multiline paste through the instruction editor, including headings, lists, quotes, code fences, CRLF, and blank lines.
+- Test replace, append, clear, and `@path` import behavior, including explicit-intent enforcement and target-path containment.
+- Add integration coverage proving that new and resumed chats place the exact effective instructions in the provider's first system message.
+- Test external edits between turns, invalid JSON recovery, prompt-cache invalidation, and absence of provider secrets in prompts or logs.
+
+## Required Behavior
+
+- [x] Pasting a multiline Markdown document preserves the complete document rather than only its first line.
+- [x] Users never need to escape Markdown for JSON manually.
+- [x] `/instructions import @path` imports a selected file without a general permission or allow-all prompt.
+- [x] An explicit natural-language request can generate and save instructions through the scoped tool.
+- [x] New and resumed chats receive the same current user-level instructions.
+
+## Safety and Regression Requirements
+
+- [x] Mentioning a file without explicit save/import intent cannot change persistent instructions.
+- [x] The instruction tool cannot write outside `~/.impulse/user-instructions.md`.
+- [x] External instruction edits affect the next turn without restarting Impulse.
+- [x] Malformed `config.json` is preserved, diagnosed clearly, and never silently replaced with defaults.
+- [x] Provider credentials and unrelated config fields never enter the system prompt, tool output, or logs.
+
+## Verification
+
+1. Run focused config, instruction-storage, prompt, paste, and tool tests.
+2. Run `bun run typecheck`.
+3. Run `bun test`.
+4. Run `bun run build`.
+5. Manually test multiline paste, `@path` import, natural-language generation, external edits, session resume, and malformed-config recovery.
+
+## Boundaries
+
+- Project instructions remain separate: `.impulse/instructions.md`, `AGENTS.md`, and other repository-level files keep their existing discovery behavior.
+- Remote repositories can be researched with existing agent tools, but only an explicit user request may persist the extracted result as user instructions.
+- The feature does not grant blanket filesystem access or bypass permissions for unrelated actions.
+- The GitHub issue remains a concise problem statement; implementation detail lives in this plan.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -20,6 +20,7 @@ See [docs/tool-input-repair.md](../tool-input-repair.md) for the validate-then-r
 - question: docs/tools/question.md
 - set_header: docs/tools/set-header.md
 - set_mode: docs/tools/set-mode.md
+- user_instructions: docs/tools/user-instructions.md
 - web_fetch: docs/tools/web-fetch.md
 - web_search: docs/tools/web-search.md
 - tool_docs: docs/tools/tool-docs.md

--- a/docs/tools/user-instructions.md
+++ b/docs/tools/user-instructions.md
@@ -1,0 +1,16 @@
+# user_instructions
+
+Read or update the user's persistent instructions at `~/.impulse/user-instructions.md`.
+
+## Parameters
+
+- `action`: `read`, `replace`, `append`, `import`, or `clear`
+- `content`: required for `replace` and `append`
+- `source_path`: required for `import`; agent-driven imports are restricted to the current workspace
+- `explicit_intent`: must be `true` for `replace`, `append`, `import`, or `clear`
+
+## Safety
+
+Use a mutating action only when the user explicitly asks to persist an instruction change. Mentioning a preference or an `@path` alone is not authorization. The tool writes only the canonical user-instructions file and does not require allow-all mode.
+
+The agent tool is available in AGENT and DEBUG modes. The `/instructions` command remains available directly from the TUI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spenceriam/impulse",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spenceriam/impulse",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "description": "Terminal-based provider-flexible AI co-partner agent for fast software development",
   "type": "module",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -91,7 +91,7 @@ import {
   type LoopCheckinDecision,
 } from "./loop-guard.js";
 import { buildDebugInstrumentationNudge } from "./debug-nudge.js";
-import { generateSystemPrompt } from "../agent/prompts";
+import { generateSystemPrompt, invalidatePromptCache } from "../agent/prompts";
 import { setCurrentMode } from "../tools/mode-state";
 import { ADVISOR_GATE_MESSAGE, shouldBlockBeforeAdvisor } from "./advisor-gate.js";
 import { shouldRetryInEnglish } from "./language-guard.js";
@@ -455,6 +455,10 @@ export class AgentLoop {
       };
 
       events.onTurnStart();
+      // Rebuild system prompt each user turn so project instructions, skills,
+      // probes, and other dynamic blocks stay fresh. Within-turn tool iterations
+      // still hit the memo via lastTurnPromptKey.
+      invalidatePromptCache();
       this.contextWrapupInjected = false;
       await this.flushTurnInjections();
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -265,7 +265,7 @@ export class AgentLoop {
     let abortIterationAssistantPersisted = false;
 
     try {
-      const config = await loadConfig();
+      const config = await loadConfig({ refresh: true });
       const manager = await getProviderManager();
 
       // Sync mode to tool-state so mode-restricted tools work

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -17,7 +17,7 @@ import {
   type UserProfile,
 } from "../util/config.js";
 import { detectShellEnvironment, generateShellContext } from "../util/shell-env.js";
-import { loadInstructions } from "../util/instructions.js";
+import { loadInstructions, clearInstructionCache } from "../util/instructions.js";
 import {
   loadEffectiveUserInstructions,
   type EffectiveUserInstructions,
@@ -39,6 +39,7 @@ export function invalidatePromptCache(): void {
   PROMPT_CACHE.clear();
   lastTurnPromptKey = undefined;
   lastTurnPrompt = undefined;
+  clearInstructionCache();
   void import("../harness/session-cache.js").then((m) => m.clearPinnedSystemPrompt());
 }
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -18,6 +18,10 @@ import {
 } from "../util/config.js";
 import { detectShellEnvironment, generateShellContext } from "../util/shell-env.js";
 import { loadInstructions } from "../util/instructions.js";
+import {
+  loadEffectiveUserInstructions,
+  type EffectiveUserInstructions,
+} from "../util/user-instructions.js";
 
 type Mode = typeof MODES[number];
 
@@ -38,15 +42,23 @@ export function invalidatePromptCache(): void {
   void import("../harness/session-cache.js").then((m) => m.clearPinnedSystemPrompt());
 }
 
-export function formatUserCollaborationProfile(profile?: UserProfile): string | null {
-  if (!profile) return null;
+export function formatUserCollaborationProfile(
+  profile?: UserProfile,
+  effectiveInstructions?: EffectiveUserInstructions,
+  options?: { instructionToolAvailable?: boolean }
+): string | null {
+  if (!profile && !effectiveInstructions?.content) return null;
 
-  const lines: string[] = ["## User collaboration profile", ""];
-  if (profile.name?.trim()) {
+  const lines: string[] = [
+    "## User collaboration profile",
+    "",
+    "Profile settings source: ~/.impulse/config.json",
+  ];
+  if (profile?.name?.trim()) {
     lines.push(`Name: ${profile.name.trim()}`);
   }
 
-  const preference = profile.responsePreference?.trim() || "balanced";
+  const preference = profile?.responsePreference?.trim() || "balanced";
   const normalized = preference.toLowerCase();
   const presets: Record<string, string[]> = {
     balanced: [
@@ -90,8 +102,25 @@ export function formatUserCollaborationProfile(profile?: UserProfile): string | 
     lines.push(`- User-described preference: ${preference}`);
   }
 
-  if (profile.customInstructions?.trim()) {
-    lines.push("", "Custom instructions:", profile.customInstructions.trim());
+  const instructions = effectiveInstructions?.content ?? profile?.customInstructions ?? "";
+  if (instructions.trim()) {
+    const source = effectiveInstructions?.sourceLabel ?? "~/.impulse/config.json";
+    const instructionLines = [
+      "",
+      `Persistent instructions source: ${source}`,
+      "The Impulse host already loaded these instructions. Do not search the workspace to verify their source.",
+      "",
+      "Custom instructions:",
+      instructions,
+    ];
+    if (options?.instructionToolAvailable !== false) {
+      instructionLines.splice(
+        3,
+        0,
+        "Use user_instructions only when the user explicitly asks to persist a replacement, append, import, or clear operation."
+      );
+    }
+    lines.push(...instructionLines);
   }
 
   return lines.join("\n");
@@ -461,10 +490,14 @@ export async function generateSystemPrompt(
   mode: Mode,
   cwd?: string,
   config?: Config,
-  options?: { sessionId?: string }
+  options?: { sessionId?: string; userInstructionsPath?: string }
 ): Promise<string> {
   const workingDir = cwd || process.cwd();
   const cfg = config ?? await loadConfig();
+  const effectiveUserInstructions = await loadEffectiveUserInstructions(
+    cfg.userProfile?.customInstructions,
+    options?.userInstructionsPath
+  );
   const experimentalGoal = isExperimentalGoalEnabled(cfg);
   let goalCacheKey = "off";
   if (options?.sessionId && experimentalGoal) {
@@ -479,7 +512,13 @@ export async function generateSystemPrompt(
       });
     }
   }
-  const turnKeyEarly = `${mode}:${workingDir}:${cfg.defaultModel ?? ""}:${options?.sessionId ?? ""}:goal=${goalCacheKey}`;
+  const profileCacheKey = JSON.stringify({
+    name: cfg.userProfile?.name ?? "",
+    responsePreference: cfg.userProfile?.responsePreference ?? "balanced",
+    instructions: effectiveUserInstructions.fingerprint,
+  });
+  const turnKey = `${mode}:${workingDir}:${cfg.defaultModel ?? ""}:${options?.sessionId ?? ""}:goal=${goalCacheKey}:profile=${profileCacheKey}`;
+  const turnKeyEarly = turnKey;
   if (lastTurnPromptKey === turnKeyEarly && lastTurnPrompt) {
     return lastTurnPrompt;
   }
@@ -541,7 +580,11 @@ IMPORTANT: When creating or editing files, ALWAYS use paths relative to or withi
     );
   }
 
-  const collaborationProfile = formatUserCollaborationProfile(cfg.userProfile);
+  const collaborationProfile = formatUserCollaborationProfile(
+    cfg.userProfile,
+    effectiveUserInstructions,
+    { instructionToolAvailable: mode === "AGENT" || mode === "DEBUG" }
+  );
   if (collaborationProfile) {
     parts.push(collaborationProfile);
   }
@@ -644,7 +687,6 @@ Use \`bash(background: true)\` for dev servers, watchers, or long-running proces
   }
 
   const result = parts.join("\n").trim();
-  const turnKey = `${mode}:${workingDir}:${cfg.defaultModel ?? ""}:${options?.sessionId ?? ""}`;
   lastTurnPromptKey = turnKey;
   lastTurnPrompt = result;
   return result;

--- a/src/agent/side-chat.ts
+++ b/src/agent/side-chat.ts
@@ -4,13 +4,21 @@
 
 import type { ChatMessage } from "../api/types.js";
 import { getProviderManager } from "../api/manager.js";
-import type { ReasoningLevel } from "../util/config.js";
+import { load as loadConfig, type ReasoningLevel } from "../util/config.js";
+import { formatUserCollaborationProfile } from "./prompts.js";
+import { loadEffectiveUserInstructions } from "../util/user-instructions.js";
 import type { Message } from "../session/store.js";
 
 export const SIDE_CONTEXT_MAX_CHARS = 4000;
 
 const SIDE_SYSTEM_PROMPT = `You are a brief side assistant for Impulse. Answer the user's clarification question concisely.
 You cannot use tools, read files, or modify the project. Do not suggest running commands unless the user explicitly asks.`;
+
+export function buildSideSystemPrompt(collaborationProfile?: string | null): string {
+  return collaborationProfile?.trim()
+    ? `${SIDE_SYSTEM_PROMPT}\n\n${collaborationProfile.trim()}`
+    : SIDE_SYSTEM_PROMPT;
+}
 
 export interface SideChatEvents {
   onToken(text: string): void;
@@ -108,8 +116,17 @@ export async function runSideChat(params: RunSideChatParams): Promise<RunSideCha
     userContent = `Recent main conversation (read-only):\n\n${contextSnapshot}\n\n---\n\nSide question: ${userText}`;
   }
 
+  const config = await loadConfig({ refresh: true });
+  const effectiveInstructions = await loadEffectiveUserInstructions(
+    config.userProfile?.customInstructions
+  );
+  const collaborationProfile = formatUserCollaborationProfile(
+    config.userProfile,
+    effectiveInstructions,
+    { instructionToolAvailable: false }
+  );
   const messages: ChatMessage[] = [
-    { role: "system", content: SIDE_SYSTEM_PROMPT },
+    { role: "system", content: buildSideSystemPrompt(collaborationProfile) },
     { role: "user", content: userContent },
   ];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { getProviderManager, resetProviderManager } from "./api/manager";
-import { createDefaultConfig, load as loadConfig, save as saveConfig } from "./util/config";
+import { load as loadConfig, save as saveConfig } from "./util/config";
 import type { Config } from "./util/config";
 import { testOllamaConnection } from "./api/providers/ollama.js";
 import { discoverModels } from "./cli/model-setup.js";
@@ -226,15 +226,7 @@ async function runSetup(): Promise<void> {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
   // Persist to config file
-  const cfg = await loadConfig().catch(() =>
-    createDefaultConfig({
-      providers: {},
-      defaultProvider: providerKey,
-      defaultModel,
-      modelExplicitlySet: Boolean(defaultModel?.trim()),
-      hasSeenWelcome: false,
-    })
-  );
+  const cfg = await loadConfig();
 
   cfg.providers[providerKey as keyof Config["providers"]] = {
     apiKey: key,

--- a/src/cli/components/profile-overlay.ts
+++ b/src/cli/components/profile-overlay.ts
@@ -39,16 +39,24 @@ function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
 }
 
+function instructionPreview(value: string): string {
+  const normalized = value.trim();
+  if (normalized.length <= 320) return normalized;
+  return `${normalized.slice(0, 319)}…`;
+}
+
 export class ProfileOverlay implements Component {
   private profile?: UserProfile;
   private selectedAction = 0;
   private measureTerminalWidth: number | null = null;
   private readonly actions = [
     { key: "edit", label: "Edit profile", hint: "e or Enter" },
+    { key: "instructions", label: "Edit instructions", hint: "i" },
     { key: "close", label: "Close", hint: "Esc" },
   ] as const;
 
   onEdit?: () => void;
+  onEditInstructions?: () => void;
   onCancel?: () => void;
 
   constructor(opts: ProfileOverlayOptions) {
@@ -64,12 +72,13 @@ export class ProfileOverlay implements Component {
   preferredBoxWidth(terminalWidth: number): number {
     const terminal = this.measureTerminalWidth ?? terminalWidth;
     const name = this.profile?.name?.trim() ?? "";
-    const instructions = this.profile?.customInstructions?.trim() ?? "";
+    const instructions = instructionPreview(this.profile?.customInstructions ?? "");
     const widths: number[] = [
       visibleWidth(`name: ${name || "(not set)"}`),
       visibleWidth(instructions || "(none)"),
       visibleWidth("  > Edit profile  e or Enter"),
-      visibleWidth("↑/↓ navigate   e: edit   Esc: close"),
+      visibleWidth("  > Edit instructions  i"),
+      visibleWidth("Up/Down navigate   e: profile   i: instructions   Esc: close"),
     ];
     return intrinsicFramedBoxWidth(terminal, "User profile", widths);
   }
@@ -95,12 +104,21 @@ export class ProfileOverlay implements Component {
       return;
     }
 
-    if (data === "e" || data === "E" || data === "\r") {
-      if (this.selectedAction === 0) {
-        this.onEdit?.();
-      } else {
-        this.onCancel?.();
-      }
+    if (data === "e" || data === "E") {
+      this.onEdit?.();
+      return;
+    }
+
+    if (data === "i" || data === "I") {
+      this.onEditInstructions?.();
+      return;
+    }
+
+    if (data === "\r") {
+      const action = this.actions[this.selectedAction]?.key;
+      if (action === "edit") this.onEdit?.();
+      else if (action === "instructions") this.onEditInstructions?.();
+      else this.onCancel?.();
       return;
     }
 
@@ -118,7 +136,7 @@ export class ProfileOverlay implements Component {
     lines.push(overlayEmptyLine(boxWidth));
 
     const name = this.profile?.name?.trim() ?? "";
-    const instructions = this.profile?.customInstructions?.trim() ?? "";
+    const instructions = instructionPreview(this.profile?.customInstructions ?? "");
 
     for (const inner of fieldLines("name", name, innerWidth)) {
       lines.push(overlaySideLine(inner, innerWidth, boxWidth));
@@ -145,7 +163,7 @@ export class ProfileOverlay implements Component {
     lines.push(overlayEmptyLine(boxWidth));
     lines.push(
       overlaySideLine(
-        overlayDim("↑/↓ navigate   e: edit   Esc: close"),
+        overlayDim("Up/Down navigate   e: profile   i: instructions   Esc: close"),
         innerWidth,
         boxWidth
       )

--- a/src/cli/markdown-table.ts
+++ b/src/cli/markdown-table.ts
@@ -86,6 +86,11 @@ function isSeparatorRow(line: string): boolean {
   return cells.length >= 2 && cells.every(isSeparatorCell);
 }
 
+/** True when a line resembles a table row or separator. */
+export function isTableLikeLine(line: string): boolean {
+  return isTableCandidate(line) || isSeparatorRow(line);
+}
+
 function normalizeRow(row: string[], width: number): string[] {
   if (row.length === width) return row;
   if (row.length > width) return row.slice(0, width);

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -3214,9 +3214,14 @@ export class ImpulseRenderer {
     }
 
     const froze = this.freezeStreamingAtSafeBoundary(true);
-    if (froze && gapAfter) {
-      this.addSectionGap();
+    if (froze) {
+      if (gapAfter) {
+        this.addSectionGap();
+      }
+      return;
     }
+
+    this.finalizeAssistantStreamingSegment(gapAfter);
   }
 
   private closeThinking(): void {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -25,6 +25,7 @@ import {
   type OverlayHandle,
 } from "@mariozechner/pi-tui";
 import type { EditorTheme } from "@mariozechner/pi-tui";
+import { z } from "zod";
 import { spawn } from "child_process";
 import {
   PromptInput,
@@ -73,6 +74,15 @@ import { dimRuleIndented } from "./format-helpers.js";
 
 /** pi-tui maxHeight for session/model list overlays */
 const LIST_OVERLAY_MAX_HEIGHT = 18;
+const InstructionsCommandActionSchema = z.enum([
+  "view",
+  "show",
+  "replace",
+  "set",
+  "append",
+  "import",
+  "clear",
+]);
 import { overlayMinWidth } from "./layout.js";
 import { overlayMaxHeightForContent, overlayViewportMaxHeight } from "./overlay-height.js";
 import { PromptHistory } from "./prompt-history.js";
@@ -93,6 +103,11 @@ import {
 import { TaskBatchPermissionOverlay } from "./components/task-batch-permission-overlay.js";
 import type { TaskBatchDecision } from "../permission/task-batch.js";
 import { MarkdownTextBlock } from "./components/markdown-text.js";
+import {
+  planStreamingRotation,
+  splitAtSafeBoundary,
+  type StreamSplit,
+} from "./stream-split.js";
 import { ShellCommandBlock } from "./components/shell-command-block.js";
 import { isLoneBang, parseAtReview, parseBangCommand } from "./shell-bang.js";
 import { isShellTakeoverChord } from "./shell-shortcuts.js";
@@ -160,6 +175,11 @@ import {
   type ReasoningLevel,
   type ThinkingDisplay,
 } from "../util/config.js";
+import {
+  USER_INSTRUCTIONS_DISPLAY_PATH,
+  loadEffectiveUserInstructions,
+  writeUserInstructions,
+} from "../util/user-instructions.js";
 import {
   checkForUpdate,
   getCurrentVersion,
@@ -406,6 +426,7 @@ export class ImpulseRenderer {
   private queuePreviewText!: Text;
   private static readonly MAX_TURN_QUEUE = DEFAULT_MAX_TURN_QUEUE;
   private static readonly MAX_MUTABLE_STREAM_LINES = 12;
+  private static readonly MAX_MUTABLE_STREAM_LINES_HARD = 24;
   private turnQueue = new TurnQueueManager(
     ImpulseRenderer.MAX_TURN_QUEUE,
     (payload) => this.isNonemptySubmitPayload(payload)
@@ -1498,6 +1519,7 @@ export class ImpulseRenderer {
   // Streaming state: current assistant text block (updated in-place)
   private streamingText: MarkdownTextBlock | null = null;
   private streamingRaw = "";
+  private nextTurnSegmentSeparator = "\n\n";
   private thinkingText: ThinkingBlock | null = null;
   private thinkingRaw = "";
   private thinkingOpen = false;
@@ -1565,6 +1587,7 @@ export class ImpulseRenderer {
   private planCompletionOverlayHandle: OverlayHandle | null = null;
   private planCompletionInputCleanup: (() => void) | null = null;
   private skillsOverlayHandle: OverlayHandle | null = null;
+  private instructionsOverlayHandle: OverlayHandle | null = null;
   private helpInputCleanup: (() => void) | null = null;
   private experimentalOverlayHandle: OverlayHandle | null = null;
   private settingsOverlayHandle: OverlayHandle | null = null;
@@ -2394,7 +2417,10 @@ export class ImpulseRenderer {
     }
 
     if (shouldTreatAsSlashCommand(input)) {
-      const canonicalSlash = canonicalizeSlashAliasInput(payload.apiText).trim();
+      const expandedSlash = canonicalizeSlashAliasInput(payload.apiText);
+      const canonicalSlash = /^\/instructions(?:\s|$)/i.test(expandedSlash.trimStart())
+        ? expandedSlash.trimStart()
+        : expandedSlash.trim();
       this.recordSubmittedPrompt(canonicalSlash);
       await this.handleSlash(canonicalSlash);
       this.tui.requestRender();
@@ -2531,6 +2557,7 @@ export class ImpulseRenderer {
       onTurnStart: () => {
         this.clearCtrlCPending();
         this.currentTurnAssistantText = "";
+        this.nextTurnSegmentSeparator = "\n\n";
         this.streamBusyPhraseSet = false;
         this.contextTokens = Math.max(
           this.contextTokens,
@@ -2551,9 +2578,7 @@ export class ImpulseRenderer {
           this.streamBusyPhraseSet = true;
         }
         this.closeThinking();
-        if (this.shouldRotateStreamingSegment()) {
-          this.rotateStreamingSegment();
-        }
+        const nextStreamingRaw = this.prepareStreamingToken(text);
         if (!this.streamingText) {
           if (this.lastBandWasTool) {
             this.addSectionGap();
@@ -2568,7 +2593,7 @@ export class ImpulseRenderer {
           this.chat.addChild(this.streamingText);
           this.hasTrailingGap = false;
         }
-        this.streamingRaw += text;
+        this.streamingRaw = nextStreamingRaw;
         this.streamingText.setText(this.streamingRaw);
         this.noteLiveGeneration(text);
         this.scheduleStreamRender();
@@ -2601,12 +2626,12 @@ export class ImpulseRenderer {
       onToolStart: (id, name, args) => {
         // Silent tools still finalize any open stream so continuation text is a new block.
         if (SILENT_TOOLS.has(name)) {
-          this.finalizeAssistantStreamingSegment(true);
+          this.finalizeStreamingAtSafeBoundary(true);
           return;
         }
 
         this.closeThinking();
-        this.finalizeAssistantStreamingSegment(false);
+        this.finalizeStreamingAtSafeBoundary(false);
         this.preToolSpacing = {
           lastBandWasTool: this.lastBandWasTool,
           lastBandToolHadBody: this.lastBandToolHadBody,
@@ -3110,30 +3135,63 @@ export class ImpulseRenderer {
    * Without this, silent tools (set_header) leave streamingRaw open and glue the next
    * continuation chunk onto the same paragraph.
    */
-  private appendAssistantTurnSegment(segment: string, separator = "\n\n"): void {
+  private appendAssistantTurnSegment(segment: string): void {
     const trimmed = segment.trim();
     if (!trimmed) return;
+    const separator = this.nextTurnSegmentSeparator;
+    this.nextTurnSegmentSeparator = "\n\n";
     this.currentTurnAssistantText = this.currentTurnAssistantText
       ? `${this.currentTurnAssistantText}${separator}${trimmed}`
       : trimmed;
   }
 
-  private shouldRotateStreamingSegment(): boolean {
-    if (!this.streamingText || !this.tui) return false;
+  private freezeStreamingSplit(split: StreamSplit): void {
+    if (!this.streamingText) return;
+    this.streamingText.setText(split.frozen);
+    this.appendAssistantTurnSegment(split.frozen);
+    if (split.kind === "paragraph") {
+      this.addSectionGap();
+    } else {
+      this.nextTurnSegmentSeparator = "\n";
+    }
+    this.streamingRaw = split.remainder;
+    this.streamingText = null;
+  }
+
+  private freezeStreamingAtSafeBoundary(allowLineCut: boolean): boolean {
+    if (!this.streamingText || !this.streamingRaw) return false;
+    const split = splitAtSafeBoundary(this.streamingRaw, { allowLineCut });
+    if (!split) return false;
+
+    this.freezeStreamingSplit(split);
+    return true;
+  }
+
+  private prepareStreamingToken(incomingToken: string): string {
+    if (!this.streamingText || !this.tui) {
+      return `${this.streamingRaw}${incomingToken}`;
+    }
     const rows = this.tui.terminal?.rows ?? this.terminal.rows ?? 24;
-    const threshold = Math.max(
+    const softLimit = Math.max(
       8,
       Math.min(ImpulseRenderer.MAX_MUTABLE_STREAM_LINES, Math.floor(rows / 3))
     );
-    return this.streamingText.render(this.terminalCols()).length >= threshold;
-  }
-
-  private rotateStreamingSegment(): void {
-    if (this.streamingRaw.trim()) {
-      this.appendAssistantTurnSegment(this.streamingRaw);
+    const renderedLines = this.streamingText.render(this.terminalCols()).length;
+    const hardLimit = Math.max(
+      softLimit * 2,
+      ImpulseRenderer.MAX_MUTABLE_STREAM_LINES_HARD
+    );
+    const plan = planStreamingRotation({
+      raw: this.streamingRaw,
+      incomingToken,
+      renderedLines,
+      softLimit,
+      hardLimit,
+    });
+    if (plan.split) {
+      this.freezeStreamingSplit(plan.split);
     }
-    this.streamingRaw = "";
-    this.streamingText = null;
+    return plan.nextRaw;
   }
 
   private finalizeAssistantStreamingSegment(gapAfter = true): void {
@@ -3145,6 +3203,18 @@ export class ImpulseRenderer {
     this.streamingRaw = "";
     this.streamingText = null;
     if (gapAfter && hadContent) {
+      this.addSectionGap();
+    }
+  }
+
+  private finalizeStreamingAtSafeBoundary(gapAfter: boolean): void {
+    if (!this.streamingText) {
+      this.finalizeAssistantStreamingSegment(gapAfter);
+      return;
+    }
+
+    const froze = this.freezeStreamingAtSafeBoundary(true);
+    if (froze && gapAfter) {
       this.addSectionGap();
     }
   }
@@ -3185,6 +3255,7 @@ export class ImpulseRenderer {
       cmdAdvisor: (arg) => r.cmdAdvisor(arg),
       cmdExperimental: () => r.cmdExperimental(),
       cmdSettings: () => r.cmdSettings(),
+      cmdInstructions: (arg) => r.cmdInstructions(arg),
       showConfigAliasHint: () => r.showConfigAliasHint(),
       cmdUpdate: () => r.cmdUpdate(),
       cmdModel: (arg) => r.cmdModel(arg),
@@ -3998,11 +4069,15 @@ export class ImpulseRenderer {
   }
 
   private appendWorkerThinking(text: string): void {
-    this.setBusyStatus("Thinking ...", BUSY_PROCESSING);
+    const filtered = filterThinkingForDisplay(text);
     if (!this.thinkingOpen) {
-      this.finalizeAssistantStreamingSegment(false);
+      if (!filtered.trim()) return;
+      this.setBusyStatus("Thinking ...", BUSY_PROCESSING);
+      this.finalizeStreamingAtSafeBoundary(false);
       this.thinkingRaw = "";
       this.thinkingText = null;
+    } else {
+      this.setBusyStatus("Thinking ...", BUSY_PROCESSING);
     }
     if (!this.thinkingText) {
       this.addSectionGap();
@@ -4014,7 +4089,6 @@ export class ImpulseRenderer {
       this.thinkingOpen = true;
       this.thinkingStartedAt = Date.now();
     }
-    const filtered = filterThinkingForDisplay(text);
     this.thinkingRaw += filtered;
     this.thinkingText.appendContent(filtered);
     if (this.thinkingDisplay !== "full") {
@@ -5194,8 +5268,14 @@ export class ImpulseRenderer {
     if (this.isRunning) return;
 
     const config = await loadConfig();
+    const effectiveInstructions = await loadEffectiveUserInstructions(
+      config.userProfile?.customInstructions
+    );
+    const profile = config.userProfile
+      ? { ...config.userProfile, customInstructions: effectiveInstructions.content }
+      : undefined;
     const overlay = new ProfileOverlay(
-      config.userProfile !== undefined ? { profile: config.userProfile } : {}
+      profile !== undefined ? { profile } : {}
     );
 
     overlay.onEdit = async () => {
@@ -5206,12 +5286,19 @@ export class ImpulseRenderer {
       await runOnboarding();
       const newConfig = await loadConfig();
       this.userName = newConfig.userProfile?.name || "you";
+      invalidatePromptCache();
       ensurePiTuiDebugRedrawDir();
       clearTerminalForTuiStart(this.terminal);
       this.tui.start();
       this.tui.setFocus(this.promptInput);
       this.addChatLine(clr.dim("Profile updated"));
       this.tui.requestRender();
+    };
+
+    overlay.onEditInstructions = () => {
+      this.profileOverlayHandle?.hide();
+      this.profileOverlayHandle = null;
+      void this.cmdInstructions("");
     };
 
     overlay.onCancel = () => {
@@ -5231,6 +5318,168 @@ export class ImpulseRenderer {
     });
     this.profileOverlayHandle.focus();
     this.tui.requestRender();
+  }
+
+  private dismissInstructionsOverlay(): void {
+    this.instructionsOverlayHandle?.hide();
+    this.instructionsOverlayHandle = null;
+  }
+
+  private beginInstructionsCommand(action: "replace" | "append" | "import"): void {
+    this.dismissInstructionsOverlay();
+    this.promptInput.clear();
+    this.promptInput.setText(`/instructions ${action} `);
+    this.tui.setFocus(this.promptInput);
+    this.tui.requestRender();
+  }
+
+  private async showCurrentUserInstructions(): Promise<void> {
+    const config = await loadConfig({ refresh: true });
+    const effective = await loadEffectiveUserInstructions(
+      config.userProfile?.customInstructions
+    );
+    this.addChatLine(
+      clr.dim(
+        `User instructions: ${effective.sourceLabel} (${effective.content.length} chars)`
+      )
+    );
+    if (!effective.content) {
+      this.addChatLine(clr.dim("  (none)"));
+    } else {
+      const lines = effective.content.split("\n");
+      for (const line of lines.slice(0, 40)) {
+        this.addChatLine(clr.dim(`  ${line}`));
+      }
+      if (lines.length > 40) {
+        this.addChatLine(clr.dim(`  ... ${lines.length - 40} more lines`));
+      }
+    }
+    this.tui.requestRender();
+  }
+
+  private async persistInstructionCommand(
+    action: "replace" | "append" | "import" | "clear",
+    value = ""
+  ): Promise<void> {
+    const stored = await writeUserInstructions(action, value);
+    invalidatePromptCache();
+    const verb = action === "replace"
+      ? "replaced"
+      : action === "append"
+        ? "appended"
+        : action === "import"
+          ? "imported"
+          : "cleared";
+    this.addChatLine(
+      clr.dim(
+        `User instructions ${verb}: ${USER_INSTRUCTIONS_DISPLAY_PATH} (${stored.content.length} chars)`
+      )
+    );
+    const allPreviewLines = stored.content.split("\n");
+    const previewLines = allPreviewLines.slice(0, 3);
+    if (previewLines.length === 1 && previewLines[0] === "") {
+      this.addChatLine(clr.dim("  (none)"));
+    } else {
+      for (const line of previewLines) {
+        const compact = line.length > 120 ? `${line.slice(0, 119)}…` : line;
+        this.addChatLine(clr.dim(`  ${compact}`));
+      }
+      if (allPreviewLines.length > previewLines.length) {
+        this.addChatLine(clr.dim("  ..."));
+      }
+    }
+    this.tui.requestRender();
+  }
+
+  private showInstructionsOverlay(): void {
+    this.dismissInstructionsOverlay();
+    const overlay = new SelectableListOverlay({
+      title: "User instructions",
+      rows: [
+        { id: "view", label: "View current instructions" },
+        { id: "replace", label: "Replace (paste multiline Markdown)" },
+        { id: "append", label: "Append Markdown" },
+        { id: "import", label: "Import @path" },
+        { id: "clear", label: "Clear instructions" },
+      ],
+      boxSizing: "responsive",
+      maxHeight: 12,
+      helpLines: ["Up/Down navigate   Enter select   Esc close"],
+    });
+    overlay.onSelect = (id) => {
+      this.dismissInstructionsOverlay();
+      if (id === "view") {
+        void this.cmdInstructions("view");
+      } else if (id === "replace" || id === "append" || id === "import") {
+        this.beginInstructionsCommand(id);
+      } else if (id === "clear") {
+        void this.cmdInstructions("clear");
+      }
+    };
+    overlay.onCancel = () => {
+      this.dismissInstructionsOverlay();
+      this.tui.setFocus(this.promptInput);
+    };
+    this.instructionsOverlayHandle = this.showListOverlay(overlay);
+  }
+
+  private async cmdInstructions(arg: string): Promise<void> {
+    if (this.isRunning) {
+      this.addChatLine(clr.warn("Wait for the current turn to finish."));
+      this.tui.requestRender();
+      return;
+    }
+
+    this.promptInput.clear();
+    const actionMatch = arg.match(/^(\S+)(?:[ \t]+([\s\S]*))?$/);
+    const rawAction = actionMatch?.[1]?.toLowerCase() ?? "";
+    const value = actionMatch?.[2] ?? "";
+
+    try {
+      if (!rawAction) {
+        this.showInstructionsOverlay();
+        return;
+      }
+      const actionResult = InstructionsCommandActionSchema.safeParse(rawAction);
+      if (!actionResult.success) {
+        this.addChatLine(
+          clr.dim(
+            "Usage: /instructions [view | replace <text> | append <text> | import @path | clear]"
+          )
+        );
+        this.tui.requestRender();
+        return;
+      }
+      const action = actionResult.data;
+      if (action === "view" || action === "show") {
+        await this.showCurrentUserInstructions();
+        return;
+      }
+      if (action === "replace" || action === "set" || action === "append") {
+        const normalizedAction = action === "append" ? "append" : "replace";
+        if (!value) {
+          this.beginInstructionsCommand(normalizedAction);
+          return;
+        }
+        await this.persistInstructionCommand(normalizedAction, value);
+        return;
+      }
+      if (action === "import") {
+        if (!value.trim()) {
+          this.beginInstructionsCommand("import");
+          return;
+        }
+        await this.persistInstructionCommand("import", value.trim());
+        return;
+      }
+      if (action === "clear") {
+        await this.persistInstructionCommand("clear");
+        return;
+      }
+    } catch (error) {
+      this.addChatLine(clr.warn(error instanceof Error ? error.message : String(error)));
+      this.tui.requestRender();
+    }
   }
 
   private clearChatView(): void {

--- a/src/cli/renderer.ts
+++ b/src/cli/renderer.ts
@@ -5276,12 +5276,14 @@ export class ImpulseRenderer {
     const effectiveInstructions = await loadEffectiveUserInstructions(
       config.userProfile?.customInstructions
     );
-    const profile = config.userProfile
-      ? { ...config.userProfile, customInstructions: effectiveInstructions.content }
-      : undefined;
-    const overlay = new ProfileOverlay(
-      profile !== undefined ? { profile } : {}
-    );
+    // Always surface file-backed instructions even when userProfile is unset
+    // (e.g. agent-only writes to ~/.impulse/user-instructions.md).
+    const profile = {
+      name: config.userProfile?.name ?? "",
+      responsePreference: config.userProfile?.responsePreference ?? "balanced",
+      customInstructions: effectiveInstructions.content,
+    };
+    const overlay = new ProfileOverlay({ profile });
 
     overlay.onEdit = async () => {
       this.profileOverlayHandle?.hide();

--- a/src/cli/slash-commands.ts
+++ b/src/cli/slash-commands.ts
@@ -73,6 +73,11 @@ export function buildSlashCommandDefs(
       helpDetail: "Show core commands and shortcuts",
     },
     {
+      cmd: "/instructions",
+      hint: "view | replace | append | import | clear",
+      helpDetail: "Manage persistent user instructions with multiline paste or @path import",
+    },
+    {
       cmd: "/model",
       hint: "choose or change model",
       helpDetail: "Choose or change the worker model; configure provider API key and endpoint",

--- a/src/cli/slash-dispatch.ts
+++ b/src/cli/slash-dispatch.ts
@@ -47,6 +47,7 @@ export interface SlashDispatchHost {
   cmdAdvisor(arg: string): Promise<void>;
   cmdExperimental(): Promise<void>;
   cmdSettings(): Promise<void>;
+  cmdInstructions(arg: string): Promise<void>;
   showConfigAliasHint(): void;
   cmdUpdate(): Promise<void>;
   cmdModel(arg: string): Promise<void>;
@@ -86,6 +87,7 @@ const SLASH_DISPATCH: Record<string, SlashHandler> = {
   advisor: (h, arg) => h.cmdAdvisor(arg),
   experimental: (h) => h.cmdExperimental(),
   settings: (h) => h.cmdSettings(),
+  instructions: (h, arg) => h.cmdInstructions(arg),
   config: (h) => h.showConfigAliasHint(),
   update: (h) => h.cmdUpdate(),
   model: (h, arg) => h.cmdModel(arg),
@@ -128,9 +130,14 @@ export function slashDispatchKeys(): string[] {
 
 /** Parse `/command args` into command slug and remainder. */
 export function parseSlashInput(input: string): { cmd: string; arg: string } {
-  const parts = input.slice(1).trim().split(/\s+/);
-  const cmd = parts[0]?.toLowerCase() ?? "";
-  const arg = parts.slice(1).join(" ").trim();
+  const body = input.slice(1).trimStart();
+  const commandMatch = body.match(/^\S+/);
+  const rawCommand = commandMatch?.[0] ?? "";
+  const cmd = rawCommand.toLowerCase();
+  const rawArg = body.slice(rawCommand.length).replace(/^[ \t]+/, "");
+  const arg = cmd === "instructions"
+    ? rawArg
+    : rawArg.trim().split(/\s+/).join(" ");
   return { cmd, arg };
 }
 

--- a/src/cli/stream-split.ts
+++ b/src/cli/stream-split.ts
@@ -127,11 +127,26 @@ export function splitAtSafeBoundary(
 export function planStreamingRotation(
   input: StreamingRotationInput
 ): StreamingRotationPlan {
-  const split = input.renderedLines >= input.softLimit
+  const atSoftLimit = input.renderedLines >= input.softLimit;
+  const atHardLimit = input.renderedLines >= input.hardLimit;
+  let split = atSoftLimit
     ? splitAtSafeBoundary(input.raw, {
-        allowLineCut: input.renderedLines >= input.hardLimit,
+        allowLineCut: atHardLimit,
       })
     : null;
+
+  // When line limits are exceeded but no Markdown-safe boundary exists (e.g. one
+  // long wrapped line), force-rotate the whole buffer like the prior line-count path.
+  if (atSoftLimit && !split && input.raw.trim().length > 0) {
+    if (atHardLimit || !input.raw.includes("\n")) {
+      split = {
+        frozen: input.raw,
+        remainder: "",
+        kind: "line",
+      };
+    }
+  }
+
   const mutableRaw = split?.remainder ?? input.raw;
   return {
     split,

--- a/src/cli/stream-split.ts
+++ b/src/cli/stream-split.ts
@@ -1,0 +1,140 @@
+/**
+ * Split a streaming Markdown buffer only at boundaries that remain valid when
+ * the frozen prefix and mutable remainder render as separate TUI blocks.
+ */
+
+import { isTableLikeLine } from "./markdown-table.js";
+
+export type StreamSplitKind = "paragraph" | "line";
+
+export interface StreamSplit {
+  frozen: string;
+  remainder: string;
+  kind: StreamSplitKind;
+}
+
+export interface StreamSplitOptions {
+  allowLineCut?: boolean;
+}
+
+export interface StreamingRotationInput {
+  raw: string;
+  incomingToken: string;
+  renderedLines: number;
+  softLimit: number;
+  hardLimit: number;
+}
+
+export interface StreamingRotationPlan {
+  split: StreamSplit | null;
+  nextRaw: string;
+}
+
+const FENCE_RE = /^\s*(```|~~~)/;
+
+function computeFenceState(lines: string[]): { before: boolean[]; after: boolean[] } {
+  const before: boolean[] = [];
+  const after: boolean[] = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    before.push(inFence);
+    if (FENCE_RE.test(line)) inFence = !inFence;
+    after.push(inFence);
+  }
+
+  return { before, after };
+}
+
+function findParagraphBoundary(
+  lines: string[],
+  inFenceBefore: boolean[]
+): { frozenEnd: number; remainderStart: number } | null {
+  let index = lines.length - 1;
+
+  while (index >= 0) {
+    if ((lines[index] ?? "").trim().length === 0 && !inFenceBefore[index]) {
+      const runEndExclusive = index + 1;
+      let runStart = index;
+      while (
+        runStart > 0 &&
+        (lines[runStart - 1] ?? "").trim().length === 0 &&
+        !inFenceBefore[runStart - 1]
+      ) {
+        runStart -= 1;
+      }
+
+      if (lines.slice(0, runStart).join("\n").trim().length > 0) {
+        return { frozenEnd: runStart, remainderStart: runEndExclusive };
+      }
+      index = runStart - 1;
+      continue;
+    }
+    index -= 1;
+  }
+
+  return null;
+}
+
+function findLineBoundary(
+  lines: string[],
+  inFenceAfter: boolean[]
+): { frozenEnd: number; remainderStart: number } | null {
+  for (let index = lines.length - 2; index >= 0; index -= 1) {
+    if (inFenceAfter[index]) continue;
+    const left = lines[index] ?? "";
+    const right = lines[index + 1] ?? "";
+    if (isTableLikeLine(left) || isTableLikeLine(right)) continue;
+    if (lines.slice(0, index + 1).join("\n").trim().length === 0) continue;
+    return { frozenEnd: index + 1, remainderStart: index + 1 };
+  }
+
+  return null;
+}
+
+export function splitAtSafeBoundary(
+  raw: string,
+  options?: StreamSplitOptions
+): StreamSplit | null {
+  const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines = normalized.split("\n");
+  const fenceState = computeFenceState(lines);
+
+  const paragraph = findParagraphBoundary(lines, fenceState.before);
+  if (paragraph) {
+    return {
+      frozen: lines.slice(0, paragraph.frozenEnd).join("\n"),
+      remainder: lines.slice(paragraph.remainderStart).join("\n"),
+      kind: "paragraph",
+    };
+  }
+
+  if (options?.allowLineCut) {
+    const line = findLineBoundary(lines, fenceState.after);
+    if (line) {
+      return {
+        frozen: lines.slice(0, line.frozenEnd).join("\n"),
+        remainder: lines.slice(line.remainderStart).join("\n"),
+        kind: "line",
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Plan the exact pre-token rotation used by the live TUI stream. */
+export function planStreamingRotation(
+  input: StreamingRotationInput
+): StreamingRotationPlan {
+  const split = input.renderedLines >= input.softLimit
+    ? splitAtSafeBoundary(input.raw, {
+        allowLineCut: input.renderedLines >= input.hardLimit,
+      })
+    : null;
+  const mutableRaw = split?.remainder ?? input.raw;
+  return {
+    split,
+    nextRaw: `${mutableRaw}${input.incomingToken}`,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@
 
 import { registerCrashRecoveryHandlers } from "./util/crash-recovery.js";
 import {
-  createDefaultConfig,
   load as loadConfig,
   save as saveConfig,
   invalidateConfigCache,
@@ -465,15 +464,7 @@ async function runSetup(): Promise<void> {
   }
 
   // Save config
-  const cfg = await loadConfig().catch(() =>
-    createDefaultConfig({
-      providers: {},
-      defaultProvider: providerKey,
-      defaultModel,
-      modelExplicitlySet: Boolean(defaultModel?.trim()),
-      hasSeenWelcome: true,
-    })
-  );
+  const cfg = await loadConfig();
 
   const providers = cfg.providers as Record<string, unknown>;
   providers[providerKey] = {
@@ -560,29 +551,18 @@ export async function runOnboarding(): Promise<void> {
   }
 
   console.log(`
-  \x1b[90mCustom instructions are injected into every session's system prompt.
-  Leave blank to skip.\x1b[0m
+  \x1b[90mCustom instructions are managed inside Impulse with /instructions.
+  That workflow supports multiline Markdown and @path imports.\x1b[0m
 `);
-  const customInstructions = await ask("  Any custom instructions? (optional): ");
 
   // Load config and save user profile
-  const cfg = await loadConfig().catch(() =>
-    createDefaultConfig({
-      defaultProvider: "ollama",
-      defaultModel: "ollama/llama3.2",
-      hasSeenWelcome: true,
-      userProfile: {
-        name: "",
-        responsePreference: "balanced",
-        customInstructions: "",
-      },
-    })
-  );
+  const cfg = await loadConfig();
+  const legacyCustomInstructions = cfg.userProfile?.customInstructions ?? "";
 
   cfg.userProfile = {
     name,
     responsePreference,
-    customInstructions: customInstructions || "",
+    customInstructions: legacyCustomInstructions,
   };
   cfg.hasSeenWelcome = true;
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ export { questionTool, resolveQuestion, rejectQuestion, hasPendingQuestion } fro
 export type { Question, QuestionOption, QuestionToolInput, QuestionToolOutput } from "./question";
 export { setHeader } from "./set-header";
 export { setMode } from "./set-mode";
+export { userInstructionsTool } from "./user-instructions";
 export { toolDocsTool } from "./tool-docs";
 export { doctorTool } from "./doctor";
 export { projectValidateTool } from "./project-validate";

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -29,6 +29,7 @@ import "./question";
 // Session
 import "./set-header";
 import "./set-mode";
+import "./user-instructions";
 
 // Tool library
 import "./tool-docs";

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -39,6 +39,7 @@ const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   todo_read: "read_only",
   set_header: "utility",
   set_mode: "utility",
+  user_instructions: "write",
   web_fetch: "read_only",
   web_search: "read_only",
   tool_docs: "read_only",

--- a/src/tools/tool-docs.ts
+++ b/src/tools/tool-docs.ts
@@ -28,6 +28,7 @@ const TOOL_DOCS_MAP: Record<string, string> = {
   question: "question.md",
   set_header: "set-header.md",
   set_mode: "set-mode.md",
+  user_instructions: "user-instructions.md",
   web_fetch: "web-fetch.md",
   web_search: "web-search.md",
   plan_revision: "plan-revision.md",

--- a/src/tools/user-instructions.ts
+++ b/src/tools/user-instructions.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { invalidatePromptCache } from "../agent/prompts.js";
+import { load as loadConfig } from "../util/config.js";
+import {
+  USER_INSTRUCTIONS_DISPLAY_PATH,
+  loadEffectiveUserInstructions,
+  resolveWorkspaceUserInstructionsImportPath,
+  writeUserInstructions,
+} from "../util/user-instructions.js";
+import { Tool, type ToolResult } from "./registry.js";
+
+const DESCRIPTION = `Read or update the user's persistent Impulse instructions.
+
+The canonical file is ${USER_INSTRUCTIONS_DISPLAY_PATH}. This tool never writes anywhere else.
+
+Use replace, append, import, or clear ONLY when the user explicitly asks to persist a change to their instructions. Merely mentioning a file or preference is not authorization.
+
+Actions:
+- read: return the current effective instructions and source
+- replace: replace instructions with content
+- append: append content as a new Markdown section
+- import: replace instructions from a workspace file identified by source_path
+- clear: intentionally clear persistent instructions
+
+For replace, append, import, or clear, set explicit_intent=true only after confirming that intent in the user's request.
+
+No allow-all mode or additional permission prompt is required for an explicit user-requested action.`;
+
+const UserInstructionsSchema = z.object({
+  action: z.enum(["read", "replace", "append", "import", "clear"]),
+  content: z.string().optional().describe("Markdown content for replace or append"),
+  source_path: z.string().optional().describe("Workspace file path for import; @path is accepted"),
+  explicit_intent: z.boolean().optional().describe(
+    "Must be true for writes after the user explicitly asked to persist this change"
+  ),
+});
+
+type UserInstructionsInput = z.infer<typeof UserInstructionsSchema>;
+
+export const userInstructionsTool: Tool<UserInstructionsInput> = Tool.define(
+  "user_instructions",
+  DESCRIPTION,
+  UserInstructionsSchema,
+  async (input: UserInstructionsInput): Promise<ToolResult> => {
+    if (input.action === "read") {
+      const config = await loadConfig({ refresh: true });
+      const effective = await loadEffectiveUserInstructions(
+        config.userProfile?.customInstructions
+      );
+      return {
+        success: true,
+        output: effective.content
+          ? `User instructions (${effective.sourceLabel}):\n\n${effective.content}`
+          : `No user instructions are set. Canonical path: ${USER_INSTRUCTIONS_DISPLAY_PATH}`,
+        metadata: {
+          action: input.action,
+          source: effective.sourceLabel,
+          chars: effective.content.length,
+        },
+      };
+    }
+
+    if (input.explicit_intent !== true) {
+      return {
+        success: false,
+        output: "A persistent instruction change requires explicit user intent.",
+      };
+    }
+
+    if (input.action === "replace" || input.action === "append") {
+      if (input.content === undefined) {
+        return { success: false, output: `${input.action} requires content.` };
+      }
+      const stored = await writeUserInstructions(input.action, input.content);
+      invalidatePromptCache();
+      return {
+        success: true,
+        output: `User instructions ${input.action === "replace" ? "replaced" : "appended"} at ${USER_INSTRUCTIONS_DISPLAY_PATH} (${stored.content.length} chars).`,
+        metadata: { action: input.action, path: USER_INSTRUCTIONS_DISPLAY_PATH, chars: stored.content.length },
+      };
+    }
+
+    if (input.action === "import") {
+      if (!input.source_path?.trim()) {
+        return { success: false, output: "import requires source_path." };
+      }
+      const cwd = process.cwd();
+      const sourcePath = await resolveWorkspaceUserInstructionsImportPath(
+        input.source_path,
+        cwd
+      );
+      const stored = await writeUserInstructions("import", sourcePath, { cwd });
+      invalidatePromptCache();
+      return {
+        success: true,
+        output: `Imported user instructions from ${sourcePath} to ${USER_INSTRUCTIONS_DISPLAY_PATH} (${stored.content.length} chars).`,
+        metadata: {
+          action: input.action,
+          sourcePath,
+          path: USER_INSTRUCTIONS_DISPLAY_PATH,
+          chars: stored.content.length,
+        },
+      };
+    }
+
+    const stored = await writeUserInstructions("clear");
+    invalidatePromptCache();
+    return {
+      success: true,
+      output: `User instructions cleared at ${USER_INSTRUCTIONS_DISPLAY_PATH}.`,
+      metadata: { action: input.action, path: USER_INSTRUCTIONS_DISPLAY_PATH, chars: stored.content.length },
+    };
+  }
+);

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "../session/manager";
 import fs from "fs/promises";
 import path from "path";
 import z from "zod";
+import { writeFileAtomic } from "./atomic-write.js";
 import { clearWindowsShellCache, clearWslCache } from "./windows-shell.js";
 
 // ============================================================
@@ -156,12 +157,41 @@ export type PreferredShell = z.infer<typeof ConfigSchema.shape.preferredShell>;
 export type Config = z.infer<typeof ConfigSchema>;
 export type UserProfile = NonNullable<Config["userProfile"]>;
 
-const configPath = path.join(Global.Path.config, "config.json");
+export const configPath = path.join(Global.Path.config, "config.json");
+export const configBackupPath = `${configPath}.bak`;
+
+export class ConfigFileError extends Error {
+  constructor(message: string, readonly sourcePath: string = configPath) {
+    super(message);
+    this.name = "ConfigFileError";
+  }
+}
+
+function invalidConfigError(error: unknown, sourcePath: string = configPath): ConfigFileError {
+  const detail = error instanceof z.ZodError
+    ? error.issues
+        .slice(0, 5)
+        .map((issue) => `${issue.path.join(".") || "config"}: ${issue.message}`)
+        .join("; ")
+    : error instanceof Error
+      ? error.message
+      : String(error);
+  return new ConfigFileError(
+    `Invalid Impulse config at ${sourcePath}: ${detail}. Fix the file or restore ${sourcePath}.bak.`,
+    sourcePath
+  );
+}
 
 async function loadConfigFile(): Promise<Partial<Config>> {
   try {
     const content = await fs.readFile(configPath, "utf-8");
-    return JSON.parse(content);
+    try {
+      const parsed = JSON.parse(content) as unknown;
+      applyDefaults(parsed as Partial<Config>);
+      return parsed as Partial<Config>;
+    } catch (error) {
+      throw invalidConfigError(error);
+    }
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
       throw e;
@@ -215,14 +245,31 @@ export function createDefaultConfig(overrides?: Partial<Config>): Config {
 }
 
 let cachedConfig: Config | null = null;
+let cachedConfigFingerprint: string | null = null;
+
+async function configFileFingerprint(): Promise<string> {
+  try {
+    const stat = await fs.stat(configPath);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+}
 
 /** Clear in-memory config after home migration or external config edits. */
 export function invalidateConfigCache(): void {
   cachedConfig = null;
+  cachedConfigFingerprint = null;
 }
 
-export async function load(): Promise<Config> {
-  if (cachedConfig !== null) {
+export async function load(options?: { refresh?: boolean }): Promise<Config> {
+  const currentFingerprint = await configFileFingerprint();
+  if (
+    options?.refresh !== true &&
+    cachedConfig !== null &&
+    cachedConfigFingerprint === currentFingerprint
+  ) {
     return applySessionVision(applySessionAdvisor({ ...cachedConfig }));
   }
 
@@ -245,7 +292,12 @@ export async function load(): Promise<Config> {
     ...envConfig,
     providers,
   };
-  const parsed = applyDefaults(merged as Partial<Config>);
+  let parsed: Config;
+  try {
+    parsed = applyDefaults(merged as Partial<Config>);
+  } catch (error) {
+    throw invalidConfigError(error);
+  }
   // Migrate showMainThinking → thinkingDisplay
   if (
     (fileConfig as { thinkingDisplay?: ThinkingDisplay }).thinkingDisplay === undefined
@@ -259,6 +311,7 @@ export async function load(): Promise<Config> {
     parsed.advisorMode = false;
   }
   cachedConfig = parsed;
+  cachedConfigFingerprint = await configFileFingerprint();
   return applySessionVision(applySessionAdvisor({ ...cachedConfig }));
 }
 
@@ -331,19 +384,7 @@ export function resolveSubagentModel(config: Config, mainModel: string): string 
 }
 
 export async function save(config: Config): Promise<void> {
-  const parsed = applyDefaults(config);
-  await fs.mkdir(Global.Path.config, { recursive: true });
-
-  // Write config and explicitly sync to disk to ensure it's persisted
-  // This is especially important on Windows where filesystem operations
-  // may be cached and not immediately visible to subsequent reads
-  const fd = await fs.open(configPath, "w");
-  try {
-    await fd.writeFile(JSON.stringify(parsed, null, 2), "utf-8");
-    await fd.sync(); // Force flush to disk
-  } finally {
-    await fd.close();
-  }
+  const parsed = await saveConfigFileAtomic(config);
 
   // Clear shell detection caches when preferredShell changes so next command picks up the new setting
   if (cachedConfig?.preferredShell !== parsed.preferredShell) {
@@ -352,4 +393,34 @@ export async function save(config: Config): Promise<void> {
   }
 
   cachedConfig = parsed;
+  cachedConfigFingerprint = await configFileFingerprint();
+}
+
+/** Validate, back up, and atomically replace a config file without hiding corruption. */
+export async function saveConfigFileAtomic(
+  config: Config,
+  targetPath: string = configPath
+): Promise<Config> {
+  let parsed: Config;
+  try {
+    parsed = applyDefaults(config);
+  } catch (error) {
+    throw invalidConfigError(error, targetPath);
+  }
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+
+  try {
+    const current = await fs.readFile(targetPath, "utf-8");
+    try {
+      applyDefaults(JSON.parse(current) as Partial<Config>);
+    } catch (error) {
+      throw invalidConfigError(error, targetPath);
+    }
+    await writeFileAtomic(`${targetPath}.bak`, current, { mode: 0o600 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  await writeFileAtomic(targetPath, JSON.stringify(parsed, null, 2), { mode: 0o600 });
+  return parsed;
 }

--- a/src/util/user-instructions.ts
+++ b/src/util/user-instructions.ts
@@ -1,0 +1,221 @@
+import { createHash } from "crypto";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Global } from "../global.js";
+import { writeFileAtomic } from "./atomic-write.js";
+
+export const USER_INSTRUCTIONS_FILE = path.join(
+  Global.Path.home,
+  "user-instructions.md"
+);
+export const USER_INSTRUCTIONS_DISPLAY_PATH = "~/.impulse/user-instructions.md";
+export const MAX_USER_INSTRUCTIONS_BYTES = 256 * 1024;
+
+export type EffectiveUserInstructionsSource = "file" | "legacy_config" | "none";
+
+export interface StoredUserInstructions {
+  exists: boolean;
+  content: string;
+  path: string;
+  mtimeMs?: number;
+}
+
+export interface EffectiveUserInstructions {
+  content: string;
+  source: EffectiveUserInstructionsSource;
+  sourceLabel: string;
+  fingerprint: string;
+}
+
+/** Preserve Markdown while making terminal and file line endings deterministic. */
+export function normalizeUserInstructions(content: string): string {
+  const withoutBom = content.startsWith("\uFEFF") ? content.slice(1) : content;
+  return withoutBom.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function validateUserInstructions(content: string): void {
+  if (content.includes("\0")) {
+    throw new Error("User instructions cannot contain NUL bytes.");
+  }
+  const bytes = Buffer.byteLength(content, "utf-8");
+  if (bytes > MAX_USER_INSTRUCTIONS_BYTES) {
+    throw new Error(
+      `User instructions are ${bytes} bytes; the limit is ${MAX_USER_INSTRUCTIONS_BYTES} bytes.`
+    );
+  }
+}
+
+export async function readStoredUserInstructions(
+  targetPath: string = USER_INSTRUCTIONS_FILE
+): Promise<StoredUserInstructions> {
+  try {
+    const stat = await fs.stat(targetPath);
+    if (stat.size > MAX_USER_INSTRUCTIONS_BYTES) {
+      throw new Error(
+        `User instructions are ${stat.size} bytes; the limit is ${MAX_USER_INSTRUCTIONS_BYTES} bytes.`
+      );
+    }
+    const raw = await fs.readFile(targetPath, "utf-8");
+    const content = normalizeUserInstructions(raw);
+    validateUserInstructions(content);
+    return { exists: true, content, path: targetPath, mtimeMs: stat.mtimeMs };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { exists: false, content: "", path: targetPath };
+    }
+    throw error;
+  }
+}
+
+export async function replaceUserInstructions(
+  content: string,
+  targetPath: string = USER_INSTRUCTIONS_FILE
+): Promise<StoredUserInstructions> {
+  const normalized = normalizeUserInstructions(content);
+  validateUserInstructions(normalized);
+  await writeFileAtomic(targetPath, normalized, { mode: 0o600 });
+  return readStoredUserInstructions(targetPath);
+}
+
+export async function appendUserInstructions(
+  content: string,
+  targetPath: string = USER_INSTRUCTIONS_FILE
+): Promise<StoredUserInstructions> {
+  const incoming = normalizeUserInstructions(content);
+  validateUserInstructions(incoming);
+  const current = await readStoredUserInstructions(targetPath);
+  let combined = incoming;
+  if (current.exists && current.content.length > 0 && incoming.length > 0) {
+    const separator = current.content.endsWith("\n\n")
+      ? ""
+      : current.content.endsWith("\n")
+        ? "\n"
+        : "\n\n";
+    combined = `${current.content}${separator}${incoming}`;
+  } else if (current.exists && incoming.length === 0) {
+    combined = current.content;
+  }
+  return replaceUserInstructions(combined, targetPath);
+}
+
+export async function clearUserInstructions(
+  targetPath: string = USER_INSTRUCTIONS_FILE
+): Promise<StoredUserInstructions> {
+  // An existing empty file intentionally overrides the legacy inline value.
+  return replaceUserInstructions("", targetPath);
+}
+
+/** Resolve a user-explicit `@path`, quoted path, absolute path, or cwd-relative path. */
+export function resolveUserInstructionsImportPath(
+  input: string,
+  cwd: string = process.cwd()
+): string {
+  let value = input.trim();
+  if (value.startsWith("@")) value = value.slice(1).trim();
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    value = value.slice(1, -1);
+  }
+  if (!value) throw new Error("Provide a Markdown or text file path to import.");
+
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.resolve(os.homedir(), value.slice(2));
+  }
+  return path.resolve(cwd, value);
+}
+
+export function isPathInsideDirectory(candidate: string, directory: string): boolean {
+  const relative = path.relative(directory, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/** Resolve symlinks before enforcing the workspace boundary for agent imports. */
+export async function resolveWorkspaceUserInstructionsImportPath(
+  input: string,
+  cwd: string = process.cwd()
+): Promise<string> {
+  const candidate = resolveUserInstructionsImportPath(input, cwd);
+  const [realCandidate, realCwd] = await Promise.all([
+    fs.realpath(candidate),
+    fs.realpath(cwd),
+  ]);
+  if (!isPathInsideDirectory(realCandidate, realCwd)) {
+    throw new Error(`Agent-driven imports are limited to the current workspace: ${realCwd}`);
+  }
+  return realCandidate;
+}
+
+export async function importUserInstructions(
+  sourcePathInput: string,
+  options?: {
+    append?: boolean;
+    cwd?: string;
+    targetPath?: string;
+  }
+): Promise<StoredUserInstructions> {
+  const sourcePath = resolveUserInstructionsImportPath(
+    sourcePathInput,
+    options?.cwd
+  );
+  const stat = await fs.stat(sourcePath);
+  if (!stat.isFile()) {
+    throw new Error(`Instruction source is not a file: ${sourcePath}`);
+  }
+  if (stat.size > MAX_USER_INSTRUCTIONS_BYTES) {
+    throw new Error(
+      `Instruction source is ${stat.size} bytes; the limit is ${MAX_USER_INSTRUCTIONS_BYTES} bytes.`
+    );
+  }
+  const content = await fs.readFile(sourcePath, "utf-8");
+  return options?.append
+    ? appendUserInstructions(content, options.targetPath)
+    : replaceUserInstructions(content, options?.targetPath);
+}
+
+export type UserInstructionsWriteAction = "replace" | "append" | "import" | "clear";
+
+/** Apply one explicit persistent-instruction mutation to the canonical Markdown file. */
+export async function writeUserInstructions(
+  action: UserInstructionsWriteAction,
+  value = "",
+  options?: { cwd?: string; targetPath?: string }
+): Promise<StoredUserInstructions> {
+  if (action === "replace") {
+    return replaceUserInstructions(value, options?.targetPath);
+  }
+  if (action === "append") {
+    return appendUserInstructions(value, options?.targetPath);
+  }
+  if (action === "import") {
+    return importUserInstructions(value, options);
+  }
+  return clearUserInstructions(options?.targetPath);
+}
+
+export async function loadEffectiveUserInstructions(
+  legacyInline: string | undefined,
+  targetPath: string = USER_INSTRUCTIONS_FILE
+): Promise<EffectiveUserInstructions> {
+  const stored = await readStoredUserInstructions(targetPath);
+  const legacy = normalizeUserInstructions(legacyInline ?? "");
+  const content = stored.exists ? stored.content : legacy;
+  const source: EffectiveUserInstructionsSource = stored.exists
+    ? "file"
+    : legacy.length > 0
+      ? "legacy_config"
+      : "none";
+  const sourceLabel = source === "file"
+    ? USER_INSTRUCTIONS_DISPLAY_PATH
+    : source === "legacy_config"
+      ? "~/.impulse/config.json"
+      : USER_INSTRUCTIONS_DISPLAY_PATH;
+  const fingerprint = createHash("sha256")
+    .update(`${source}\0${content}`, "utf-8")
+    .digest("hex");
+  return { content, source, sourceLabel, fingerprint };
+}

--- a/test/config-recovery.test.ts
+++ b/test/config-recovery.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { createDefaultConfig, saveConfigFileAtomic } from "../src/util/config.js";
+
+describe("config recovery writes", () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-config-recovery-"));
+    target = path.join(dir, "config.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test("backs up the last valid config before atomic replacement", async () => {
+    const previous = JSON.stringify(createDefaultConfig({ hasSeenWelcome: false }), null, 2);
+    await fs.writeFile(target, previous, "utf-8");
+
+    await saveConfigFileAtomic(createDefaultConfig({ hasSeenWelcome: true }), target);
+
+    expect(await fs.readFile(`${target}.bak`, "utf-8")).toBe(previous);
+    expect(JSON.parse(await fs.readFile(target, "utf-8")).hasSeenWelcome).toBe(true);
+  });
+
+  test("preserves malformed config and reports the file and backup paths", async () => {
+    const malformed = '{"userProfile": {"name": "broken"';
+    await fs.writeFile(target, malformed, "utf-8");
+
+    await expect(
+      saveConfigFileAtomic(createDefaultConfig({ hasSeenWelcome: true }), target)
+    ).rejects.toThrow(target);
+    await expect(
+      saveConfigFileAtomic(createDefaultConfig({ hasSeenWelcome: true }), target)
+    ).rejects.toThrow(`${target}.bak`);
+    expect(await fs.readFile(target, "utf-8")).toBe(malformed);
+  });
+});

--- a/test/profile-preferences.test.ts
+++ b/test/profile-preferences.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { formatUserCollaborationProfile } from "../src/agent/prompts.js";
+import { buildChatMessages } from "../src/agent/build-chat-messages.js";
+import { buildSideSystemPrompt } from "../src/agent/side-chat.js";
 
 describe("formatUserCollaborationProfile", () => {
   test("compiles balanced preference into behavioral instructions", () => {
@@ -19,9 +21,60 @@ describe("formatUserCollaborationProfile", () => {
       name: "",
       responsePreference: "technical",
       customInstructions: "Prefer exact file names.",
+    }, {
+      content: "# Persistent\n\nPrefer exact file names.",
+      source: "file",
+      sourceLabel: "~/.impulse/user-instructions.md",
+      fingerprint: "test-fingerprint",
     });
 
     expect(block).toContain("Style: technical");
-    expect(block).toContain("Prefer exact file names.");
+    expect(block).toContain("Persistent instructions source: ~/.impulse/user-instructions.md");
+    expect(block).toContain("The Impulse host already loaded these instructions");
+    expect(block).toContain("# Persistent\n\nPrefer exact file names.");
+  });
+
+  test("places the effective instructions in the provider system message", () => {
+    const block = formatUserCollaborationProfile({
+      name: "",
+      responsePreference: "balanced",
+      customInstructions: "",
+    }, {
+      content: "# Complete document\n\n- Keep every line\n- Preserve Markdown",
+      source: "file",
+      sourceLabel: "~/.impulse/user-instructions.md",
+      fingerprint: "provider-test",
+    });
+
+    const messages = buildChatMessages([], block ?? "");
+    expect(messages[0]?.role).toBe("system");
+    expect(messages[0]?.content).toContain(
+      "# Complete document\n\n- Keep every line\n- Preserve Markdown"
+    );
+    expect(messages[0]?.content).not.toContain("apiKey");
+  });
+
+  test("does not trim intentional instruction boundary whitespace", () => {
+    const block = formatUserCollaborationProfile(undefined, {
+      content: "\n    indented Markdown\n\n",
+      source: "file",
+      sourceLabel: "~/.impulse/user-instructions.md",
+      fingerprint: "whitespace-test",
+    });
+
+    expect(block).toContain("Custom instructions:\n\n    indented Markdown\n\n");
+  });
+
+  test("places instructions in side chats without advertising unavailable tools", () => {
+    const profile = formatUserCollaborationProfile(undefined, {
+      content: "Answer with the decision first.",
+      source: "file",
+      sourceLabel: "~/.impulse/user-instructions.md",
+      fingerprint: "side-test",
+    }, { instructionToolAvailable: false });
+    const systemPrompt = buildSideSystemPrompt(profile);
+
+    expect(systemPrompt).toContain("Answer with the decision first.");
+    expect(systemPrompt).not.toContain("Use user_instructions");
   });
 });

--- a/test/skill-hydration.test.ts
+++ b/test/skill-hydration.test.ts
@@ -23,6 +23,7 @@ function createHost(calls: string[]): SlashDispatchHost {
     cmdAdvisor: async (arg) => record("advisor", arg),
     cmdExperimental: async () => record("experimental"),
     cmdSettings: async () => record("settings"),
+    cmdInstructions: async (arg) => record("instructions", arg),
     showConfigAliasHint: () => record("config"),
     cmdUpdate: async () => record("update"),
     cmdModel: async (arg) => record("model", arg),

--- a/test/slash-aliases.test.ts
+++ b/test/slash-aliases.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/cli/slash-aliases.js";
 import {
   dispatchSlashCommand,
+  parseSlashInput,
   slashDispatchKeys,
   type SlashDispatchHost,
 } from "../src/cli/slash-dispatch.js";
@@ -13,6 +14,7 @@ import {
   shouldShowSlashAutocomplete,
 } from "../src/cli/slash-autocomplete.js";
 import { buildSlashCommandList } from "../src/cli/slash-commands.js";
+import { buildSubmitPayload } from "../src/cli/prompt-input.js";
 
 function createHost(calls: string[]): SlashDispatchHost {
   const record = (name: string, arg = "") => {
@@ -24,6 +26,7 @@ function createHost(calls: string[]): SlashDispatchHost {
     cmdAdvisor: async (arg) => record("advisor", arg),
     cmdExperimental: async () => record("experimental"),
     cmdSettings: async () => record("settings"),
+    cmdInstructions: async (arg) => record("instructions", arg),
     showConfigAliasHint: () => record("config"),
     cmdUpdate: async () => record("update"),
     cmdModel: async (arg) => record("model", arg),
@@ -64,6 +67,37 @@ describe("slash aliases", () => {
     expect(canonicalizeSlashAliasInput("/mdl glm-4.7")).toBe("/model glm-4.7");
     expect(canonicalizeSlashAliasInput("/unknown arg")).toBe("/unknown arg");
     expect(canonicalizeSlashAliasInput("not /aa")).toBe("not /aa");
+  });
+
+  test("preserves multiline slash-command arguments", () => {
+    expect(parseSlashInput("/instructions replace # Header\n\n- First\n- Second")).toEqual({
+      cmd: "instructions",
+      arg: "replace # Header\n\n- First\n- Second",
+    });
+    expect(parseSlashInput("/instructions replace \n    indented\n")).toEqual({
+      cmd: "instructions",
+      arg: "replace \n    indented\n",
+    });
+    expect(parseSlashInput("/mode   debug  ")).toEqual({
+      cmd: "mode",
+      arg: "debug",
+    });
+  });
+
+  test("expands a multiline paste before instruction command dispatch", () => {
+    const marker = "[Pasted text #1]";
+    const markdown = "# Header\r\n\r\n- First\r\n- Second";
+    const payload = buildSubmitPayload(`/instructions replace ${marker}`, [{
+      display: marker,
+      originalDisplay: marker,
+      content: markdown,
+      kind: "text",
+    }]);
+
+    expect(parseSlashInput(payload.apiText)).toEqual({
+      cmd: "instructions",
+      arg: `replace ${markdown}`,
+    });
   });
 
   test("aliases are unique and do not shadow canonical dispatch keys", () => {

--- a/test/stream-split.test.ts
+++ b/test/stream-split.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  planStreamingRotation,
+  splitAtSafeBoundary,
+} from "../src/cli/stream-split.js";
+
+describe("splitAtSafeBoundary", () => {
+  test("carries the incomplete final line into the next streaming block", () => {
+    const plan = planStreamingRotation({
+      raw: "Completed summary.\n\nNext",
+      incomingToken: ": tell me which section to expand",
+      renderedLines: 12,
+      softLimit: 12,
+      hardLimit: 24,
+    });
+    const split = plan.split;
+
+    expect(split).toEqual({
+      frozen: "Completed summary.",
+      remainder: "Next",
+      kind: "paragraph",
+    });
+    expect(plan.nextRaw).toBe("Next: tell me which section to expand");
+  });
+
+  test("returns null when a single paragraph has no safe boundary", () => {
+    expect(splitAtSafeBoundary("para one contin")).toBeNull();
+  });
+
+  test("uses the last paragraph boundary", () => {
+    expect(splitAtSafeBoundary("para one\n\npara two\n\npara three contin")).toEqual({
+      frozen: "para one\n\npara two",
+      remainder: "para three contin",
+      kind: "paragraph",
+    });
+  });
+
+  test("ignores blank lines inside an open code fence", () => {
+    expect(splitAtSafeBoundary("text\n\n```ts\ncode\n\nmore")).toEqual({
+      frozen: "text",
+      remainder: "```ts\ncode\n\nmore",
+      kind: "paragraph",
+    });
+    expect(splitAtSafeBoundary("```ts\na\n\nb", { allowLineCut: true })).toBeNull();
+  });
+
+  test("line cuts only when explicitly allowed", () => {
+    const raw = "1. Item one\n2. Item two contin";
+    expect(splitAtSafeBoundary(raw)).toBeNull();
+    expect(splitAtSafeBoundary(raw, { allowLineCut: true })).toEqual({
+      frozen: "1. Item one",
+      remainder: "2. Item two contin",
+      kind: "line",
+    });
+  });
+
+  test("does not line cut through an incomplete table", () => {
+    const raw = "| a | b |\n| --- | --- |\n| 1 | 2";
+    expect(splitAtSafeBoundary(raw, { allowLineCut: true })).toBeNull();
+  });
+
+  test("keeps an open code fence in the mutable remainder", () => {
+    expect(splitAtSafeBoundary("intro\n```ts\ncode", { allowLineCut: true })).toEqual({
+      frozen: "intro",
+      remainder: "```ts\ncode",
+      kind: "line",
+    });
+  });
+
+  test("normalizes carriage returns before splitting", () => {
+    expect(splitAtSafeBoundary("para one\r\n\r\npara two contin")).toEqual({
+      frozen: "para one",
+      remainder: "para two contin",
+      kind: "paragraph",
+    });
+  });
+
+  test("never freezes a whitespace-only prefix", () => {
+    expect(splitAtSafeBoundary("   \n\nreal content here")).toBeNull();
+  });
+
+  test("carries an incomplete heading or list item forward whole", () => {
+    expect(splitAtSafeBoundary("intro line\n### incomplete", { allowLineCut: true })).toEqual({
+      frozen: "intro line",
+      remainder: "### incomplete",
+      kind: "line",
+    });
+    expect(splitAtSafeBoundary("para one\n\n- first item\n- second item in progr", {
+      allowLineCut: true,
+    })).toEqual({
+      frozen: "para one",
+      remainder: "- first item\n- second item in progr",
+      kind: "paragraph",
+    });
+  });
+});

--- a/test/stream-split.test.ts
+++ b/test/stream-split.test.ts
@@ -23,6 +23,68 @@ describe("splitAtSafeBoundary", () => {
     expect(plan.nextRaw).toBe("Next: tell me which section to expand");
   });
 
+  test("force-rotates a single long line when soft limit is reached", () => {
+    const plan = planStreamingRotation({
+      raw: "para one contin",
+      incomingToken: "uation",
+      renderedLines: 12,
+      softLimit: 12,
+      hardLimit: 24,
+    });
+
+    expect(plan.split).toEqual({
+      frozen: "para one contin",
+      remainder: "",
+      kind: "line",
+    });
+    expect(plan.nextRaw).toBe("uation");
+  });
+
+  test("waits for hard limit before force-rotating multi-line prose without paragraph breaks", () => {
+    const softPlan = planStreamingRotation({
+      raw: "line one\nline two contin",
+      incomingToken: "uation",
+      renderedLines: 12,
+      softLimit: 12,
+      hardLimit: 24,
+    });
+
+    expect(softPlan.split).toBeNull();
+    expect(softPlan.nextRaw).toBe("line one\nline two continuation");
+
+    const hardPlan = planStreamingRotation({
+      raw: "line one\nline two contin",
+      incomingToken: "uation",
+      renderedLines: 24,
+      softLimit: 12,
+      hardLimit: 24,
+    });
+
+    expect(hardPlan.split).toEqual({
+      frozen: "line one",
+      remainder: "line two contin",
+      kind: "line",
+    });
+    expect(hardPlan.nextRaw).toBe("line two continuation");
+  });
+
+  test("force-rotates at hard limit when no safe boundary exists", () => {
+    const plan = planStreamingRotation({
+      raw: "| a | b |\n| --- | --- |\n| 1 | 2",
+      incomingToken: " next",
+      renderedLines: 24,
+      softLimit: 12,
+      hardLimit: 24,
+    });
+
+    expect(plan.split).toEqual({
+      frozen: "| a | b |\n| --- | --- |\n| 1 | 2",
+      remainder: "",
+      kind: "line",
+    });
+    expect(plan.nextRaw).toBe(" next");
+  });
+
   test("returns null when a single paragraph has no safe boundary", () => {
     expect(splitAtSafeBoundary("para one contin")).toBeNull();
   });

--- a/test/user-instructions-prompt.test.ts
+++ b/test/user-instructions-prompt.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import path from "path";
+import { buildChatMessages } from "../src/agent/build-chat-messages.js";
+import { generateSystemPrompt, invalidatePromptCache } from "../src/agent/prompts.js";
+import type { Config } from "../src/util/config.js";
+import { replaceUserInstructions } from "../src/util/user-instructions.js";
+
+const projectDir = mkdtempSync(path.join(process.cwd(), ".tmp-user-prompt-"));
+const instructionsPath = path.join(projectDir, "user-instructions.md");
+
+afterAll(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("user instructions provider integration", () => {
+  test("new and resumed sessions receive the exact persisted Markdown", async () => {
+    const content = "# Persistent\n\n- Keep every line\n- Preserve Markdown";
+    await replaceUserInstructions(content, instructionsPath);
+    const config = {
+      userProfile: {
+        name: "Spencer",
+        responsePreference: "balanced",
+        customInstructions: "legacy value must not win",
+      },
+    } as Config;
+
+    invalidatePromptCache();
+    const newPrompt = await generateSystemPrompt("AGENT", projectDir, config, {
+      sessionId: "new-session",
+      userInstructionsPath: instructionsPath,
+    });
+    const resumedPrompt = await generateSystemPrompt("AGENT", projectDir, config, {
+      sessionId: "resumed-session",
+      userInstructionsPath: instructionsPath,
+    });
+
+    for (const prompt of [newPrompt, resumedPrompt]) {
+      const messages = buildChatMessages([], prompt);
+      expect(messages[0]?.role).toBe("system");
+      expect(messages[0]?.content).toContain(content);
+      expect(messages[0]?.content).not.toContain("legacy value must not win");
+    }
+
+    const explorePrompt = await generateSystemPrompt("EXPLORE", projectDir, config, {
+      sessionId: "explore-session",
+      userInstructionsPath: instructionsPath,
+    });
+    expect(explorePrompt).toContain(content);
+    expect(explorePrompt).not.toContain("Use user_instructions");
+  });
+});

--- a/test/user-instructions-tool.test.ts
+++ b/test/user-instructions-tool.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { isToolAllowedForMode, Tool } from "../src/tools/registry.js";
+import { userInstructionsTool } from "../src/tools/user-instructions.js";
+
+describe("user_instructions tool", () => {
+  test("is registered as a scoped write tool only in execution modes", () => {
+    expect(Tool.get("user_instructions")).toBe(userInstructionsTool);
+    expect(isToolAllowedForMode("user_instructions", "AGENT")).toBe(true);
+    expect(isToolAllowedForMode("user_instructions", "DEBUG")).toBe(true);
+    expect(isToolAllowedForMode("user_instructions", "EXPLORE")).toBe(false);
+    expect(isToolAllowedForMode("user_instructions", "PLAN")).toBe(false);
+  });
+
+  test("documents explicit persistence intent and the single write target", () => {
+    expect(userInstructionsTool.description).toContain("ONLY when the user explicitly asks");
+    expect(userInstructionsTool.description).toContain("never writes anywhere else");
+    expect(userInstructionsTool.description).toContain("~/.impulse/user-instructions.md");
+  });
+
+  test("rejects a mutating action without confirmed explicit intent", async () => {
+    const result = await userInstructionsTool.handler({
+      action: "replace",
+      content: "Merely mentioned preference",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("explicit user intent");
+  });
+});

--- a/test/user-instructions.test.ts
+++ b/test/user-instructions.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  appendUserInstructions,
+  clearUserInstructions,
+  importUserInstructions,
+  loadEffectiveUserInstructions,
+  normalizeUserInstructions,
+  readStoredUserInstructions,
+  replaceUserInstructions,
+  resolveUserInstructionsImportPath,
+  resolveWorkspaceUserInstructionsImportPath,
+} from "../src/util/user-instructions.js";
+
+describe("user instructions storage", () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "impulse-user-instructions-"));
+    target = path.join(dir, "user-instructions.md");
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test("normalizes line endings while preserving Markdown structure", async () => {
+    const markdown = "# Header\r\n\r\n- first\r- second\r\n\r\n```ts\r\nconst x = 1;\r\n```";
+    const stored = await replaceUserInstructions(markdown, target);
+
+    expect(stored.content).toBe(
+      "# Header\n\n- first\n- second\n\n```ts\nconst x = 1;\n```"
+    );
+    expect(await fs.readFile(target, "utf-8")).toBe(stored.content);
+  });
+
+  test("appends a separate Markdown block", async () => {
+    await replaceUserInstructions("# First\n\nBody", target);
+    const stored = await appendUserInstructions("## Second\n\nMore", target);
+
+    expect(stored.content).toBe("# First\n\nBody\n\n## Second\n\nMore");
+  });
+
+  test("an existing empty file intentionally overrides legacy inline instructions", async () => {
+    await clearUserInstructions(target);
+    const effective = await loadEffectiveUserInstructions("Legacy instruction", target);
+
+    expect(effective.source).toBe("file");
+    expect(effective.content).toBe("");
+  });
+
+  test("falls back to legacy inline instructions when the Markdown file is missing", async () => {
+    const effective = await loadEffectiveUserInstructions("Legacy\r\ncontent", target);
+
+    expect(effective.source).toBe("legacy_config");
+    expect(effective.sourceLabel).toBe("~/.impulse/config.json");
+    expect(effective.content).toBe("Legacy\ncontent");
+  });
+
+  test("imports an explicit @path relative to the working directory", async () => {
+    const source = path.join(dir, "source.md");
+    await fs.writeFile(source, "# Imported\r\n\r\nComplete", "utf-8");
+
+    const stored = await importUserInstructions("@source.md", {
+      cwd: dir,
+      targetPath: target,
+    });
+
+    expect(stored.content).toBe("# Imported\n\nComplete");
+    expect(resolveUserInstructionsImportPath("@source.md", dir)).toBe(source);
+  });
+
+  test("reports a missing canonical file without creating it", async () => {
+    await expect(readStoredUserInstructions(target)).resolves.toMatchObject({
+      exists: false,
+      content: "",
+      path: target,
+    });
+  });
+
+  test("agent imports reject paths outside the real workspace", async () => {
+    const workspace = path.join(dir, "workspace");
+    const outside = path.join(dir, "outside.md");
+    await fs.mkdir(workspace);
+    await fs.writeFile(outside, "outside", "utf-8");
+
+    await expect(
+      resolveWorkspaceUserInstructionsImportPath("@../outside.md", workspace)
+    ).rejects.toThrow("limited to the current workspace");
+  });
+
+  test("re-reads external edits even when the file size is unchanged", async () => {
+    await replaceUserInstructions("first", target);
+    const first = await loadEffectiveUserInstructions(undefined, target);
+    await fs.writeFile(target, "later", "utf-8");
+    const later = await loadEffectiveUserInstructions(undefined, target);
+
+    expect(later.content).toBe("later");
+    expect(later.fingerprint).not.toBe(first.fingerprint);
+  });
+});


### PR DESCRIPTION
## Problems

- User-level custom instructions from config were easy to miss, go stale, or lack provenance (#129), especially after multiline paste or while Impulse stayed running.
- Instruction authoring depended on single-line readline / JSON-escaped config strings, so Markdown pastes often kept only the first line.
- Long streamed assistant output could rotate/split at unsafe Markdown boundaries (#127), breaking headings, lists, punctuation, and inline spans across terminal lines.

## Fixed

- Store and load user instructions from `~/.impulse/user-instructions.md` with legacy `customInstructions` fallback; refresh between turns into main and side-chat prompts with a clear source label.
- Add `/instructions` (view/replace/append/import/clear) plus a scoped `user_instructions` tool that requires explicit save intent; atomic config saves with last-known-good backup and preserved malformed configs.
- Rotate long streams only at safe Markdown boundaries via `stream-split`.
- Bump patch version to **1.9.1** and update the changelog.

## Validation

- Focused tests: `user-instructions*`, `stream-split`, `config-recovery`, related slash/profile coverage.
- Manual sanity: instructions provenance, multiline paste, `@path` import, external edit refresh, `/resume`, streaming headings/lists/tables.
- Pre-merge: `bun run typecheck`, `bun test`, `bun run build`.

Fixes #127
Fixes #129

Made with [Cursor](https://cursor.com)